### PR TITLE
CVSL-131: Pull staff caseload from Delius

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -2,6 +2,7 @@ PORT=3007
 HMPPS_AUTH_URL=http://localhost:9091/auth
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 LICENCE_API_URL=http://localhost:9091
+COMMUNITY_API_URL=http://localhost:9091
 NODE_ENV=development
 API_CLIENT_ID=clientid
 API_CLIENT_SECRET=clientsecret

--- a/integration_tests/integration/createLicence.spec.ts
+++ b/integration_tests/integration/createLicence.spec.ts
@@ -13,6 +13,7 @@ context('Create a licence', () => {
     cy.task('stubPutAppointmentTime', 1)
     cy.task('stubPutAppointmentAddress', 1)
     cy.task('stubPutContactNumber', 1)
+    cy.task('stubGetManagedOffenders', 2500012436)
     cy.signIn()
   })
 

--- a/integration_tests/integration/createLicence.spec.ts
+++ b/integration_tests/integration/createLicence.spec.ts
@@ -13,7 +13,8 @@ context('Create a licence', () => {
     cy.task('stubPutAppointmentTime', 1)
     cy.task('stubPutAppointmentAddress', 1)
     cy.task('stubPutContactNumber', 1)
-    cy.task('stubGetManagedOffenders', 2500012436)
+    cy.task('stubGetStaffDetails', 'USER1')
+    cy.task('stubGetManagedOffenders', 2000)
     cy.signIn()
   })
 

--- a/integration_tests/mockApis/community.ts
+++ b/integration_tests/mockApis/community.ts
@@ -1,0 +1,30 @@
+import { SuperAgentRequest } from 'superagent'
+import { stubFor } from '../wiremock'
+
+export default {
+  stubGetManagedOffenders: (staffId: string): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/secure/staff/staffIdentifier/${staffId}/managedOffenders`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: [
+          {
+            staffCode: 'NHIALLU',
+            staffIdentifier: 2500012436,
+            offenderId: 2500368308,
+            nomsNumber: 'G9786GC',
+            crnNumber: 'X344165',
+            offenderSurname: 'Balasaravika',
+            currentRo: true,
+            currentOm: false,
+            currentPom: true,
+          },
+        ],
+      },
+    })
+  },
+}

--- a/integration_tests/mockApis/community.ts
+++ b/integration_tests/mockApis/community.ts
@@ -2,6 +2,22 @@ import { SuperAgentRequest } from 'superagent'
 import { stubFor } from '../wiremock'
 
 export default {
+  stubGetStaffDetails: (deliusUsername: string): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/secure/staff/username/${deliusUsername}`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          staffIdentifier: 2000,
+        },
+      },
+    })
+  },
+
   stubGetManagedOffenders: (staffId: string): SuperAgentRequest => {
     return stubFor({
       request: {
@@ -20,8 +36,8 @@ export default {
             crnNumber: 'X344165',
             offenderSurname: 'Balasaravika',
             currentRo: false,
-            currentOm: false, // TODO: This should be true when we have our own delius accounts to use in dev
-            currentPom: true,
+            currentOm: true,
+            currentPom: false,
           },
         ],
       },

--- a/integration_tests/mockApis/community.ts
+++ b/integration_tests/mockApis/community.ts
@@ -19,8 +19,8 @@ export default {
             nomsNumber: 'G9786GC',
             crnNumber: 'X344165',
             offenderSurname: 'Balasaravika',
-            currentRo: true,
-            currentOm: false,
+            currentRo: false,
+            currentOm: false, // TODO: This should be true when we have our own delius accounts to use in dev
             currentPom: true,
           },
         ],

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -3,6 +3,7 @@ import { resetStubs } from '../wiremock'
 import auth from '../mockApis/auth'
 import tokenVerification from '../mockApis/tokenVerification'
 import licence from '../mockApis/licence'
+import community from '../mockApis/community'
 
 export default (on: (string, Record) => void): void => {
   on('task', {
@@ -21,5 +22,7 @@ export default (on: (string, Record) => void): void => {
     stubPutAppointmentTime: licence.stubPutAppointmentTime,
     stubPutAppointmentAddress: licence.stubPutAppointmentAddress,
     stubPutContactNumber: licence.stubPutContactNumber,
+
+    stubGetManagedOffenders: community.stubGetManagedOffenders,
   })
 }

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -23,6 +23,7 @@ export default (on: (string, Record) => void): void => {
     stubPutAppointmentAddress: licence.stubPutAppointmentAddress,
     stubPutContactNumber: licence.stubPutContactNumber,
 
+    stubGetStaffDetails: community.stubGetStaffDetails,
     stubGetManagedOffenders: community.stubGetManagedOffenders,
   })
 }

