### PR TITLE
CVSL-116: Confirmation page

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,6 +16,8 @@ generic-service:
     LICENCE_API_URL: "https://create-and-vary-a-licence-api-dev.hmpps.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-offender-search-dev.prison.service.justice.gov.uk"
     PROBATION_SEARCH_API_URL: "https://probation-offender-search-dev.hmpps.service.justice.gov.uk"
+    EXIT_SURVEY_LINK: "#"
+    PHASE_BANNER_LINK: "#"
 
     # A reference to the Gotenberg service - to submit HTML to PDF conversions (internal within namespace)
     GOTENBERG_API_URL: "http://create-and-vary-a-licence-gotenberg"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,8 +16,8 @@ generic-service:
     LICENCE_API_URL: "https://create-and-vary-a-licence-api-dev.hmpps.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-offender-search-dev.prison.service.justice.gov.uk"
     PROBATION_SEARCH_API_URL: "https://probation-offender-search-dev.hmpps.service.justice.gov.uk"
-    EXIT_SURVEY_LINK: "#"
-    PHASE_BANNER_LINK: "#"
+    EXIT_SURVEY_LINK: "https://eu.surveymonkey.com/r/Preview/?sm=CQIWAIrnp68aIE1_2BNn3aRSTf_2BXWLpL8B9mtgPre1TKl4OznrnkajcbEz6SvRvXwn"
+    PHASE_BANNER_LINK: "https://eu.surveymonkey.com/r/Preview/?sm=CQIWAIrnp68aIE1_2BNn3aRSTf_2BXWLpL8B9mtgPre1TKl4OznrnkajcbEz6SvRvXwn"
 
     # A reference to the Gotenberg service - to submit HTML to PDF conversions (internal within namespace)
     GOTENBERG_API_URL: "http://create-and-vary-a-licence-gotenberg"

--- a/integration_tests/integration/createLicence.spec.js
+++ b/integration_tests/integration/createLicence.spec.js
@@ -1,4 +1,5 @@
 const IndexPage = require('../pages/index')
+// const ConfirmationPage = require('../pages/confirmation')
 
 context('Create a Licence', () => {
   beforeEach(() => {
@@ -10,6 +11,7 @@ context('Create a Licence', () => {
   it('User can create a licence', () => {
     cy.login()
     IndexPage.verifyOnPage()
-    // TODO: Expand this test as the journey is built
+    // TODO: Needs forerunners to be implemented first
+    // ConfirmationPage.verifyOnPage()
   })
 })

--- a/integration_tests/integration/createLicence.spec.js
+++ b/integration_tests/integration/createLicence.spec.js
@@ -6,12 +6,15 @@ context('Create a Licence', () => {
     cy.task('reset')
     cy.task('stubLogin')
     cy.task('stubAuthUser')
+    cy.task('stubGetLicence', 1)
   })
 
   it('User can create a licence', () => {
     cy.login()
     IndexPage.verifyOnPage()
     // TODO: Needs forerunners to be implemented first
+    // TODO: Needs the list & selection from list
+    // TODO: Needs API calls stubbed - prisoner-offender-search, communityApi (for caseload)
     // ConfirmationPage.verifyOnPage()
   })
 })

--- a/integration_tests/mockApis/licence.js
+++ b/integration_tests/mockApis/licence.js
@@ -1,0 +1,60 @@
+const { stubFor } = require('./wiremock')
+
+module.exports = {
+  stubGetLicence: ({ licenceId }) => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/licence/id/${licenceId}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          id: 1,
+          typeCode: 'AP',
+          version: '1.1',
+          statusCode: 'IN_PROGRESS',
+          nomsId: 'A1234AA',
+          bookingNo: '123456',
+          bookingId: '54321',
+          crn: 'X12345',
+          pnc: '2019/123445',
+          cro: '12345',
+          prisonCode: 'LEI',
+          prisonDescription: 'Leeds (HMP)',
+          forename: 'Bob',
+          surname: 'Zimmer',
+          dateOfBirth: '12/02/1980',
+          conditionalReleaseDate: '13/03/2021',
+          actualReleaseDate: '01/04/2021',
+          sentenceStartDate: '10/01/2019',
+          sentenceEndDate: '26/04/2022',
+          licenceStartDate: '01/04/2021',
+          licenceExpiryDate: '26/04/2022',
+          comFirstName: 'Stephen',
+          comLastName: 'Mills',
+          comUsername: 'X12345',
+          comStaffId: '12345',
+          comEmail: 'stephen.mills@nps.gov.uk',
+          comTelephone: '0116 2788777',
+          probationAreaCode: 'N01',
+          probationLduCode: 'LDU1',
+          dateCreated: '10/009/2021 10:00:00', // Make dynamic to now?
+          createdByUsername: 'X12345',
+          standardConditions: [
+            { id: 1, code: 'goodBehaviour', sequence: 1, text: 'Be of good behaviour' },
+            { id: 2, code: 'notBreakLaw', sequence: 2, text: 'Do not break the law' },
+            { id: 3, code: 'attendMeetings', sequence: 3, text: 'Attend arranged meetings' },
+          ],
+          additionalConditions: [],
+          bespokeConditions: [],
+        },
+      },
+    })
+  },
+
+  // TODO: POST for createLicenceRequest with createLicenceResponse
+  // TODO: Additional POSTs for each creation stage too
+  // As we are working with a single licence for the creation flow - all operations relate to this licence
+}

