### PR TITLE
CVSL-51: Rectify nunjucks template name

### DIFF
--- a/server/routes/creatingLicences/handlers/initialMeetingName.test.ts
+++ b/server/routes/creatingLicences/handlers/initialMeetingName.test.ts
@@ -19,7 +19,7 @@ describe('Route Handlers - Create Licence - Initial Meeting Name', () => {
   describe('GET', () => {
     it('should render view', async () => {
       await handler.GET(req, res)
-      expect(res.render).toHaveBeenCalledWith('pages/create/initialMeetingName', {
+      expect(res.render).toHaveBeenCalledWith('pages/create/initialMeetingPerson', {
         offender: {
           name: 'Adam Balasaravika',
         },

--- a/server/routes/creatingLicences/handlers/initialMeetingName.ts
+++ b/server/routes/creatingLicences/handlers/initialMeetingName.ts
@@ -5,7 +5,7 @@ export default class InitialMeetingNameRoutes {
     const offender = {
       name: 'Adam Balasaravika',
     }
-    res.render('pages/create/initialMeetingName', { offender })
+    res.render('pages/create/initialMeetingPerson', { offender })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {


### PR DESCRIPTION
- Fixes error where nunjucks fails to find template with the wrong name