### PR TITLE
CVSL-54: Added validation middleware and flash messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2959,15 +2959,6 @@
         "@types/node": "*"
       }
     },
-    "@types/supertest": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/@types/supertest/-/supertest-2.0.11.tgz",
-      "integrity": "sha512-uci4Esokrw9qGb9bvhhSVEjd6rkny/dk5PK/Qz4yxKiyppEI+dOPlNrZBahE3i+PoKFYyDxChVXZ/ysS/nrm1Q==",
-      "dev": true,
-      "requires": {
-        "@types/superagent": "*"
-      }
-    },
     "@types/tunnel": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
@@ -2975,6 +2966,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/validator": {
+      "version": "13.6.3",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.6.3.tgz",
+      "integrity": "sha512-fWG42pMJOL4jKsDDZZREnXLjc3UE0R8LOJfARWYg6U966rxDT7TYejYzLnUF5cvSObGg34nd0+H2wHHU5Omdfw=="
     },
     "@types/yargs": {
       "version": "15.0.9",
@@ -3971,6 +3967,21 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz",
       "integrity": "sha512-jVamGdJPDeuQilKhvVn1h3knuMOZzr8QDnpk+M9aMlCaMkTDd6fBWPhiDqFvFZ07pL0liqabAiuy8SY4jGHeaw==",
       "dev": true
+    },
+    "class-transformer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.4.0.tgz",
+      "integrity": "sha512-ETWD/H2TbWbKEi7m9N4Km5+cw1hNcqJSxlSYhsLsNjQzWWiZIYA1zafxpK9PwVfaZ6AqR5rrjPVUBGESm5tQUA=="
+    },
+    "class-validator": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.13.1.tgz",
+      "integrity": "sha512-zWIeYFhUitvAHBwNhDdCRK09hWx+P0HUwFE8US8/CxFpMVzkUK8RJl7yOIE+BVu2lxyPNgeOaFv78tLE47jBIg==",
+      "requires": {
+        "@types/validator": "^13.1.3",
+        "libphonenumber-js": "^1.9.7",
+        "validator": "^13.5.2"
+      }
     },
     "clean-stack": {
       "version": "2.2.0",
@@ -9258,6 +9269,11 @@
         "type-check": "~0.4.0"
       }
     },
+    "libphonenumber-js": {
+      "version": "1.9.25",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.9.25.tgz",
+      "integrity": "sha512-LsSjcmXXGujESsrOsF2rrLdmuABj3OluCzPJKVNslJ2qc7xF5KdKXN8y0OcxHVurqosVf1/r4itrVrKSrlbVHA=="
+    },
     "lines-and-columns": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
@@ -10957,6 +10973,12 @@
         "redis-errors": "^1.0.0"
       }
     },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
+      "dev": true
+    },
     "regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -11707,16 +11729,6 @@
         }
       }
     },
-    "supertest": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.1.3.tgz",
-      "integrity": "sha512-v2NVRyP73XDewKb65adz+yug1XMtmvij63qIWHZzSX8tp6wiq6xBLUy4SUAd2NII6wIipOmHT/FD9eicpJwdgQ==",
-      "dev": true,
-      "requires": {
-        "methods": "^1.1.2",
-        "superagent": "^6.1.0"
-      }
-    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12334,6 +12346,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.6.0.tgz",
+      "integrity": "sha512-gVgKbdbHgtxpRyR8K0O6oFZPhhB5tT1jeEHZR0Znr9Svg03U0+r9DXWMrnRAB+HtCStDQKlaIZm42tVsVjqtjg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "body-parser": "^1.19.0",
     "bunyan": "^1.8.15",
     "bunyan-format": "^0.2.1",
+    "class-transformer": "^0.4.0",
+    "class-validator": "^0.13.1",
     "compression": "^1.7.4",
     "connect-flash": "^0.1.1",
     "connect-redis": "^6.0.0",
@@ -106,6 +108,7 @@
     "http-errors": "^1.8.0",
     "jquery": "^3.6.0",
     "jwt-decode": "^3.1.2",
+    "moment": "^2.29.1",
     "nocache": "^3.0.1",
     "nunjucks": "^3.2.3",
     "passport": "^0.4.1",
@@ -158,6 +161,7 @@
     "path-parse": "^1.0.7",
     "pdf-parse": "^1.1.1",
     "prettier": "^2.3.2",
+    "reflect-metadata": "^0.1.13",
     "ts-jest": "^27.0.3",
     "typescript": "^4.4.2"
   }

--- a/server/app.ts
+++ b/server/app.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import 'reflect-metadata'
 import express from 'express'
 
 import createError from 'http-errors'

--- a/server/middleware/flashMessageMiddleware.test.ts
+++ b/server/middleware/flashMessageMiddleware.test.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from 'express'
+import checkFlashForErrors from './flashMessageMiddleware'
+
+const flashMock = jest.fn()
+
+const req = { flash: flashMock, body: { reportType: 'counterCorruptionReport' } } as unknown as Request
+const res = { redirect: jest.fn(), locals: {} } as unknown as Response
+const next = jest.fn()
+
+const middleware = checkFlashForErrors()
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  req.method = 'GET'
+  res.locals = {}
+})
+
+describe('flashMessageMiddleware', () => {
+  it('should call next if no errors', async () => {
+    middleware(req, res, next)
+    expect(res.locals).toEqual({})
+    expect(next).toBeCalledTimes(1)
+  })
+
+  it('should not read from flash if request method is not GET', async () => {
+    flashMock
+      .mockReturnValueOnce([JSON.stringify({ val: 'error' })])
+      .mockReturnValueOnce([JSON.stringify({ form: 'response' })])
+
+    req.method = 'POST'
+
+    middleware(req, res, next)
+    expect(res.locals).toEqual({})
+    expect(next).toBeCalledTimes(1)
+  })
+
+  it('should set validation errors if they exist', async () => {
+    flashMock
+      .mockReturnValueOnce([JSON.stringify({ val: 'error' })])
+      .mockReturnValueOnce([JSON.stringify({ form: 'response' })])
+
+    middleware(req, res, next)
+    expect(res.locals).toEqual({ validationErrors: { val: 'error' }, formResponses: { form: 'response' } })
+    expect(next).toBeCalledTimes(1)
+  })
+})