--- a/integration_tests/pages/confirmation.js
+++ b/integration_tests/pages/confirmation.js
@@ -1,0 +1,8 @@
+const page = require('./page')
+
+const confirmationPage = () =>
+  page('Confirmation', {
+    headerUserName: () => cy.get('[data-qa=header-user-name]'),
+  })
+
+module.exports = { verifyOnPage: confirmationPage }

--- a/integration_tests/pages/page.js
+++ b/integration_tests/pages/page.js
@@ -4,7 +4,7 @@ module.exports = (name, pageObject = {}, axeTest = true) => {
     cy.checkA11y()
   }
 
-  const checkOnPage = () => cy.get('h1').contains(name)
+  const checkOnPage = () => cy.get('h1').contains(name) || cy.get('title').contains(name)
   const logout = () => cy.get('[data-qa=logout]')
   checkOnPage()
   return { ...pageObject, checkStillOnPage: checkOnPage, logout }

--- a/integration_tests/plugins/index.js
+++ b/integration_tests/plugins/index.js
@@ -1,6 +1,7 @@
 const { resetStubs } = require('../mockApis/wiremock')
 
 const auth = require('../mockApis/auth')
+const licence = require('../mockApis/licence')
 const tokenVerification = require('../mockApis/tokenVerification')
 
 module.exports = on => {
@@ -14,5 +15,7 @@ module.exports = on => {
     stubAuthPing: auth.stubPing,
 
     stubTokenVerificationPing: tokenVerification.stubPing,
+
+    stubGetLicence: licence.stubGetLicence,
   })
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -123,6 +123,6 @@ export default {
     },
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
-  exitSurveyLink: get('EXIT_SURVEY_LINK', 'http://tim-test-exit', requiredInProduction),
-  phaseBannerLink: get('PHASE_BANNER_LINK', 'http://tim-test-phase', requiredInProduction),
+  exitSurveyLink: get('EXIT_SURVEY_LINK', 'https://exit-survey-placeholder-link', requiredInProduction),
+  phaseBannerLink: get('PHASE_BANNER_LINK', 'https://phase-banner-placeholder-link', requiredInProduction),
 }

--- a/server/config.ts
+++ b/server/config.ts
@@ -123,4 +123,6 @@ export default {
     },
   },
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
+  exitSurveyLink: get('EXIT_SURVEY_LINK', 'http://tim-test-exit', requiredInProduction),
+  phaseBannerLink: get('PHASE_BANNER_LINK', 'http://tim-test-phase', requiredInProduction),
 }

