### PR TITLE
CVL-12: Use correct reference to gotenberg service

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -15,10 +15,10 @@ generic-service:
     PRISON_API_URL: "https://api-dev.prison.service.justice.gov.uk"
     LICENCE_API_URL: "https://create-and-vary-a-licence-api-dev.hmpps.service.justice.gov.uk"
 
-    # A reference to the local Gotenberg container to send HTML to PDF conversions
-    GOTENBERG_API_URL: "http://gotenberg:3000"
+    # A reference to the Gotenberg service - to submit HTML to PDF conversions (internal within cluster)
+    GOTENBERG_API_URL: "http://create-and-vary-a-licence-gotenberg:3000"
 
-    # A reference from the Gotenberg container to the CVL container to get images/stylesheets
+    # A reference to the CVL service - to get images/stylesheets (internal within cluster)
     LICENCES_URL: "http://create-and-vary-a-licence:80"
 
   # Switches off the allow list in the DEV env only.


### PR DESCRIPTION
The Gotenberg container is referenced by its service name within the cluster, so its URL from within the create-and-vary-a-licence service should have been `http://create-and-vary-a-licence-gotenberg:3000` - now corrected.