--- a/server/middleware/flashMessageMiddleware.ts
+++ b/server/middleware/flashMessageMiddleware.ts
@@ -1,0 +1,16 @@
+import { RequestHandler } from 'express'
+
+export default function checkForFlashMessages(): RequestHandler {
+  return (req, res, next) => {
+    if (req.method === 'GET') {
+      const validationErrors = (req.flash('validationErrors') || [])[0]
+      const formResponses = (req.flash('formResponses') || [])[0]
+
+      if (validationErrors) {
+        res.locals.validationErrors = JSON.parse(validationErrors)
+        res.locals.formResponses = JSON.parse(formResponses)
+      }
+    }
+    next()
+  }
+}

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -9,6 +9,7 @@ export default function setUpWebSecurity(): Router {
   // 2. https://www.npmjs.com/package/helmet
   router.use(
     helmet({
+      referrerPolicy: { policy: 'same-origin' },
       contentSecurityPolicy: {
         directives: {
           defaultSrc: ["'self'"],

--- a/server/middleware/validationMiddleware.test.ts
+++ b/server/middleware/validationMiddleware.test.ts
@@ -1,0 +1,103 @@
+// eslint-disable-next-line max-classes-per-file
+import 'reflect-metadata'
+import { Request, Response } from 'express'
+import { IsIn, IsNotEmpty, ValidateNested } from 'class-validator'
+import { Expose, Type } from 'class-transformer'
+import validationMiddleware from './validationMiddleware'
+
+describe('validationMiddleware', () => {
+  describe('middleware', () => {
+    const notEmptyMessage = 'not empty'
+    const notValidMessage = 'not a valid selection'
+
+    class DummyChild {
+      @Expose()
+      @IsNotEmpty({ message: notEmptyMessage })
+      @IsIn(['valid'], { message: notValidMessage })
+      name: string
+    }
+
+    class DummyForm {
+      @Expose()
+      @IsNotEmpty({ message: notEmptyMessage })
+      id: string
+
+      @Expose()
+      @ValidateNested()
+      @Type(() => DummyChild)
+      child: DummyChild
+    }
+
+    it('should call next when there are no validation errors', async () => {
+      const next = jest.fn()
+      const req = {
+        body: {
+          id: 'abc',
+          child: { name: 'valid' },
+        },
+      } as Request
+      const res = { redirect: jest.fn() } as unknown as Response
+      await validationMiddleware(DummyForm)(req, res, next)
+
+      expect(next).toHaveBeenCalledTimes(1)
+    })
+
+    it('should return flash responses', async () => {
+      const next = jest.fn()
+      const req = {
+        flash: jest.fn(),
+        body: {
+          id: '',
+          child: { name: 'valid' },
+        },
+      } as unknown as Request
+      const res = { redirect: jest.fn() } as unknown as Response
+      await validationMiddleware(DummyForm)(req, res, next)
+
+      expect(next).not.toHaveBeenCalled()
+      expect(req.flash).toHaveBeenCalledWith(
+        'validationErrors',
+        JSON.stringify([{ field: 'id', message: notEmptyMessage }])
+      )
+      expect(req.flash).toHaveBeenCalledWith('formResponses', JSON.stringify(req.body))
+    })
+
+    it('should return the top level property on the error messages', async () => {
+      const next = jest.fn()
+      const req = {
+        flash: jest.fn(),
+        body: {
+          id: 'abc',
+          child: { name: '' },
+        },
+      } as unknown as Request
+      const res = { redirect: jest.fn() } as unknown as Response
+      await validationMiddleware(DummyForm)(req, res, next)
+
+      expect(next).not.toHaveBeenCalled()
+      expect(req.flash).toHaveBeenCalledWith(
+        'validationErrors',
+        JSON.stringify([{ field: 'child', message: notEmptyMessage }])
+      )
+    })
+
+    it('should return the full path property on the error messages', async () => {
+      const next = jest.fn()
+      const req = {
+        flash: jest.fn(),
+        body: {
+          id: 'abc',
+          child: { name: '' },
+        },
+      } as unknown as Request
+      const res = { redirect: jest.fn() } as unknown as Response
+      await validationMiddleware(DummyForm, true)(req, res, next)
+
+      expect(next).not.toHaveBeenCalled()
+      expect(req.flash).toHaveBeenCalledWith(
+        'validationErrors',
+        JSON.stringify([{ field: 'child[name]', message: notEmptyMessage }])
+      )
+    })
+  })
+})

--- a/server/middleware/validationMiddleware.ts
+++ b/server/middleware/validationMiddleware.ts
@@ -1,0 +1,46 @@
+import { plainToClass } from 'class-transformer'
+import { validate, ValidationError } from 'class-validator'
+import { RequestHandler } from 'express'
+
+export type FieldValidationError = {
+  field: string
+  message: string
+}
+
+function validationMiddleware(type: new () => unknown, useChildPath = false): RequestHandler {
+  return async (req, res, next) => {
+    const errors: ValidationError[] = await validate(
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      plainToClass(type, req.body, { excludeExtraneousValues: true }) as object
+    )
+
+    if (errors.length === 0) {
+      return next()
+    }
+
+    const addError = (
+      error: ValidationError,
+      constraints: {
+        [type: string]: string
+      },
+      path?: string
+    ): FieldValidationError => ({
+      field: useChildPath && path ? path : error.property,
+      message: Object.values(constraints)[Object.values(constraints).length - 1],
+    })
+
+    const mapErrors = (error: ValidationError) =>
+      error.children.length > 0
+        ? error.children.map((childError: ValidationError) =>
+            addError(error, childError.constraints, `${error.property}[${childError.property}]`)
+          )
+        : addError(error, error.constraints)
+
+    req.flash('validationErrors', JSON.stringify(errors.flatMap(mapErrors)))
+    req.flash('formResponses', JSON.stringify(req.body))
+
+    return res.redirect('back')
+  }
+}
+
+export default validationMiddleware

--- a/server/routes/creatingLicences/handlers/additionalConditionsQuestion.test.ts
+++ b/server/routes/creatingLicences/handlers/additionalConditionsQuestion.test.ts
@@ -36,7 +36,7 @@ describe('Route Handlers - Create Licence - Additional Conditions Question', () 
       req = {
         ...req,
         body: {
-          'additional-conditions-required': 'yes',
+          answer: 'yes',
         },
       } as unknown as Request
       await handler.POST(req, res)
@@ -47,7 +47,7 @@ describe('Route Handlers - Create Licence - Additional Conditions Question', () 
       req = {
         ...req,
         body: {
-          'additional-conditions-required': 'no',
+          answer: 'no',
         },
       } as unknown as Request
       await handler.POST(req, res)

--- a/server/routes/creatingLicences/handlers/additionalConditionsQuestion.ts
+++ b/server/routes/creatingLicences/handlers/additionalConditionsQuestion.ts
@@ -11,7 +11,7 @@ export default class AdditionalConditionsQuestionRoutes {
   POST = async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params
     const payload = req.body
-    if (payload['additional-conditions-required'] === 'yes') {
+    if (payload.answer === 'yes') {
       res.redirect(`/licence/create/id/${id}/additional-conditions`)
     } else {
       res.redirect(`/licence/create/id/${id}/bespoke-conditions-question`)

--- a/server/routes/creatingLicences/handlers/bespokeConditionsQuestion.test.ts
+++ b/server/routes/creatingLicences/handlers/bespokeConditionsQuestion.test.ts
@@ -36,7 +36,7 @@ describe('Route Handlers - Create Licence - Bespoke Conditions Question', () => 
       req = {
         ...req,
         body: {
-          'bespoke-conditions-required': 'yes',
+          answer: 'yes',
         },
       } as unknown as Request
       await handler.POST(req, res)
@@ -47,7 +47,7 @@ describe('Route Handlers - Create Licence - Bespoke Conditions Question', () => 
       req = {
         ...req,
         body: {
-          'bespoke-conditions-required': 'no',
+          answer: 'no',
         },
       } as unknown as Request
       await handler.POST(req, res)

--- a/server/routes/creatingLicences/handlers/bespokeConditionsQuestion.ts
+++ b/server/routes/creatingLicences/handlers/bespokeConditionsQuestion.ts
@@ -11,7 +11,7 @@ export default class BespokeConditionsQuestionRoutes {
   POST = async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params
     const payload = req.body
-    if (payload['bespoke-conditions-required'] === 'yes') {
+    if (payload.answer === 'yes') {
       res.redirect(`/licence/create/id/${id}/bespoke-conditions`)
     } else {
       res.redirect(`/licence/create/id/${id}/check-your-answers`)

--- a/server/routes/creatingLicences/index.ts
+++ b/server/routes/creatingLicences/index.ts
@@ -13,12 +13,21 @@ import BespokeConditionsRoutes from './handlers/bespokeConditions'
 import CheckAnswersRoutes from './handlers/checkAnswers'
 import ConfirmationRoutes from './handlers/confirmation'
 import { Services } from '../../services'
+import PersonName from './types/personName'
+import validationMiddleware from '../../middleware/validationMiddleware'
+import Address from './types/address'
+import Telephone from './types/telephone'
+import SimpleDateTime from './types/simpleDateTime'
+import YesOrNoQuestion from './types/yesOrNo'
 
 export default function Index({ licenceService }: Services): Router {
   const router = Router()
 
-  const get = (path: string, handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
-  const post = (path: string, handler: RequestHandler) => router.post(path, asyncMiddleware(handler))
+  const routePrefix = (path: string) => `/licence/create${path}`
+
+  const get = (path: string, handler: RequestHandler) => router.get(routePrefix(path), asyncMiddleware(handler))
+  const post = (path: string, handler: RequestHandler, type?: new () => unknown) =>
+    router.post(routePrefix(path), validationMiddleware(type), asyncMiddleware(handler))
 
   const caseloadHandler = new CaseloadRoutes()
   const initialMeetingNameHandler = new InitialMeetingNameRoutes()
@@ -32,26 +41,26 @@ export default function Index({ licenceService }: Services): Router {
   const checkAnswersHandler = new CheckAnswersRoutes(licenceService)
   const confirmationHandler = new ConfirmationRoutes()
 
-  get('/licence/create/caseload', caseloadHandler.GET)
-  get('/licence/create/crn/:crn/initial-meeting-name', initialMeetingNameHandler.GET)
-  post('/licence/create/crn/:crn/initial-meeting-name', initialMeetingNameHandler.POST)
-  get('/licence/create/id/:id/initial-meeting-place', initialMeetingPlaceHandler.GET)
-  post('/licence/create/id/:id/initial-meeting-place', initialMeetingPlaceHandler.POST)
-  get('/licence/create/id/:id/initial-meeting-contact', initialMeetingContactHandler.GET)
-  post('/licence/create/id/:id/initial-meeting-contact', initialMeetingContactHandler.POST)
-  get('/licence/create/id/:id/initial-meeting-time', initialMeetingTimeHandler.GET)
-  post('/licence/create/id/:id/initial-meeting-time', initialMeetingTimeHandler.POST)
-  get('/licence/create/id/:id/additional-conditions-question', additionalConditionsQuestionHandler.GET)
-  post('/licence/create/id/:id/additional-conditions-question', additionalConditionsQuestionHandler.POST)
-  get('/licence/create/id/:id/additional-conditions', additionalConditionsHandler.GET)
-  post('/licence/create/id/:id/additional-conditions', additionalConditionsHandler.POST)
-  get('/licence/create/id/:id/bespoke-conditions-question', bespokeConditionsQuestionHandler.GET)
-  post('/licence/create/id/:id/bespoke-conditions-question', bespokeConditionsQuestionHandler.POST)
-  get('/licence/create/id/:id/bespoke-conditions', bespokeConditionsHandler.GET)
-  post('/licence/create/id/:id/bespoke-conditions', bespokeConditionsHandler.POST)
-  get('/licence/create/id/:id/check-your-answers', checkAnswersHandler.GET)
-  post('/licence/create/id/:id/check-your-answers', checkAnswersHandler.POST)
-  get('/licence/create/id/:id/confirmation', confirmationHandler.GET)
+  get('/caseload', caseloadHandler.GET)
+  get('/crn/:crn/initial-meeting-name', initialMeetingNameHandler.GET)
+  post('/crn/:crn/initial-meeting-name', initialMeetingNameHandler.POST, PersonName)
+  get('/id/:id/initial-meeting-place', initialMeetingPlaceHandler.GET)
+  post('/id/:id/initial-meeting-place', initialMeetingPlaceHandler.POST, Address)
+  get('/id/:id/initial-meeting-contact', initialMeetingContactHandler.GET)
+  post('/id/:id/initial-meeting-contact', initialMeetingContactHandler.POST, Telephone)
+  get('/id/:id/initial-meeting-time', initialMeetingTimeHandler.GET)
+  post('/id/:id/initial-meeting-time', initialMeetingTimeHandler.POST, SimpleDateTime)
+  get('/id/:id/additional-conditions-question', additionalConditionsQuestionHandler.GET)
+  post('/id/:id/additional-conditions-question', additionalConditionsQuestionHandler.POST, YesOrNoQuestion)
+  get('/id/:id/additional-conditions', additionalConditionsHandler.GET)
+  post('/id/:id/additional-conditions', additionalConditionsHandler.POST)
+  get('/id/:id/bespoke-conditions-question', bespokeConditionsQuestionHandler.GET)
+  post('/id/:id/bespoke-conditions-question', bespokeConditionsQuestionHandler.POST, YesOrNoQuestion)
+  get('/id/:id/bespoke-conditions', bespokeConditionsHandler.GET)
+  post('/id/:id/bespoke-conditions', bespokeConditionsHandler.POST)
+  get('/id/:id/check-your-answers', checkAnswersHandler.GET)
+  post('/id/:id/check-your-answers', checkAnswersHandler.POST)
+  get('/id/:id/confirmation', confirmationHandler.GET)
 
   return router
 }

--- a/server/routes/creatingLicences/types/address.ts
+++ b/server/routes/creatingLicences/types/address.ts
@@ -1,0 +1,29 @@
+import { Expose } from 'class-transformer'
+import { IsNotEmpty, IsOptional, Matches } from 'class-validator'
+
+class Address {
+  @Expose()
+  @IsNotEmpty({ message: 'Enter a building name or number' })
+  addressLine1: string
+
+  @Expose()
+  @IsOptional()
+  addressLine2: string
+
+  @Expose()
+  @IsNotEmpty({ message: 'Enter a town' })
+  addressTown: string
+
+  @Expose()
+  @IsNotEmpty({ message: 'Enter a county' })
+  addressCounty: string
+
+  @Expose()
+  @IsNotEmpty({ message: 'Enter a postcode' })
+  @Matches(/[A-Za-z]{1,2}[0-9Rr][0-9A-Za-z]?\s?[0-9][ABD-HJLNP-UW-Zabd-hjlnp-uw-z]{2}/, {
+    message: 'Enter a valid postcode',
+  })
+  addressPostcode: string
+}
+
+export default Address

--- a/server/routes/creatingLicences/types/date.ts
+++ b/server/routes/creatingLicences/types/date.ts
@@ -1,0 +1,19 @@
+import { Expose } from 'class-transformer'
+import moment, { Moment } from 'moment'
+
+class SimpleDate {
+  @Expose()
+  day: string
+
+  @Expose()
+  month: string
+
+  @Expose()
+  year: string
+
+  toMoment(): Moment {
+    return moment([this.year, this.month, this.day].join('-'), ['YYYY-M-D', 'YY-M-D'], true)
+  }
+}
+
+export default SimpleDate

--- a/server/routes/creatingLicences/types/personName.ts
+++ b/server/routes/creatingLicences/types/personName.ts
@@ -1,0 +1,10 @@
+import { Expose } from 'class-transformer'
+import { IsNotEmpty } from 'class-validator'
+
+class PersonName {
+  @Expose()
+  @IsNotEmpty({ message: 'Enter the name of a person' })
+  contactName: string
+}
+
+export default PersonName

--- a/server/routes/creatingLicences/types/simpleDateTime.ts
+++ b/server/routes/creatingLicences/types/simpleDateTime.ts
@@ -1,0 +1,20 @@
+import { Expose, Type } from 'class-transformer'
+import { Validate } from 'class-validator'
+import SimpleDate from './date'
+import ValidSimpleDate from '../../../validators/simpleDateValidator'
+import SimpleTime from './time'
+import ValidSimpleTime from '../../../validators/simpleTimeValidator'
+
+class SimpleDateTime {
+  @Expose()
+  @Type(() => SimpleDate)
+  @Validate(ValidSimpleDate)
+  inductionDate: SimpleDate
+
+  @Expose()
+  @Type(() => SimpleTime)
+  @Validate(ValidSimpleTime)
+  inductionTime: SimpleTime
+}
+
+export default SimpleDateTime

--- a/server/routes/creatingLicences/types/telephone.ts
+++ b/server/routes/creatingLicences/types/telephone.ts
@@ -1,0 +1,14 @@
+import { Expose } from 'class-transformer'
+import { IsNotEmpty, Matches } from 'class-validator'
+
+class Telephone {
+  @Expose()
+  @IsNotEmpty({ message: 'Enter a telephone number' })
+  @Matches(
+    /^(((\+44\s?\d{4}|\(?0\d{4}\)?)\s?\d{3}\s?\d{3})|((\+44\s?\d{3}|\(?0\d{3}\)?)\s?\d{3}\s?\d{4})|((\+44\s?\d{2}|\(?0\d{2}\)?)\s?\d{4}\s?\d{4}))(\s?\\#(\d{4}|\d{3}))?$/,
+    { message: 'Enter a valid UK telephone number' }
+  )
+  telephone: string
+}
+
+export default Telephone

--- a/server/routes/creatingLicences/types/time.ts
+++ b/server/routes/creatingLicences/types/time.ts
@@ -1,0 +1,19 @@
+import { Expose } from 'class-transformer'
+
+export enum AmPm {
+  AM = 'am',
+  PM = 'pm',
+}
+
+class SimpleTime {
+  @Expose()
+  hour: string
+
+  @Expose()
+  minute: string
+
+  @Expose()
+  ampm: AmPm
+}
+
+export default SimpleTime

--- a/server/routes/creatingLicences/types/yesOrNo.ts
+++ b/server/routes/creatingLicences/types/yesOrNo.ts
@@ -1,0 +1,13 @@
+import { Expose } from 'class-transformer'
+import { IsIn, IsNotEmpty } from 'class-validator'
+
+const message = 'Select either Yes or No'
+
+class YesOrNoQuestion {
+  @Expose()
+  @IsNotEmpty({ message })
+  @IsIn(['yes', 'no'], { message })
+  answer: string
+}
+
+export default YesOrNoQuestion

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -8,6 +8,7 @@ import spikeRoutes from './spikes'
 import auth from '../authentication/auth'
 import tokenVerifier from '../data/tokenVerification'
 import populateCurrentUser from '../middleware/populateCurrentUser'
+import flashMessages from '../middleware/flashMessageMiddleware'
 
 export default function Index(services: Services): Router {
   const router = Router({ mergeParams: true })
@@ -15,6 +16,7 @@ export default function Index(services: Services): Router {
   router.use(auth.authenticationMiddleware(tokenVerifier))
   router.use(populateCurrentUser(services.userService))
   router.use(csrf())
+  router.use(flashMessages())
 
   router.use(homeRoutes())
   router.use(createLicenceRoutes(services))

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -1,0 +1,112 @@
+import cheerio from 'cheerio'
+import nunjucks, { Template } from 'nunjucks'
+import { registerNunjucks } from './nunjucksSetup'
+
+describe('Nunjucks Filters', () => {
+  let compiledTemplate: Template
+  let viewContext: Record<string, unknown>
+
+  const njkEnv = registerNunjucks()
+
+  describe('initialiseName', () => {
+    it('should return null if full name is not provided', () => {
+      viewContext = {}
+      const nunjucksString = '{{ fullName | initialiseName }}'
+      compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      expect($('body').text()).toBe('')
+    })
+
+    it('should return formatted name', () => {
+      viewContext = {
+        fullName: 'Joe Bloggs',
+      }
+      const nunjucksString = '{{ fullName | initialiseName }}'
+      compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      expect($('body').text()).toBe('J. Bloggs')
+    })
+  })
+
+  describe('concatValues', () => {
+    it('should return null if object is not provided', () => {
+      viewContext = {}
+      const nunjucksString = '{{ testObject | concatValues }}'
+      compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      expect($('body').text()).toBe('')
+    })
+
+    it('should return concatenated object values', () => {
+      viewContext = {
+        testObject: {
+          data1: 'test1',
+          data2: 'test2',
+          data3: 'test3',
+        },
+      }
+      const nunjucksString = '{{ testObject | concatValues }}'
+      compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      expect($('body').text()).toBe('test1, test2, test3')
+    })
+  })
+
+  describe('errorSummaryList', () => {
+    it('should map errors to text and href', () => {
+      viewContext = {
+        errors: [
+          {
+            field: 'field1',
+            message: 'message1',
+          },
+          {
+            field: 'field2',
+            message: 'message2',
+          },
+        ],
+      }
+      const nunjucksString = `
+        {% set errorSummaryList = errors | errorSummaryList %}
+        {% for error in errorSummaryList %}
+            <a href="{{ errorSummaryList[loop.index0].href }}">{{ errorSummaryList[loop.index0].text }}</a>
+        {% endfor %}
+      `
+      compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      expect($('a:nth-child(1)').text()).toBe('message1')
+      expect($('a:nth-child(1)').attr('href')).toBe('#field1')
+      expect($('a:nth-child(2)').text()).toBe('message2')
+      expect($('a:nth-child(2)').attr('href')).toBe('#field2')
+    })
+  })
+
+  describe('findError', () => {
+    it('should find error from list of errors where field matches given value', () => {
+      viewContext = {
+        errors: [
+          {
+            field: 'field1',
+            message: 'message1',
+          },
+          {
+            field: 'field2',
+            message: 'message2',
+          },
+        ],
+      }
+      const nunjucksString = `
+        <div>{{ (errors | findError('field1')).text }}</div>
+      `
+      compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+      const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+      expect($('div').text()).toBe('message1')
+    })
+  })
+})

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -2,6 +2,7 @@
 import nunjucks, { Environment } from 'nunjucks'
 import express from 'express'
 import path from 'path'
+import { FieldValidationError } from '../middleware/validationMiddleware'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -55,6 +56,23 @@ export function registerNunjucks(app?: express.Express): Environment {
       return null
     }
     return Object.values(object).join(', ')
+  })
+
+  njkEnv.addFilter('errorSummaryList', (array = []) => {
+    return array.map((error: FieldValidationError) => ({
+      text: error.message,
+      href: `#${error.field}`,
+    }))
+  })
+
+  njkEnv.addFilter('findError', (array: FieldValidationError[] = [], formFieldId: string) => {
+    const item = array.find(error => error.field === formFieldId)
+    if (item) {
+      return {
+        text: item.message,
+      }
+    }
+    return null
   })
 
   return njkEnv

--- a/server/validators/simpleDateValidator.test.ts
+++ b/server/validators/simpleDateValidator.test.ts
@@ -1,0 +1,92 @@
+import { plainToClass } from 'class-transformer'
+import SimpleDate from '../routes/creatingLicences/types/date'
+import ValidSimpleDate from './simpleDateValidator'
+
+describe('Validators - ValidSimpleDate', () => {
+  let validator: ValidSimpleDate
+  let date: SimpleDate
+
+  beforeEach(() => {
+    validator = new ValidSimpleDate()
+    date = plainToClass(
+      SimpleDate,
+      {
+        day: '31',
+        month: '12',
+        year: new Date().getFullYear().toString(),
+      },
+      { excludeExtraneousValues: true }
+    )
+  })
+
+  it('should pass validation with well formed data', () => {
+    expect(validator.validate(date)).toBe(true)
+  })
+
+  it('should fail validation when all fields are blank', () => {
+    date.day = ''
+    date.month = ''
+    date.year = ''
+    expect(validator.validate(date)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter a date')
+  })
+
+  it('should fail validation with badly formed day', () => {
+    date.day = '40'
+    expect(validator.validate(date)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter a valid day')
+  })
+
+  it('should fail validation with badly formed month', () => {
+    date.month = '13'
+    expect(validator.validate(date)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter a valid month')
+  })
+
+  it('should fail validation with badly formed year', () => {
+    date.year = '123'
+    expect(validator.validate(date)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter a valid year')
+  })
+
+  it('should fail validation with a non existing date', () => {
+    date.day = '29'
+    date.month = '02'
+    date.year = '23'
+    expect(validator.validate(date)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter a valid date')
+  })
+
+  it('should fail validation with a date in the past', () => {
+    date.day = '23'
+    date.month = '02'
+    date.year = '19'
+    expect(validator.validate(date)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter a date in the future')
+  })
+
+  it("should fail validation with yesterday's date", () => {
+    const today = new Date('2020-03-1')
+    const yesterday = new Date(today)
+    yesterday.setDate(yesterday.getDate() - 1)
+
+    date.day = yesterday.getDate().toString()
+    date.month = (yesterday.getMonth() + 1).toString()
+    date.year = yesterday.getFullYear().toString()
+    expect(validator.validate(date)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter a date in the future')
+  })
+
+  it("should pass validation with today's date", () => {
+    const today = new Date()
+    date.day = today.getDate().toString()
+    date.month = (today.getMonth() + 1).toString()
+    date.year = today.getFullYear().toString()
+    expect(validator.validate(date)).toBe(true)
+  })
+
+  it('should return null as default message', () => {
+    validator.validate(date)
+    expect(validator.defaultMessage()).toBe(null)
+  })
+})

--- a/server/validators/simpleDateValidator.ts
+++ b/server/validators/simpleDateValidator.ts
@@ -1,0 +1,58 @@
+import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator'
+import moment from 'moment'
+import SimpleDate from '../routes/creatingLicences/types/date'
+
+@ValidatorConstraint()
+export default class ValidSimpleDate implements ValidatorConstraintInterface {
+  private date: SimpleDate
+
+  validate(simpleDate: SimpleDate): boolean {
+    this.date = simpleDate
+    return (
+      !this.isBlank() &&
+      this.isValidDay() &&
+      this.isValidMonth() &&
+      this.isValidYear() &&
+      this.isValidDate() &&
+      this.isOnOrAfterToday()
+    )
+  }
+
+  defaultMessage(): string {
+    if (this.isBlank()) return 'Enter a date'
+    if (!this.isValidDay()) return 'Enter a valid day'
+    if (!this.isValidMonth()) return 'Enter a valid month'
+    if (!this.isValidYear()) return 'Enter a valid year'
+    if (!this.isValidDate()) return 'Enter a valid date'
+    if (!this.isOnOrAfterToday()) return 'Enter a date in the future'
+    return null
+  }
+
+  private isBlank(): boolean {
+    return [this.date.day, this.date.month, this.date.year].join('').length === 0
+  }
+
+  private isValidDay(): boolean {
+    const day = this.date.day as unknown as number
+    return day >= 1 && day <= 31
+  }
+
+  private isValidMonth(): boolean {
+    const month = this.date.month as unknown as number
+    return month >= 1 && month <= 12
+  }
+
+  private isValidYear(): boolean {
+    const { year } = this.date
+    return year.length === 2 || year.length === 4
+  }
+
+  private isValidDate(): boolean {
+    const dateToCheck = this.date.toMoment()
+    return dateToCheck.isValid()
+  }
+
+  private isOnOrAfterToday(): boolean {
+    return !this.date.toMoment().isBefore(moment().subtract(1, 'day'))
+  }
+}

--- a/server/validators/simpleTimeValidator.test.ts
+++ b/server/validators/simpleTimeValidator.test.ts
@@ -1,0 +1,61 @@
+import { plainToClass } from 'class-transformer'
+import SimpleTime from '../routes/creatingLicences/types/time'
+import ValidSimpleTime from './simpleTimeValidator'
+
+describe('Validators - ValidSimpleTime', () => {
+  let validator: ValidSimpleTime
+  let time: SimpleTime
+
+  beforeEach(() => {
+    validator = new ValidSimpleTime()
+    time = plainToClass(
+      SimpleTime,
+      {
+        hour: '01',
+        minute: '59',
+        ampm: 'am',
+      },
+      { excludeExtraneousValues: true }
+    )
+  })
+
+  it('should pass validation with well formed data', () => {
+    expect(validator.validate(time)).toBe(true)
+  })
+
+  it('should fail validation when all fields are blank', () => {
+    time.hour = ''
+    time.minute = ''
+    expect(validator.validate(time)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter a time')
+  })
+
+  it('should fail validation with a badly formed hour', () => {
+    time.hour = '13'
+    expect(validator.validate(time)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter an hour between 1 and 12')
+  })
+
+  it('should fail validation with an empty hour', () => {
+    time.hour = ''
+    expect(validator.validate(time)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter an hour between 1 and 12')
+  })
+
+  it('should fail validation with a badly formed minute', () => {
+    time.minute = '70'
+    expect(validator.validate(time)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter a minute between 00 and 59')
+  })
+
+  it('should fail validation with an empty minute', () => {
+    time.minute = ''
+    expect(validator.validate(time)).toBe(false)
+    expect(validator.defaultMessage()).toBe('Enter a minute between 00 and 59')
+  })
+
+  it('should return null as default message', () => {
+    validator.validate(time)
+    expect(validator.defaultMessage()).toBe(null)
+  })
+})

--- a/server/validators/simpleTimeValidator.ts
+++ b/server/validators/simpleTimeValidator.ts
@@ -1,0 +1,38 @@
+import { ValidatorConstraint, ValidatorConstraintInterface } from 'class-validator'
+import SimpleTime, { AmPm } from '../routes/creatingLicences/types/time'
+
+@ValidatorConstraint()
+export default class ValidSimpleTime implements ValidatorConstraintInterface {
+  private time: SimpleTime
+
+  validate(simpleTime: SimpleTime): boolean {
+    this.time = simpleTime
+    return !this.isBlank() && this.isValidHour() && this.isValidMinute() && this.isValidAmPm()
+  }
+
+  defaultMessage(): string {
+    if (this.isBlank()) return 'Enter a time'
+    if (!this.isValidHour()) return 'Enter an hour between 1 and 12'
+    if (!this.isValidMinute()) return 'Enter a minute between 00 and 59'
+    if (!this.isValidAmPm()) return 'Select either Am or Pm'
+    return null
+  }
+
+  private isBlank(): boolean {
+    return [this.time.hour, this.time.minute].join('').length === 0
+  }
+
+  private isValidHour(): boolean {
+    const hour = this.time.hour as unknown as number
+    return this.time.hour !== '' && hour >= 1 && hour <= 12
+  }
+
+  private isValidMinute(): boolean {
+    const minute = this.time.minute as unknown as number
+    return this.time.minute !== '' && minute >= 0 && minute <= 59
+  }
+
+  private isValidAmPm(): boolean {
+    return Object.values(AmPm).includes(this.time.ampm)
+  }
+}

--- a/server/views/layout.njk
+++ b/server/views/layout.njk
@@ -31,10 +31,12 @@
 {% block beforeContent %}
   {{ govukPhaseBanner({
     tag: {
-      text: "alpha"
+      text: "beta"
     },
     html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
   }) }}
+
+  {% include 'partials/formError.njk' %}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/server/views/pages/create/additionalConditionsQuestion.njk
+++ b/server/views/pages/create/additionalConditionsQuestion.njk
@@ -17,14 +17,18 @@
             <div class="govuk-grid-column-full">
                 {{ govukRadios({
                     classes: "govuk-radios--inline",
-                    idPrefix: "additional-conditions-required",
-                    name: "additional-conditions-required",
+                    idPrefix: "radio-option",
+                    name: "answer",
                     fieldset: {
+                        attributes: {
+                            id: 'answer'
+                        },
                         legend: {
                             text: "Additional conditions question",
                             classes: "govuk-visually-hidden"
                         }
                     },
+                    errorMessage: validationErrors | findError('answer'),
                     items: [
                         {
                             value: "yes",

--- a/server/views/pages/create/bespokeConditionsQuestion.njk
+++ b/server/views/pages/create/bespokeConditionsQuestion.njk
@@ -17,14 +17,18 @@
             <div class="govuk-grid-column-full">
                 {{ govukRadios({
                     classes: "govuk-radios--inline",
-                    idPrefix: "bespoke-conditions-required",
-                    name: "bespoke-conditions-required",
+                    idPrefix: "radio-option",
+                    name: "answer",
                     fieldset: {
+                        attributes: {
+                            id: 'answer'
+                        },
                         legend: {
                             text: "Bespoke conditions question",
                             classes: "govuk-visually-hidden"
                         }
                     },
+                    errorMessage: validationErrors | findError('answer'),
                     items: [
                         {
                             value: "yes",

--- a/server/views/pages/create/initialMeetingContact.njk
+++ b/server/views/pages/create/initialMeetingContact.njk
@@ -21,7 +21,9 @@
                     },
                     id: "telephone",
                     name: "telephone",
-                    classes: "govuk-input--width-20"
+                    classes: "govuk-input--width-20",
+                    errorMessage: validationErrors | findError('telephone'),
+                    value: formResponses.telephone
                 }) }}
 
                 {{ govukButton({

--- a/server/views/pages/create/initialMeetingPerson.njk
+++ b/server/views/pages/create/initialMeetingPerson.njk
@@ -16,9 +16,11 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 {{ govukInput({
-                    id: "contact-name",
-                    name: "contact-name",
-                    classes: "govuk-!-width-one-third"
+                    id: "contactName",
+                    name: "contactName",
+                    classes: "govuk-!-width-one-third",
+                    errorMessage: validationErrors | findError('contactName'),
+                    value: formResponses.contactName
                 }) }}
 
                 {{ govukButton({

--- a/server/views/pages/create/initialMeetingPlace.njk
+++ b/server/views/pages/create/initialMeetingPlace.njk
@@ -27,20 +27,23 @@
                         label: {
                             html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
                         },
-                        id: "address-line-1",
-                        name: "address-line-1",
+                        id: "addressLine1",
+                        name: "addressLine1",
                         autocomplete: "address-line1",
-                        classes: 'govuk-!-width-one-third'
+                        classes: 'govuk-!-width-one-third',
+                        errorMessage: validationErrors | findError('addressLine1'),
+                        value: formResponses.addressLine1
                     }) }}
 
                     {{ govukInput({
                         label: {
                             html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
                         },
-                        id: "address-line-2",
-                        name: "address-line-2",
+                        id: "addressLine2",
+                        name: "addressLine2",
                         autocomplete: "address-line2",
-                        classes: 'govuk-!-width-one-third'
+                        classes: 'govuk-!-width-one-third',
+                        value: formResponses.addressLine2
                     }) }}
 
                     {{ govukInput({
@@ -48,9 +51,11 @@
                             text: "Town or city"
                         },
                         classes: "govuk-!-width-one-quarter",
-                        id: "address-town",
-                        name: "address-town",
-                        autocomplete: "address-level2"
+                        id: "addressTown",
+                        name: "addressTown",
+                        autocomplete: "address-level2",
+                        errorMessage: validationErrors | findError('addressTown'),
+                        value: formResponses.addressTown
                     }) }}
 
                     {{ govukInput({
@@ -58,8 +63,10 @@
                             text: "County"
                         },
                         classes: "govuk-!-width-one-quarter",
-                        id: "address-county",
-                        name: "address-county"
+                        id: "addressCounty",
+                        name: "addressCounty",
+                        errorMessage: validationErrors | findError('addressCounty'),
+                        value: formResponses.addressCounty
                     }) }}
 
                     {{ govukInput({
@@ -67,9 +74,11 @@
                             text: "Postcode"
                         },
                         classes: "govuk-input--width-10",
-                        id: "address-postcode",
-                        name: "address-postcode",
-                        autocomplete: "postal-code"
+                        id: "addressPostcode",
+                        name: "addressPostcode",
+                        autocomplete: "postal-code",
+                        errorMessage: validationErrors | findError('addressPostcode'),
+                        value: formResponses.addressPostcode
                     }) }}
 
                 {% endcall %}

--- a/server/views/pages/create/initialMeetingTime.njk
+++ b/server/views/pages/create/initialMeetingTime.njk
@@ -1,8 +1,8 @@
 {% extends "layout.njk" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
 {% from "../../partials/timePicker.njk" import timePicker %}
+{% from "../../partials/datePicker.njk" import datePicker %}
 
 {% set pageTitle = applicationName + " - Create a licence - Induction meeting" %}
 
@@ -16,23 +16,25 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                {{ govukDateInput({
-                    id: "induction-date",
-                    namePrefix: "induction-date",
+                {{ datePicker({
+                    id: "inductionDate",
                     hint: {
                         text: "For example, 12 11 2022"
-                    }
+                    },
+                    errorMessage: validationErrors | findError('inductionDate'),
+                    formResponses: formResponses
                 }) }}
 
                 {{ timePicker({
-                    id: "induction-time",
-                    namePrefix: "induction-time",
+                    id: "inductionTime",
                     label: {
                         text: "Time"
                     },
                     hint: {
                         text: "For example, 9:30am or 2:55pm"
-                    }
+                    },
+                    errorMessage: validationErrors | findError('inductionTime'),
+                    formResponses: formResponses
                 }) }}
 
                 {{ govukButton({

--- a/server/views/partials/datePicker.njk
+++ b/server/views/partials/datePicker.njk
@@ -1,0 +1,36 @@
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+
+{% macro datePicker(params) %}
+    {% set errorClass = '' %}
+    {% if params.errorMessage %}
+        {% set errorClass = ' govuk-input--error' %}
+    {% endif %}
+    {{ govukDateInput({
+        id: params.id,
+        hint: params.hint,
+        errorMessage: params.errorMessage,
+        items: [
+            {
+                id: params.id + '-day',
+                label: 'Day',
+                name: params.id + '[day]',
+                classes: 'govuk-input--width-2' + errorClass,
+                value: params.formResponses[params.id]['day']
+            },
+            {
+                id: params.id + '-month',
+                label: 'Month',
+                name: params.id + '[month]',
+                classes: 'govuk-input--width-2' + errorClass,
+                value: params.formResponses[params.id]['month']
+            },
+            {
+                id: params.id + '-year',
+                label: 'Year',
+                name: params.id + '[year]',
+                classes: 'govuk-input--width-4' + errorClass,
+                value: params.formResponses[params.id]['year']
+            }
+        ]
+    }) }}
+{% endmacro %}

--- a/server/views/partials/datePicker.test.ts
+++ b/server/views/partials/datePicker.test.ts
@@ -1,0 +1,43 @@
+import cheerio from 'cheerio'
+import nunjucks, { Template } from 'nunjucks'
+import { registerNunjucks } from '../../utils/nunjucksSetup'
+
+describe('View Partials - Date Picker', () => {
+  let compiledTemplate: Template
+  let viewContext: Record<string, unknown>
+
+  const njkEnv = registerNunjucks()
+
+  it('should add error class to inputs when an error is present', () => {
+    viewContext = {
+      options: {
+        id: 'datePicker',
+        errorMessage: {
+          text: 'error',
+        },
+      },
+    }
+    const nunjucksString = '{% from "partials/datePicker.njk" import datePicker %}{{ datePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('#datePicker-day').hasClass('govuk-input--error')).toBe(true)
+    expect($('#datePicker-month').hasClass('govuk-input--error')).toBe(true)
+    expect($('#datePicker-year').hasClass('govuk-input--error')).toBe(true)
+  })
+
+  it('should not add error class to inputs when an error is not present', () => {
+    viewContext = {
+      options: {
+        id: 'datePicker',
+      },
+    }
+    const nunjucksString = '{% from "partials/datePicker.njk" import datePicker %}{{ datePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('#datePicker-day').hasClass('govuk-input--error')).toBe(false)
+    expect($('#datePicker-month').hasClass('govuk-input--error')).toBe(false)
+    expect($('#datePicker-year').hasClass('govuk-input--error')).toBe(false)
+  })
+})

--- a/server/views/partials/formError.njk
+++ b/server/views/partials/formError.njk
@@ -1,0 +1,14 @@
+{% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
+{% set errorSummaryList = validationErrors | errorSummaryList %}
+
+{% if errorSummaryList.length > 0 %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukErrorSummary({
+                titleText: "There is a problem",
+                errorList: errorSummaryList,
+                classes: 'govuk-!-margin-top-5 govuk-!-margin-bottom-0'
+            }) }}
+        </div>
+    </div>
+{% endif %}

--- a/server/views/partials/formError.test.ts
+++ b/server/views/partials/formError.test.ts
@@ -1,0 +1,38 @@
+import cheerio from 'cheerio'
+import nunjucks, { Template } from 'nunjucks'
+import { registerNunjucks } from '../../utils/nunjucksSetup'
+
+describe('View Partials - Form Error', () => {
+  let compiledTemplate: Template
+  let viewContext: Record<string, unknown>
+
+  const njkEnv = registerNunjucks()
+
+  it('should not show error summary if no errors exist', () => {
+    viewContext = {
+      errorSummaryList: [],
+    }
+    const nunjucksString = '{% include "partials/formError.njk" %}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('.govuk-error-summary').length).toBe(0)
+  })
+
+  it('should display error summary when errors exist', () => {
+    viewContext = {
+      validationErrors: [
+        {
+          field: 'field',
+          message: 'Error',
+        },
+      ],
+    }
+    const nunjucksString = '{% include "partials/formError.njk" %}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('.govuk-error-summary__list > li').length).toBe(1)
+    expect($('.govuk-error-summary__list > li > a').text()).toBe('Error')
+  })
+})

--- a/server/views/partials/timePicker.njk
+++ b/server/views/partials/timePicker.njk
@@ -1,7 +1,7 @@
 {% macro timePicker(params) %}
-    <div class="govuk-form-group">
+    <div class="govuk-form-group {% if params.errorMessage %}govuk-form-group--error{% endif %}">
         {% if params.label %}
-            <label id="{{ params.id }}-label" for="{{ params.id }}" class="govuk-label {{ params.label.classes }}">
+            <label id="{{ params.id }}-label" class="govuk-label {{ params.label.classes }}">
                 {{ params.label.text }}
             </label>
         {% endif %}
@@ -10,34 +10,49 @@
                 {{ params.hint.text }}
             </div>
         {% endif %}
+        {% if params.errorMessage %}
+            <span id="{{ params.id }}-error" class="govuk-error-message">
+                <span class="govuk-visually-hidden">Error:</span>
+                <span>{{ params.errorMessage.text }}</span>
+            </span>
+        {% endif %}
         <div class="govuk-date-input" id="{{ params.id }}">
             <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
                     <label class="govuk-label govuk-date-input__label" for="{{ params.id }}-hour">
                         Hour
                     </label>
-                    <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="{{ params.id }}-hour"
-                           name="{{ params.namePrefix }}-hour" type="text" pattern="[0-9]*" inputmode="numeric">
+                    <input class="govuk-input govuk-date-input__input govuk-input--width-2 {% if params.errorMessage %}govuk-input--error{% endif %}"
+                           id="{{ params.id }}-hour"
+                           name="{{ params.id }}[hour]" type="text" pattern="[0-9]*" inputmode="numeric"
+                           value="{{ params.formResponses[params.id]['hour'] }}">
                 </div>
             </div>
             <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                    <label class="govuk-label govuk-date-input__label" for="{{ params.id }}-month">
+                    <label class="govuk-label govuk-date-input__label" for="{{ params.id }}-minute">
                         Minute
                     </label>
-                    <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="{{ params.id }}-month"
-                           name="{{ params.namePrefix }}-month" type="text" pattern="[0-9]*" inputmode="numeric">
+                    <input class="govuk-input govuk-date-input__input govuk-input--width-2 {% if params.errorMessage %}govuk-input--error{% endif %}"
+                           id="{{ params.id }}-minute"
+                           name="{{ params.id }}[minute]" type="text" pattern="[0-9]*" inputmode="numeric"
+                           value="{{ params.formResponses[params.id]['minute'] }}">
                 </div>
             </div>
             <div class="govuk-date-input__item">
                 <div class="govuk-form-group">
-                    <label class="govuk-label govuk-date-input__label" for="{{ params.id }}-year">
+                    <label class="govuk-label govuk-date-input__label" for="{{ params.id }}-ampm">
                         am or pm
                     </label>
-                    <select class="govuk-select govuk-date-input__input govuk-input--width-2" id="{{ params.id }}-year"
-                           name="{{ params.namePrefix }}-year">
-                        <option value="am">am</option>
-                        <option value="pm">pm</option>
+                    <select class="govuk-select govuk-date-input__input govuk-input--width-2 {% if params.errorMessage %}govuk-select--error{% endif %}"
+                            id="{{ params.id }}-ampm"
+                            name="{{ params.id }}[ampm]">
+                        <option value="am" {% if params.formResponses[params.id]['ampm'] == 'am' %} selected {% endif %}>
+                            am
+                        </option>
+                        <option value="pm" {% if params.formResponses[params.id]['ampm'] == 'pm' %} selected {% endif %}>
+                            pm
+                        </option>
                     </select>
                 </div>
             </div>

--- a/server/views/partials/timePicker.test.ts
+++ b/server/views/partials/timePicker.test.ts
@@ -62,4 +62,162 @@ describe('View Partials - Time Picker', () => {
 
     expect($('.govuk-hint').length).toBe(0)
   })
+
+  it('should add error class to form group if error exists', () => {
+    viewContext = {
+      options: {
+        errorMessage: {
+          text: 'error',
+        },
+      },
+    }
+    const nunjucksString = '{% from "partials/timePicker.njk" import timePicker %}{{ timePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('.govuk-form-group').attr('class')).toContain('govuk-form-group--error')
+  })
+
+  it('should not add error class to form group when error does not exist', () => {
+    viewContext = {
+      options: {},
+    }
+    const nunjucksString = '{% from "partials/timePicker.njk" import timePicker %}{{ timePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('.govuk-form-group').attr('class')).not.toContain('govuk-form-group--error')
+  })
+
+  it('should display error span if error exists', () => {
+    viewContext = {
+      options: {
+        errorMessage: {
+          text: 'error',
+        },
+      },
+    }
+    const nunjucksString = '{% from "partials/timePicker.njk" import timePicker %}{{ timePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('.govuk-error-message').length).toBe(1)
+    expect($('.govuk-error-message > span:nth-child(2)').text().trim()).toBe('error')
+  })
+
+  it('should not display error span when error does not exist', () => {
+    viewContext = {
+      options: {},
+    }
+    const nunjucksString = '{% from "partials/timePicker.njk" import timePicker %}{{ timePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('.govuk-error-message').length).toBe(0)
+  })
+
+  it('should mark AM time option as selected when AM is in the form response', () => {
+    viewContext = {
+      options: {
+        id: 'timePicker',
+        formResponses: {
+          timePicker: {
+            ampm: 'am',
+          },
+        },
+      },
+    }
+    const nunjucksString = '{% from "partials/timePicker.njk" import timePicker %}{{ timePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('#timePicker-ampm > option:nth-child(1)').attr('selected')).toBe('selected')
+    expect($('#timePicker-ampm > option:nth-child(2)').attr('selected')).toBeUndefined()
+  })
+
+  it('should mark PM time option as selected when AM is in the form response', () => {
+    viewContext = {
+      options: {
+        id: 'timePicker',
+        formResponses: {
+          timePicker: {
+            ampm: 'pm',
+          },
+        },
+      },
+    }
+    const nunjucksString = '{% from "partials/timePicker.njk" import timePicker %}{{ timePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('#timePicker-ampm > option:nth-child(1)').attr('selected')).toBeUndefined()
+    expect($('#timePicker-ampm > option:nth-child(2)').attr('selected')).toBe('selected')
+  })
+
+  it('should mark AM time option as selected when AM is in the form response', () => {
+    viewContext = {
+      options: {
+        id: 'timePicker',
+        formResponses: {
+          timePicker: {
+            ampm: 'am',
+          },
+        },
+      },
+    }
+    const nunjucksString = '{% from "partials/timePicker.njk" import timePicker %}{{ timePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('#timePicker-ampm > option:nth-child(1)').attr('selected')).toBe('selected')
+    expect($('#timePicker-ampm > option:nth-child(2)').attr('selected')).toBeUndefined()
+  })
+
+  it('should not mark either time option as selected when timePicker is not in the form response', () => {
+    viewContext = {
+      options: {
+        id: 'timePicker',
+        formResponses: {},
+      },
+    }
+    const nunjucksString = '{% from "partials/timePicker.njk" import timePicker %}{{ timePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('#timePicker-ampm > option:nth-child(1)').attr('selected')).toBeUndefined()
+    expect($('#timePicker-ampm > option:nth-child(2)').attr('selected')).toBeUndefined()
+  })
+
+  it('should add error class to inputs when an error is present', () => {
+    viewContext = {
+      options: {
+        id: 'timePicker',
+        errorMessage: {
+          text: 'error',
+        },
+      },
+    }
+    const nunjucksString = '{% from "partials/timePicker.njk" import timePicker %}{{ timePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('#timePicker-hour').hasClass('govuk-input--error')).toBe(true)
+    expect($('#timePicker-minute').hasClass('govuk-input--error')).toBe(true)
+    expect($('#timePicker-ampm').hasClass('govuk-select--error')).toBe(true)
+  })
+
+  it('should not add error class to inputs when an error is not present', () => {
+    viewContext = {
+      options: {
+        id: 'timePicker',
+      },
+    }
+    const nunjucksString = '{% from "partials/timePicker.njk" import timePicker %}{{ timePicker(options)}}'
+    compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('#timePicker-hour').hasClass('govuk-input--error')).toBe(false)
+    expect($('#timePicker-minute').hasClass('govuk-input--error')).toBe(false)
+    expect($('#timePicker-ampm').hasClass('govuk-select--error')).toBe(false)
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": true,
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
     "moduleResolution": "node",
     "outDir": "./dist",


### PR DESCRIPTION
- Added validation middleware
- Add error messages to flash to be retrieved on the following GET
- Map errors to GOV.uk format for display https://design-system.service.gov.uk/components/error-summary/
- Add `REFERER` header to allow `res.redirect('back')` to work. Same origin only.
- Add cheerio tests to test the nunjucks filters in isolation
- Errors are displayed in the order they are validated (i.e. annotated)

![screencapture-localhost-3000-licence-create-id-1-initial-meeting-time-2021-09-02-21_11_59](https://user-images.githubusercontent.com/30229564/131909651-11ed9935-e613-4fde-8a2b-38d4fb3bd991.png)
