### PR TITLE
CVSL-53: Update typescript to 4.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12098,9 +12098,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+      "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
       "dev": true
     },
     "uid-safe": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "clean": "rm -rf dist build node_modules stylesheets"
   },
   "engines": {
-    "node": "^14",
-    "npm": "^6.4.1"
+    "node": ">=14 <15",
+    "npm": ">=6.4"
   },
   "jest": {
     "preset": "ts-jest",
@@ -161,6 +161,6 @@
     "prettier": "^2.3.2",
     "supertest": "^6.1.3",
     "ts-jest": "^27.0.3",
-    "typescript": "^4.3.5"
+    "typescript": "^4.4.2"
   }
 }


### PR DESCRIPTION
Updates typescript to resolve `check_outdated` build failure.