--- a/server/routes/creatingLicences/handlers/confirmation.test.ts
+++ b/server/routes/creatingLicences/handlers/confirmation.test.ts
@@ -22,12 +22,7 @@ describe('Route Handlers - Create Licence - Confirmation', () => {
   describe('GET', () => {
     it('should render view', async () => {
       await handler.GET(req, res)
-      expect(res.render).toHaveBeenCalledWith('pages/create/confirmation', {
-        offender: {
-          name: 'Adam Balasaravika',
-          prison: 'Brixton Prison',
-        },
-      })
+      expect(res.render).toHaveBeenCalledWith('pages/create/confirmation')
     })
   })
 })

--- a/server/routes/creatingLicences/handlers/confirmation.ts
+++ b/server/routes/creatingLicences/handlers/confirmation.ts
@@ -1,11 +1,8 @@
 import { Request, Response } from 'express'
+import config from '../../../config'
 
 export default class ConfirmationRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {
-    const offender = {
-      name: 'Adam Balasaravika',
-      prison: 'Brixton Prison',
-    }
-    res.render('pages/create/confirmation', { offender })
+    res.render('pages/create/confirmation')
   }
 }

--- a/server/routes/creatingLicences/handlers/confirmation.ts
+++ b/server/routes/creatingLicences/handlers/confirmation.ts
@@ -1,5 +1,4 @@
 import { Request, Response } from 'express'
-import config from '../../../config'
 
 export default class ConfirmationRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -3,6 +3,7 @@ import nunjucks, { Environment } from 'nunjucks'
 import express from 'express'
 import path from 'path'
 import { FieldValidationError } from '../middleware/validationMiddleware'
+import config from '../config'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -11,6 +12,10 @@ export default function nunjucksSetup(app: express.Express): void {
 
   app.locals.asset_path = '/assets/'
   app.locals.applicationName = 'Create And Vary A Licence'
+
+  // Set the values for the phase banner and exit survey links from config
+  app.locals.phaseBannerLink = config.phaseBannerLink
+  app.locals.exitSurveyLink = config.exitSurveyLink
 
   // Cachebusting version string
   if (production) {

--- a/server/views/layout.njk
+++ b/server/views/layout.njk
@@ -36,7 +36,7 @@
       tag: {
         text: "beta"
       },
-      html: 'This is a new service – your <a class="govuk-link" href="'+ phaseBannerLink +'">feedback</a> will help us to improve it.'
+      html: 'This is a new service – your <a class="govuk-link" rel="noreferrer noopener" target="_blank" href="'+ phaseBannerLink +'">feedback</a> will help us to improve it.'
     }) }}
   {% include 'partials/formError.njk' %}
 {% endblock %}

--- a/server/views/layout.njk
+++ b/server/views/layout.njk
@@ -36,7 +36,7 @@
       tag: {
         text: "beta"
       },
-      html: 'This is a new service – your <a class="govuk-link" href="#">feedback</a> will help us to improve it.'
+      html: 'This is a new service – your <a class="govuk-link" href="'+ phaseBannerLink +'">feedback</a> will help us to improve it.'
     }) }}
   {% include 'partials/formError.njk' %}
 {% endblock %}

--- a/server/views/pages/create/confirmation.njk
+++ b/server/views/pages/create/confirmation.njk
@@ -1,5 +1,6 @@
 {% extends "layout.njk" %}
 
+{% from "govuk/components//button/macro.njk" import govukButton %}
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
 {% set pageTitle = applicationName + " - Create a licence - Confirmation" %}
@@ -8,20 +9,29 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {{ govukPanel({
-                titleText: "Licence conditions for " + offender.name + " sent"
+              titleText: "Licence conditions for " + licence.forename + " " + licence.surname + " sent"
             }) }}
 
             <h2 class="govuk-heading-m">What happens next</h2>
             <p class="govuk-body">
-                We have sent the licence conditions to {{ offender.prison }} for approval.
+              We have sent the licence conditions to {{ licence.prisonDescription }} for approval.
             </p>
             <p class="govuk-body">
-                You will get an email notification when they are approved.
+              You will get an email notification when they are approved.
             </p>
 
             <h2 class="govuk-heading-m">Give us your feedback</h2>
             <p class="govuk-body">
-                <a href="#" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+                <a href="{{ exitSurveyLink }}" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+            </p>
+
+            <p class="govuk-body">
+            {{ govukButton({
+                text: "Return to home page",
+                classes: "govuk-button--primary govuk-!-margin-bottom-0",
+                href: '/',
+                attributes: { 'data-qa': 'return-to-home-page' }
+            }) }}
             </p>
         </div>
     </div>

