### PR TITLE
CVL-28: Community API remove non-Delius username from client token.

### DIFF
--- a/server/services/communityService.ts
+++ b/server/services/communityService.ts
@@ -16,7 +16,7 @@ export default class CommunityService {
   async getManagedOffenders(username: string, staffIdentifier: number): Promise<CommunityApiManagedOffender[]> {
     logger.info(`communityService: getManagedOffenders(${username},${staffIdentifier}`)
     logger.info(`Getting a system token`)
-    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+    const token = await this.hmppsAuthClient.getSystemClientToken()
     logger.info(`system token = ${token}`)
     return new CommunityApiClient(token).getStaffCaseload(staffIdentifier)
   }


### PR DESCRIPTION
Small, speculative change to test whether the username is important when connecting to the community api.
I suspect that where we supplied a username it will try to validate it as a Delius user, and fail.