### PR TITLE
Update to circle orb to 3.8 to get around Veracode scanning issue.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@3.6
+  hmpps: ministryofjustice/hmpps@3.8
   slack: circleci/slack@4.4.2
 
 parameters:


### PR DESCRIPTION
Updates orb version 3.6 -> 3.8