--- a/server/views/pages/create/confirmation.njk
+++ b/server/views/pages/create/confirmation.njk
@@ -22,7 +22,7 @@
 
             <h2 class="govuk-heading-m">Give us your feedback</h2>
             <p class="govuk-body">
-                <a href="{{ exitSurveyLink }}" id="exit-survey" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+                <a href="{{ exitSurveyLink }}" target="_blank" id="exit-survey" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
             </p>
 
             <p class="govuk-body">

--- a/server/views/pages/create/confirmation.njk
+++ b/server/views/pages/create/confirmation.njk
@@ -22,7 +22,7 @@
 
             <h2 class="govuk-heading-m">Give us your feedback</h2>
             <p class="govuk-body">
-                <a href="{{ exitSurveyLink }}" target="_blank" id="exit-survey" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+                <a href="{{ exitSurveyLink }}" rel="noreferrer noopener" target="_blank" id="exit-survey" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
             </p>
 
             <p class="govuk-body">

--- a/server/views/pages/create/confirmation.njk
+++ b/server/views/pages/create/confirmation.njk
@@ -13,22 +13,22 @@
             }) }}
 
             <h2 class="govuk-heading-m">What happens next</h2>
-            <p class="govuk-body">
-              We have sent the licence conditions to {{ licence.prisonDescription }} for approval.
+            <p class="govuk-body" id="sent-to">
+                We have sent the licence conditions to {{ licence.prisonDescription }} for approval.
             </p>
             <p class="govuk-body">
-              You will get an email notification when they are approved.
+                You will get an email notification when they are approved.
             </p>
 
             <h2 class="govuk-heading-m">Give us your feedback</h2>
             <p class="govuk-body">
-                <a href="{{ exitSurveyLink }}" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
+                <a href="{{ exitSurveyLink }}" id="exit-survey" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
             </p>
 
             <p class="govuk-body">
             {{ govukButton({
                 text: "Return to home page",
-                classes: "govuk-button--primary govuk-!-margin-bottom-0",
+                classes: "govuk-button--primary govuk-!-margin-bottom-0 govuk-body",
                 href: '/',
                 attributes: { 'data-qa': 'return-to-home-page' }
             }) }}

--- a/server/views/pages/create/confirmation.test.ts
+++ b/server/views/pages/create/confirmation.test.ts
@@ -1,0 +1,33 @@
+import fs from 'fs'
+import cheerio from 'cheerio'
+import nunjucks, { Template } from 'nunjucks'
+import { registerNunjucks } from '../../../utils/nunjucksSetup'
+
+const snippet = fs.readFileSync('server/views/pages/create/confirmation.njk')
+
+describe('Create a licence - confirmation', () => {
+  let compiledTemplate: Template
+  let viewContext: Record<string, unknown>
+
+  const njkEnv = registerNunjucks()
+
+  beforeEach(() => {
+    compiledTemplate = nunjucks.compile(snippet.toString(), njkEnv)
+    viewContext = {
+      exitSurveyLink: 'test-exit-survey',
+      licence: {
+        forename: 'Bobby',
+        surname: 'Z',
+        prisonDescription: 'Leeds',
+      },
+    }
+  })
+
+  it('should display the name, prison and exit survey link', () => {
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+
+    expect($('#exit-survey').attr('href')).toBe('test-exit-survey')
+    expect($('#sent-to').text().trim()).toBe('We have sent the licence conditions to Leeds for approval.')
+    expect($('.govuk-panel__title').text().trim()).toBe('Licence conditions for Bobby Z sent')
+  })
+})


### PR DESCRIPTION
This PR:

* Adds the `fetchLicenceMiddleware` to the confirmation page and shows licence details.
* Adds configurable links for the phase banner and exit survey - by environment (in nunjucksSetup module - app.locals)
* Adds a `Return to home` button
* Template tests using cheerio to check content
* Puts some scaffolding in place for integration tests - licenceApi, getLicence stub, confirmation page definition (not used yet)