### PR TITLE
CVSL-96: Updated alert channel to public channel and updated dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,11 +7,11 @@ orbs:
 parameters:
   alerts-slack-channel:
     type: string
-    default: farsight-devs
+    default: farsight-alerts
 
   releases-slack-channel:
     type: string
-    default: farsight-devs
+    default: farsight-alerts
 
   node-version:
     type: string

--- a/package-lock.json
+++ b/package-lock.json
@@ -6237,9 +6237,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.0.tgz",
-      "integrity": "sha512-JiPCeasuHZ+9m1VyqhsfE81PhWIW4Sweoe6Jvn6oMjQNr75ZpupiytN3DGwA+WKOoESHZibIG+heAzlkdZ/MhA=="
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.13.1.tgz",
+      "integrity": "sha512-OlbAVVpJfZ8tEhkScVoNFA+27RUfMDslN4uxtJyASfXwg4QZYHTX8RqmKBbgVJWaybpa5RsYDuRKQNJe3qN8gw=="
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -11207,9 +11207,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass": {
-      "version": "1.32.13",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.32.13.tgz",
-      "integrity": "sha512-dEgI9nShraqP7cXQH+lEXVf73WOPCse0QlFzSD8k+1TcOxCMwVXfQlr0jtoluZysQOyJGnfr21dLvYKDJq8HkA==",
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.39.0.tgz",
+      "integrity": "sha512-F4o+RhJkNOIG0b6QudYU8c78ZADKZjKDk5cyrf8XTKWfrgbtyVVXImFstJrc+1pkQDCggyidIOytq6gS4gCCZg==",
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
       "prettier --write",
       "eslint --fix"
     ],
-    "*.{json}": [
+    "*.json": [
       "prettier --write"
     ]
   },
@@ -105,7 +105,7 @@
     "express": "^4.17.1",
     "express-request-id": "^1.4.1",
     "express-session": "^1.17.2",
-    "govuk-frontend": "^3.13.0",
+    "govuk-frontend": "^3.13.1",
     "helmet": "^4.6.0",
     "http-errors": "^1.8.0",
     "jquery": "^3.6.0",
@@ -117,7 +117,7 @@
     "passport-oauth2": "^1.5.0",
     "redis": "^3.1.2",
     "reflect-metadata": "^0.1.13",
-    "sass": "^1.32.13",
+    "sass": "^1.39.0",
     "superagent": "^6.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
In this PR
* Use farsight-alerts in place of farsight-devs for alerts (public channel)
* Update sass version
* Update govuk-frontend version - fails the check_outdated circle job overnight