--- a/server/data/communityApiClient.test.ts
+++ b/server/data/communityApiClient.test.ts
@@ -48,7 +48,7 @@ describe('Community API client tests', () => {
     it('Get managed cases', async () => {
       hmppsAuthClient.getSystemClientToken.mockResolvedValue('a token')
       fakeApi.get('/secure/staff/staffIdentifier/1234/managedOffenders', '').reply(200, stubbedManagedOffenders)
-      const data = await communityService.getManagedOffenders('XTEST1', 1234)
+      const data = await communityService.getManagedOffenders(1234)
       expect(data).toEqual(stubbedManagedOffenders)
       expect(nock.isDone()).toBe(true)
       expect(hmppsAuthClient.getSystemClientToken).toBeCalled()
@@ -58,7 +58,7 @@ describe('Community API client tests', () => {
       hmppsAuthClient.getSystemClientToken.mockResolvedValue('')
       fakeApi.get('/secure/staff/staffIdentifier/1234/managedOffenders', '').reply(401)
       try {
-        await communityService.getManagedOffenders('XTEST1', 1234)
+        await communityService.getManagedOffenders(1234)
       } catch (e) {
         expect(e.message).toContain('Unauthorized')
       }
@@ -69,7 +69,7 @@ describe('Community API client tests', () => {
     it('Empty caseload', async () => {
       hmppsAuthClient.getSystemClientToken.mockResolvedValue('a token')
       fakeApi.get('/secure/staff/staffIdentifier/1234/managedOffenders', '').reply(200, [])
-      const data = await communityService.getManagedOffenders('XTEST1', 1234)
+      const data = await communityService.getManagedOffenders(1234)
       expect(data).toEqual([])
       expect(nock.isDone()).toBe(true)
       expect(hmppsAuthClient.getSystemClientToken).toBeCalled()
@@ -79,7 +79,7 @@ describe('Community API client tests', () => {
       hmppsAuthClient.getSystemClientToken.mockResolvedValue('a token')
       fakeApi.get('/secure/staff/staffIdentifier/1111/managedOffenders', '').reply(404)
       try {
-        await communityService.getManagedOffenders('XTEST1', 1111)
+        await communityService.getManagedOffenders(1111)
       } catch (e) {
         expect(e.message).toContain('Not Found')
       }
@@ -92,7 +92,7 @@ describe('Community API client tests', () => {
     it('Get staff details', async () => {
       hmppsAuthClient.getSystemClientToken.mockResolvedValue('a token')
       fakeApi.get('/secure/staff/username/TestUserNPS', '').reply(200, stubbedStaffDetails)
-      const data = await communityService.getStaffDetail('XTEST1', 'TestUserNPS')
+      const data = await communityService.getStaffDetail('TestUserNPS')
       expect(data).toEqual(stubbedStaffDetails)
       expect(nock.isDone()).toBe(true)
       expect(hmppsAuthClient.getSystemClientToken).toBeCalled()

--- a/server/data/probationSearchApiClient.test.ts
+++ b/server/data/probationSearchApiClient.test.ts
@@ -36,7 +36,7 @@ describe('Probation search API client', () => {
     it('Get search results', async () => {
       hmppsAuthClient.getSystemClientToken.mockResolvedValue('a token')
       fakeApi.post('/search', searchCriteria).reply(200, stubbedSearchResult)
-      const data = await communityService.searchProbationers('user1', searchCriteria)
+      const data = await communityService.searchProbationers(searchCriteria)
       expect(data).toEqual(stubbedSearchResult)
       expect(nock.isDone()).toBe(true)
       expect(hmppsAuthClient.getSystemClientToken).toBeCalled()
@@ -46,7 +46,7 @@ describe('Probation search API client', () => {
       hmppsAuthClient.getSystemClientToken.mockResolvedValue('')
       fakeApi.post('/search', searchCriteria).reply(401)
       try {
-        await communityService.searchProbationers('user1', searchCriteria)
+        await communityService.searchProbationers(searchCriteria)
       } catch (e) {
         expect(e.message).toContain('Unauthorized')
       }
@@ -57,7 +57,7 @@ describe('Probation search API client', () => {
     it('Search - no matches', async () => {
       hmppsAuthClient.getSystemClientToken.mockResolvedValue('a token')
       fakeApi.post('/search', searchCriteria).reply(200, [])
-      const data = await communityService.searchProbationers('user1', searchCriteria)
+      const data = await communityService.searchProbationers(searchCriteria)
       expect(data).toEqual([])
       expect(nock.isDone()).toBe(true)
       expect(hmppsAuthClient.getSystemClientToken).toBeCalled()

--- a/server/routes/creatingLicences/handlers/caseload.test.ts
+++ b/server/routes/creatingLicences/handlers/caseload.test.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express'
 import CaseloadRoutes from './caseload'
 import LicenceService from '../../../services/licenceService'
 import CommunityService from '../../../services/communityService'
-import { CommunityApiManagedOffender } from '../../../data/communityClientTypes'
+import { CommunityApiManagedOffender, CommunityApiStaffDetails } from '../../../data/communityClientTypes'
 
 const licenceService = new LicenceService(null) as jest.Mocked<LicenceService>
 const communityService = new CommunityService(null) as jest.Mocked<CommunityService>
@@ -21,13 +21,22 @@ describe('Route Handlers - Create Licence - Caseload', () => {
 
     res = {
       render: jest.fn(),
+      locals: {
+        user: {
+          username: 'USER1',
+        },
+      },
     } as unknown as Response
+
+    communityService.getStaffDetail.mockResolvedValue({
+      staffIdentifier: 2000,
+    } as unknown as CommunityApiStaffDetails)
 
     communityService.getManagedOffenders.mockResolvedValue([
       {
         offenderSurname: 'Balasaravika',
         crnNumber: 'X381306',
-        currentOm: false,
+        currentOm: true,
       } as unknown as CommunityApiManagedOffender,
     ])
   })
@@ -44,6 +53,8 @@ describe('Route Handlers - Create Licence - Caseload', () => {
           },
         ],
       })
+      expect(communityService.getStaffDetail).toHaveBeenCalledWith('USER1')
+      expect(communityService.getManagedOffenders).toHaveBeenCalledWith(2000)
     })
   })
 })

--- a/server/routes/creatingLicences/handlers/caseload.test.ts
+++ b/server/routes/creatingLicences/handlers/caseload.test.ts
@@ -2,11 +2,17 @@ import { Request, Response } from 'express'
 
 import CaseloadRoutes from './caseload'
 import LicenceService from '../../../services/licenceService'
+import CommunityService from '../../../services/communityService'
+import { CommunityApiManagedOffender } from '../../../data/communityClientTypes'
 
 const licenceService = new LicenceService(null) as jest.Mocked<LicenceService>
+const communityService = new CommunityService(null) as jest.Mocked<CommunityService>
+
+jest.mock('../../../services/licenceService')
+jest.mock('../../../services/communityService')
 
 describe('Route Handlers - Create Licence - Caseload', () => {
-  const handler = new CaseloadRoutes(licenceService)
+  const handler = new CaseloadRoutes(licenceService, communityService)
   let req: Request
   let res: Response
 
@@ -16,6 +22,13 @@ describe('Route Handlers - Create Licence - Caseload', () => {
     res = {
       render: jest.fn(),
     } as unknown as Response
+
+    communityService.getManagedOffenders.mockResolvedValue([
+      {
+        offenderSurname: 'Balasaravika',
+        crnNumber: 'X381306',
+      } as unknown as CommunityApiManagedOffender,
+    ])
   })
 
   describe('GET', () => {
@@ -24,7 +37,7 @@ describe('Route Handlers - Create Licence - Caseload', () => {
       expect(res.render).toHaveBeenCalledWith('pages/create/caseload', {
         caseload: [
           {
-            name: 'Adam Balasaravika',
+            name: 'Balasaravika',
             crnNumber: 'X381306',
             conditionalReleaseDate: '03 August 2022',
           },

--- a/server/routes/creatingLicences/handlers/caseload.test.ts
+++ b/server/routes/creatingLicences/handlers/caseload.test.ts
@@ -34,7 +34,7 @@ describe('Route Handlers - Create Licence - Caseload', () => {
 
     communityService.getManagedOffenders.mockResolvedValue([
       {
-        offenderSurname: 'Balasaravika',
+        offenderSurname: 'Jones',
         crnNumber: 'X381306',
         currentOm: true,
       } as unknown as CommunityApiManagedOffender,
@@ -47,8 +47,13 @@ describe('Route Handlers - Create Licence - Caseload', () => {
       expect(res.render).toHaveBeenCalledWith('pages/create/caseload', {
         caseload: [
           {
-            name: 'Balasaravika',
+            name: 'Jones',
             crnNumber: 'X381306',
+            conditionalReleaseDate: '03 August 2022',
+          },
+          {
+            name: 'Adam Balasaravika',
+            crnNumber: 'X344165',
             conditionalReleaseDate: '03 August 2022',
           },
         ],

--- a/server/routes/creatingLicences/handlers/caseload.test.ts
+++ b/server/routes/creatingLicences/handlers/caseload.test.ts
@@ -27,6 +27,7 @@ describe('Route Handlers - Create Licence - Caseload', () => {
       {
         offenderSurname: 'Balasaravika',
         crnNumber: 'X381306',
+        currentOm: false,
       } as unknown as CommunityApiManagedOffender,
     ])
   })

--- a/server/routes/creatingLicences/handlers/caseload.ts
+++ b/server/routes/creatingLicences/handlers/caseload.ts
@@ -8,13 +8,15 @@ export default class CaseloadRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {
     const staffId = 2500012436 // TODO: This needs to be looked up in delius using res.locals.user.username
     const managedOffenders = await this.communityService.getManagedOffenders(staffId)
-    const caseload = managedOffenders.map(offender => {
-      return {
-        name: offender.offenderSurname,
-        crnNumber: offender.crnNumber,
-        conditionalReleaseDate: '03 August 2022', // TODO: Get conditionalReleaseDate from nomis??
-      }
-    })
+    const caseload = managedOffenders
+      .filter(offender => !offender.currentOm) // TODO: This should be (offender => offender.currentOm) but until we have a delius user to use, we need to negate this clause for now
+      .map(offender => {
+        return {
+          name: offender.offenderSurname,
+          crnNumber: offender.crnNumber,
+          conditionalReleaseDate: '03 August 2022', // TODO: Get conditionalReleaseDate from nomis??
+        }
+      })
     res.render('pages/create/caseload', { caseload })
   }
 

--- a/server/routes/creatingLicences/handlers/caseload.ts
+++ b/server/routes/creatingLicences/handlers/caseload.ts
@@ -6,10 +6,10 @@ export default class CaseloadRoutes {
   constructor(private readonly licenceService: LicenceService, private readonly communityService: CommunityService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
-    const staffId = 2500012436 // TODO: This needs to be looked up in delius using res.locals.user.username
-    const managedOffenders = await this.communityService.getManagedOffenders(staffId)
+    const { staffIdentifier } = await this.communityService.getStaffDetail(res.locals.user.username)
+    const managedOffenders = await this.communityService.getManagedOffenders(staffIdentifier)
     const caseload = managedOffenders
-      .filter(offender => !offender.currentOm) // TODO: This should be (offender => offender.currentOm) but until we have a delius user to use, we need to negate this clause for now
+      .filter(offender => offender.currentOm)
       .map(offender => {
         return {
           name: offender.offenderSurname,

--- a/server/routes/creatingLicences/handlers/caseload.ts
+++ b/server/routes/creatingLicences/handlers/caseload.ts
@@ -1,22 +1,26 @@
 import { Request, Response } from 'express'
 import LicenceService from '../../../services/licenceService'
+import CommunityService from '../../../services/communityService'
 
 export default class CaseloadRoutes {
-  constructor(private readonly licenceService: LicenceService) {}
+  constructor(private readonly licenceService: LicenceService, private readonly communityService: CommunityService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
-    const caseload = [
-      {
-        name: 'Adam Balasaravika',
-        crnNumber: 'X381306',
-        conditionalReleaseDate: '03 August 2022',
-      },
-    ]
+    const staffId = 2500012436 // TODO: This needs to be looked up in delius using res.locals.user.username
+    const managedOffenders = await this.communityService.getManagedOffenders(staffId)
+    const caseload = managedOffenders.map(offender => {
+      return {
+        name: offender.offenderSurname,
+        crnNumber: offender.crnNumber,
+        conditionalReleaseDate: '03 August 2022', // TODO: Get conditionalReleaseDate from nomis??
+      }
+    })
     res.render('pages/create/caseload', { caseload })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
     const { username } = res.locals.user
+    // TODO: Populate licence with real data from nomis/delius
     const { licenceId } = await this.licenceService.createLicence(username)
     res.redirect(`/licence/create/id/${licenceId}/initial-meeting-name`)
   }

--- a/server/routes/creatingLicences/index.ts
+++ b/server/routes/creatingLicences/index.ts
@@ -22,7 +22,7 @@ import SimpleDateTime from './types/simpleDateTime'
 import YesOrNoQuestion from './types/yesOrNo'
 import AdditionalConditions from './types/additionalConditions'
 
-export default function Index({ licenceService }: Services): Router {
+export default function Index({ licenceService, communityService }: Services): Router {
   const router = Router()
 
   const routePrefix = (path: string) => `/licence/create${path}`
@@ -38,7 +38,7 @@ export default function Index({ licenceService }: Services): Router {
   const post = (path: string, handler: RequestHandler, type?: new () => unknown) =>
     router.post(routePrefix(path), validationMiddleware(type), asyncMiddleware(handler))
 
-  const caseloadHandler = new CaseloadRoutes(licenceService)
+  const caseloadHandler = new CaseloadRoutes(licenceService, communityService)
   const initialMeetingNameHandler = new InitialMeetingNameRoutes(licenceService)
   const initialMeetingPlaceHandler = new InitialMeetingPlaceRoutes(licenceService)
   const initialMeetingContactHandler = new InitialMeetingContactRoutes(licenceService)

--- a/server/routes/spikes/handlers/spikes.ts
+++ b/server/routes/spikes/handlers/spikes.ts
@@ -21,9 +21,8 @@ export default class SpikeRoutes {
   }
 
   public getStaffDetail: RequestHandler = async (req, res): Promise<void> => {
-    const { username } = res.locals.user
     const deliusUsername = req.params.username
-    const staffDetail = await this.communityService.getStaffDetail(username, deliusUsername)
+    const staffDetail = await this.communityService.getStaffDetail(deliusUsername)
     res.render('pages/staffDetail', { staffDetail })
   }
 
@@ -35,10 +34,9 @@ export default class SpikeRoutes {
   }
 
   public getStaffCaseload: RequestHandler = async (req, res): Promise<void> => {
-    const { username } = res.locals.user
     const { staffId } = req.params
     const staffIdentifier = staffId as unknown as number
-    const managedOffenders = await this.communityService.getManagedOffenders(username, staffIdentifier)
+    const managedOffenders = await this.communityService.getManagedOffenders(staffIdentifier)
     res.render('pages/managedOffenders', { managedOffenders })
   }
 
@@ -91,14 +89,13 @@ export default class SpikeRoutes {
 
   public searchProbation: RequestHandler = async (req, res): Promise<void> => {
     const { prisonerIdentifier, firstName, lastName, crn } = req.query as Record<string, string>
-    const { username } = res.locals.user
     const searchValues = { prisonerIdentifier, firstName, lastName, crn }
 
     if (!(prisonerIdentifier || firstName || lastName || crn)) {
       return res.render('pages/probationers')
     }
 
-    const probationers = await this.communityService.searchProbationers(username, {
+    const probationers = await this.communityService.searchProbationers({
       firstName,
       surname: lastName,
       nomsNumber: prisonerIdentifier || null,

--- a/server/services/communityService.ts
+++ b/server/services/communityService.ts
@@ -7,21 +7,21 @@ import { CommunityApiStaffDetails, CommunityApiManagedOffender } from '../data/c
 export default class CommunityService {
   constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
 
-  async getStaffDetail(username: string, deliusUsername: string): Promise<CommunityApiStaffDetails> {
+  async getStaffDetail(deliusUsername: string): Promise<CommunityApiStaffDetails> {
     // Important: No username is passed into the getSystemClientToken for the community API
     const token = await this.hmppsAuthClient.getSystemClientToken()
     return new CommunityApiClient(token).getStaffDetailByUsername(deliusUsername)
   }
 
-  async getManagedOffenders(username: string, staffIdentifier: number): Promise<CommunityApiManagedOffender[]> {
+  async getManagedOffenders(staffIdentifier: number): Promise<CommunityApiManagedOffender[]> {
     // Important: No username is passed into the getSystemClientToken for the community API
     const token = await this.hmppsAuthClient.getSystemClientToken()
     return new CommunityApiClient(token).getStaffCaseload(staffIdentifier)
   }
 
-  async searchProbationers(username: string, searchCriteria: SearchDto): Promise<OffenderDetail[]> {
-    // Important: Check whether the username is required for probation-offender-search-api??
-    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+  async searchProbationers(searchCriteria: SearchDto): Promise<OffenderDetail[]> {
+    // Important: No username is passed into the getSystemClientToken for the community search API
+    const token = await this.hmppsAuthClient.getSystemClientToken()
     return new ProbationSearchApiClient(token).searchProbationer(searchCriteria)
   }
 }


### PR DESCRIPTION
* Added wiremock for community api
*  Query delius for a staff member's caseload to populate the caseload list. 

_**From now on, we need to log in a user in Auth, who also is a user in DELIUS, who also has a caseload, otherwise, the caseload screen will just have 1 stubbed case**_