### PR TITLE
CVSL-111:  Add / update for multiple bespoke conditions

### DIFF
--- a/integration_tests/integration/createLicence.spec.ts
+++ b/integration_tests/integration/createLicence.spec.ts
@@ -12,6 +12,7 @@ context('Create a licence', () => {
     cy.task('stubPutAppointmentPerson', 1)
     cy.task('stubPutAppointmentTime', 1)
     cy.task('stubPutAppointmentAddress', 1)
+    cy.task('stubPutBespokeConditions', 1)
     cy.task('stubPutContactNumber', 1)
     cy.task('stubGetStaffDetails', 'USER1')
     cy.task('stubGetManagedOffenders', 2000)
@@ -39,13 +40,19 @@ context('Create a licence', () => {
       .enterTime(moment())
       .clickContinue()
 
-    const additionalConditionsPage = additionalConditionsQuestionPage.selectYes()
+    const additionalConditionsPage = additionalConditionsQuestionPage.selectYes().clickContinue()
 
     const bespokeConditionsQuestionPage = additionalConditionsPage.clickContinue()
 
-    const bespokeConditionsPage = bespokeConditionsQuestionPage.selectYes()
+    const bespokeConditionsPage = bespokeConditionsQuestionPage.selectYes().clickContinue()
 
-    const checkAnswersPage = bespokeConditionsPage.clickContinue()
+    const checkAnswersPage = bespokeConditionsPage
+      .enterBespokeCondition(0, 'An unusual bespoke condition to be approved.')
+      .clickAddAnother()
+      .enterBespokeCondition(1, 'Another unusual and unlikely bespoke condition')
+      .clickAddAnother()
+      .enterBespokeCondition(2, 'A third bespoke condition must surely be be a mistake')
+      .clickContinue()
 
     const confirmationPage = checkAnswersPage.clickSendLicenceConditionsToPrison()
 

--- a/integration_tests/mockApis/licence.ts
+++ b/integration_tests/mockApis/licence.ts
@@ -128,4 +128,18 @@ export default {
       },
     })
   },
+
+  stubPutBespokeConditions: (licenceId: string): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'PUT',
+        urlPattern: `/licence/id/${licenceId}/bespoke-conditions`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {},
+      },
+    })
+  },
 }

--- a/integration_tests/pages/additionalConditionsQuestion.ts
+++ b/integration_tests/pages/additionalConditionsQuestion.ts
@@ -10,8 +10,12 @@ export default class AdditionalConditionsQuestionPage extends Page {
     super('additional-conditions-question-page', false)
   }
 
-  selectYes = (): AdditionalConditionsPage => {
+  selectYes = (): AdditionalConditionsQuestionPage => {
     cy.get(this.yesRadioButtonId).click()
+    return this
+  }
+
+  clickContinue = (): AdditionalConditionsPage => {
     cy.get(this.continueButtonId).click()
     return Page.verifyOnPage(AdditionalConditionsPage)
   }

--- a/integration_tests/pages/bespokeConditions.ts
+++ b/integration_tests/pages/bespokeConditions.ts
@@ -4,8 +4,21 @@ import CheckAnswersPage from './checkAnswers'
 export default class BespokeConditionsPage extends Page {
   private continueButtonId = '[data-qa=continue]'
 
+  private addAnotherId = '[data-qa=add-another]'
+
   constructor() {
     super('bespoke-conditions-page')
+  }
+
+  enterBespokeCondition = (conditionId: number, condition: string): BespokeConditionsPage => {
+    const fieldName = `conditions[${conditionId}]`
+    cy.get(`textarea[name="${fieldName}"]`).type(condition)
+    return this
+  }
+
+  clickAddAnother = (): BespokeConditionsPage => {
+    cy.get(this.addAnotherId).click()
+    return this
   }
 
   clickContinue = (): CheckAnswersPage => {

--- a/integration_tests/pages/bespokeConditionsQuestion.ts
+++ b/integration_tests/pages/bespokeConditionsQuestion.ts
@@ -10,8 +10,12 @@ export default class BespokeConditionsQuestionPage extends Page {
     super('bespoke-conditions-question-page')
   }
 
-  selectYes = (): BespokeConditionsPage => {
+  selectYes = (): BespokeConditionsQuestionPage => {
     cy.get(this.yesRadioButtonId).click()
+    return this
+  }
+
+  clickContinue = (): BespokeConditionsPage => {
     cy.get(this.continueButtonId).click()
     return Page.verifyOnPage(BespokeConditionsPage)
   }

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -22,6 +22,7 @@ export default (on: (string, Record) => void): void => {
     stubPutAppointmentTime: licence.stubPutAppointmentTime,
     stubPutAppointmentAddress: licence.stubPutAppointmentAddress,
     stubPutContactNumber: licence.stubPutContactNumber,
+    stubPutBespokeConditions: licence.stubPutBespokeConditions,
 
     stubGetStaffDetails: community.stubGetStaffDetails,
     stubGetManagedOffenders: community.stubGetManagedOffenders,

--- a/server/@types/licenceApiImport/index.d.ts
+++ b/server/@types/licenceApiImport/index.d.ts
@@ -8,6 +8,10 @@ export interface paths {
     /** Update the contact number for the officer related to this licence. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN. */
     put: operations['updateContactNumber']
   }
+  '/licence/id/{licenceId}/bespoke-conditions': {
+    /** Add or replace the bespoke conditions on a licence with the content of this request. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN. */
+    put: operations['updateBespokeConditions']
+  }
   '/licence/id/{licenceId}/appointmentTime': {
     /** Update the date and time for the initial appointment. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN. */
     put: operations['updateAppointmentTime']
@@ -48,6 +52,11 @@ export interface components {
       developerMessage?: string
       moreInfo?: string
     }
+    /** A list of bespoke conditions to add to a licence */
+    BespokeConditionRequest: {
+      /** A list of bespoke conditions to add to a licence */
+      conditions: string[]
+    }
     /** Request object for updating the date and time of the initial appointment */
     AppointmentTimeRequest: {
       /** The date and time of the initial appointment */
@@ -61,7 +70,7 @@ export interface components {
     /** Request object for updating the address of the initial appointment */
     AppointmentAddressRequest: {
       /** The address of initial appointment */
-      appointmentAddress?: string
+      appointmentAddress: string
     }
     /** Request object for creating a new licence */
     CreateLicenceRequest: {
@@ -322,6 +331,47 @@ export interface operations {
     requestBody: {
       content: {
         'application/json': components['schemas']['ContactNumberRequest']
+      }
+    }
+  }
+  /** Add or replace the bespoke conditions on a licence with the content of this request. Requires ROLE_SYSTEM_USER or ROLE_CVL_ADMIN. */
+  updateBespokeConditions: {
+    parameters: {
+      path: {
+        licenceId: number
+      }
+    }
+    responses: {
+      /** Bespoke conditions added or replaced */
+      200: unknown
+      /** Bad request, request body must be valid */
+      400: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** Unauthorised, requires a valid Oauth2 token */
+      401: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** Forbidden, requires an appropriate role */
+      403: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+      /** The licence for this ID was not found. */
+      404: {
+        content: {
+          'application/json': components['schemas']['ErrorResponse']
+        }
+      }
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['BespokeConditionRequest']
       }
     }
   }

--- a/server/data/licenceApiClient.test.ts
+++ b/server/data/licenceApiClient.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 import config from '../config'
 import LicenceService from '../services/licenceService'
 import HmppsAuthClient from './hmppsAuthClient'
+import BespokeCondition from '../routes/creatingLicences/types/bespokeConditions'
 import SimpleDate from '../routes/creatingLicences/types/date'
 import SimpleTime, { AmPm } from '../routes/creatingLicences/types/time'
 import SimpleDateTime from '../routes/creatingLicences/types/simpleDateTime'
@@ -9,6 +10,7 @@ import {
   AppointmentAddressRequest,
   AppointmentPersonRequest,
   AppointmentTimeRequest,
+  BespokeConditionsRequest,
   ContactNumberRequest,
   LicenceApiTestData,
 } from './licenceApiClientTypes'
@@ -126,5 +128,47 @@ describe('Licence API client tests', () => {
         expect(hmppsAuthClient.getSystemClientToken).toBeCalled()
       })
     })
+
+    describe('Bespoke conditions', () => {
+      it('No bespoke conditions entered', async () => {
+        const formConditions = makeFormBespokeConditions([])
+        const apiRequestConditions = makeApiRequestBespokeConditions([])
+        hmppsAuthClient.getSystemClientToken.mockResolvedValue('a token')
+        fakeApi.put('/licence/id/1/bespoke-conditions', apiRequestConditions).reply(200)
+        await licenceService.updateBespokeConditions('1', formConditions, username)
+        expect(nock.isDone()).toBe(true)
+        expect(hmppsAuthClient.getSystemClientToken).toBeCalled()
+      })
+
+      it('Three bespoke conditions entered', async () => {
+        const formConditions = makeFormBespokeConditions(['C1', 'C2', 'C3'])
+        const apiRequestConditions = makeApiRequestBespokeConditions(formConditions.conditions)
+        hmppsAuthClient.getSystemClientToken.mockResolvedValue('a token')
+        fakeApi.put('/licence/id/1/bespoke-conditions', apiRequestConditions).reply(200)
+        await licenceService.updateBespokeConditions('1', formConditions, username)
+        expect(nock.isDone()).toBe(true)
+        expect(hmppsAuthClient.getSystemClientToken).toBeCalled()
+      })
+
+      it('Remove empty bespoke conditions', async () => {
+        const formConditions = makeFormBespokeConditions(['C1', '', '', 'C4'])
+        const apiRequestConditions = makeApiRequestBespokeConditions(['C1', 'C4'])
+        hmppsAuthClient.getSystemClientToken.mockResolvedValue('a token')
+        fakeApi.put('/licence/id/1/bespoke-conditions', apiRequestConditions).reply(200)
+        await licenceService.updateBespokeConditions('1', formConditions, username)
+        expect(nock.isDone()).toBe(true)
+        expect(hmppsAuthClient.getSystemClientToken).toBeCalled()
+      })
+    })
   })
 })
+
+const makeFormBespokeConditions = (conditions: string[]): BespokeCondition => {
+  const formConditions = new BespokeCondition()
+  formConditions.conditions = conditions
+  return formConditions
+}
+
+const makeApiRequestBespokeConditions = (conditions: string[]): BespokeConditionsRequest => {
+  return { conditions } as BespokeConditionsRequest
+}

--- a/server/data/licenceApiClient.ts
+++ b/server/data/licenceApiClient.ts
@@ -8,6 +8,7 @@ import type {
   AppointmentPersonRequest,
   AppointmentTimeRequest,
   AppointmentAddressRequest,
+  BespokeConditionsRequest,
 } from './licenceApiClientTypes'
 import config, { ApiConfig } from '../config'
 
@@ -47,5 +48,9 @@ export default class LicenceApiClient {
 
   async updateContactNumber(licenceId: string, contactNumber: ContactNumberRequest): Promise<void> {
     await this.restClient.put({ path: `/licence/id/${licenceId}/contact-number`, data: contactNumber })
+  }
+
+  async updateBespokeConditions(licenceId: string, bespokeConditions: BespokeConditionsRequest): Promise<void> {
+    await this.restClient.put({ path: `/licence/id/${licenceId}/bespoke-conditions`, data: bespokeConditions })
   }
 }

--- a/server/data/licenceApiClientTypes.ts
+++ b/server/data/licenceApiClientTypes.ts
@@ -1,10 +1,11 @@
 import { components } from '../@types/licenceApiImport'
 
-export type LicenceApiTestData = components['schemas']['TestData']
-export type CreateLicenceResponse = components['schemas']['CreateLicenceResponse']
-export type CreateLicenceRequest = components['schemas']['CreateLicenceRequest']
-export type Licence = components['schemas']['Licence']
+export type AppointmentAddressRequest = components['schemas']['AppointmentAddressRequest']
 export type AppointmentPersonRequest = components['schemas']['AppointmentPersonRequest']
 export type AppointmentTimeRequest = components['schemas']['AppointmentTimeRequest']
-export type AppointmentAddressRequest = components['schemas']['AppointmentAddressRequest']
+export type BespokeConditionsRequest = components['schemas']['BespokeConditionRequest']
 export type ContactNumberRequest = components['schemas']['ContactNumberRequest']
+export type CreateLicenceRequest = components['schemas']['CreateLicenceRequest']
+export type CreateLicenceResponse = components['schemas']['CreateLicenceResponse']
+export type Licence = components['schemas']['Licence']
+export type LicenceApiTestData = components['schemas']['TestData']

--- a/server/routes/creatingLicences/handlers/bespokeConditions.test.ts
+++ b/server/routes/creatingLicences/handlers/bespokeConditions.test.ts
@@ -1,32 +1,54 @@
 import { Request, Response } from 'express'
 
+import BespokeConditions from '../types/bespokeConditions'
 import BespokeConditionsRoutes from './bespokeConditions'
+import LicenceService from '../../../services/licenceService'
+
+const licenceService = new LicenceService(null) as jest.Mocked<LicenceService>
 
 describe('Route Handlers - Create Licence - Bespoke Conditions', () => {
-  const handler = new BespokeConditionsRoutes()
+  const handler = new BespokeConditionsRoutes(licenceService)
   let req: Request
   let res: Response
+  let formBespokeConditions: BespokeConditions
 
   beforeEach(() => {
+    formBespokeConditions = {
+      conditions: ['Condition 1', 'Condition 2'],
+    } as unknown as BespokeConditions
+
     req = {
       params: {
         licenceId: 1,
       },
+      body: formBespokeConditions,
     } as unknown as Request
 
     res = {
       render: jest.fn(),
       redirect: jest.fn(),
+      locals: {
+        user: {
+          username: 'joebloggs',
+        },
+        licence: {
+          id: 1,
+          bespokeConditions: [
+            { id: 1, seq: 0, text: 'Condition 1' },
+            { id: 2, seq: 1, text: 'Condition 2' },
+          ],
+        },
+      },
     } as unknown as Response
+
+    licenceService.updateBespokeConditions = jest.fn()
   })
 
   describe('GET', () => {
-    it('should render view', async () => {
+    it('should render licence with bespoke conditions view', async () => {
       await handler.GET(req, res)
       expect(res.render).toHaveBeenCalledWith('pages/create/bespokeConditions', {
-        offender: {
-          name: 'Adam Balasaravika',
-        },
+        conditions: formBespokeConditions.conditions,
       })
     })
   })
@@ -34,6 +56,11 @@ describe('Route Handlers - Create Licence - Bespoke Conditions', () => {
   describe('POST', () => {
     it('should redirect to the check answers page', async () => {
       await handler.POST(req, res)
+      expect(licenceService.updateBespokeConditions).toHaveBeenCalledWith(
+        1,
+        formBespokeConditions,
+        res.locals.user.username
+      )
       expect(res.redirect).toHaveBeenCalledWith('/licence/create/id/1/check-your-answers')
     })
   })

--- a/server/routes/creatingLicences/handlers/bespokeConditions.ts
+++ b/server/routes/creatingLicences/handlers/bespokeConditions.ts
@@ -1,16 +1,20 @@
 import { Request, Response } from 'express'
+import LicenceService from '../../../services/licenceService'
 
 export default class BespokeConditionsRoutes {
+  constructor(private readonly licenceService: LicenceService) {}
+
   GET = async (req: Request, res: Response): Promise<void> => {
-    const offender = {
-      name: 'Adam Balasaravika',
-    }
-    res.render('pages/create/bespokeConditions', { offender })
+    const conditionsList = res.locals?.licence?.bespokeConditions || []
+    const conditions = conditionsList?.length > 0 ? conditionsList.map((c: { text: string }) => c.text) : []
+    res.render('pages/create/bespokeConditions', { conditions })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
-    // TODO: Some work to do here to redirect to the same page if "Add another" or "Remove" is selected and javascript is turned off browserside
+    // TODO: Some work to do here to redirect to the same page if "Add another" or "Remove" is selected and javascript is off
     const { licenceId } = req.params
+    const { username } = res.locals.user
+    await this.licenceService.updateBespokeConditions(licenceId, req.body, username)
     res.redirect(`/licence/create/id/${licenceId}/check-your-answers`)
   }
 }

--- a/server/routes/creatingLicences/index.ts
+++ b/server/routes/creatingLicences/index.ts
@@ -12,6 +12,7 @@ import AdditionalConditionsQuestionRoutes from './handlers/additionalConditionsQ
 import AdditionalConditionsRoutes from './handlers/additionalConditions'
 import BespokeConditionsQuestionRoutes from './handlers/bespokeConditionsQuestion'
 import BespokeConditionsRoutes from './handlers/bespokeConditions'
+import BespokeConditions from './types/bespokeConditions'
 import CheckAnswersRoutes from './handlers/checkAnswers'
 import ConfirmationRoutes from './handlers/confirmation'
 import { Services } from '../../services'
@@ -46,7 +47,7 @@ export default function Index({ licenceService, communityService }: Services): R
   const additionalConditionsQuestionHandler = new AdditionalConditionsQuestionRoutes()
   const additionalConditionsHandler = new AdditionalConditionsRoutes()
   const bespokeConditionsQuestionHandler = new BespokeConditionsQuestionRoutes()
-  const bespokeConditionsHandler = new BespokeConditionsRoutes()
+  const bespokeConditionsHandler = new BespokeConditionsRoutes(licenceService)
   const checkAnswersHandler = new CheckAnswersRoutes(licenceService)
   const confirmationHandler = new ConfirmationRoutes()
 
@@ -67,7 +68,7 @@ export default function Index({ licenceService, communityService }: Services): R
   get('/id/:licenceId/bespoke-conditions-question', bespokeConditionsQuestionHandler.GET)
   post('/id/:licenceId/bespoke-conditions-question', bespokeConditionsQuestionHandler.POST, YesOrNoQuestion)
   get('/id/:licenceId/bespoke-conditions', bespokeConditionsHandler.GET)
-  post('/id/:licenceId/bespoke-conditions', bespokeConditionsHandler.POST)
+  post('/id/:licenceId/bespoke-conditions', bespokeConditionsHandler.POST, BespokeConditions)
   get('/id/:licenceId/check-your-answers', checkAnswersHandler.GET)
   post('/id/:licenceId/check-your-answers', checkAnswersHandler.POST)
   get('/id/:licenceId/confirmation', confirmationHandler.GET)

--- a/server/routes/creatingLicences/types/bespokeConditions.ts
+++ b/server/routes/creatingLicences/types/bespokeConditions.ts
@@ -1,0 +1,8 @@
+import { Expose } from 'class-transformer'
+
+class BespokeConditions {
+  @Expose()
+  conditions: string[]
+}
+
+export default BespokeConditions

--- a/server/routes/creatingLicences/types/yesOrNo.ts
+++ b/server/routes/creatingLicences/types/yesOrNo.ts
@@ -2,7 +2,7 @@ import { Expose } from 'class-transformer'
 import { IsIn, IsNotEmpty } from 'class-validator'
 import YesOrNo from '../../../enumeration/yesOrNo'
 
-const message = 'Select either Yes or No'
+const message = 'Select yes or no'
 
 class YesOrNoQuestion {
   @Expose()

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -3,6 +3,7 @@ import {
   AppointmentAddressRequest,
   AppointmentPersonRequest,
   AppointmentTimeRequest,
+  BespokeConditionsRequest,
   ContactNumberRequest,
   CreateLicenceRequest,
   CreateLicenceResponse,
@@ -17,6 +18,7 @@ import PersonName from '../routes/creatingLicences/types/personName'
 import SimpleDateTime from '../routes/creatingLicences/types/simpleDateTime'
 import Telephone from '../routes/creatingLicences/types/telephone'
 import Address from '../routes/creatingLicences/types/address'
+import BespokeConditions from '../routes/creatingLicences/types/bespokeConditions'
 
 export default class LicenceService {
   constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
@@ -96,6 +98,13 @@ export default class LicenceService {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
     const requestBody = { comTelephone: formData.telephone } as ContactNumberRequest
     return new LicenceApiClient(token).updateContactNumber(id, requestBody)
+  }
+
+  async updateBespokeConditions(id: string, formData: BespokeConditions, username: string): Promise<void> {
+    const token = await this.hmppsAuthClient.getSystemClientToken(username)
+    const sanitised = formData.conditions.filter((c: string) => c !== null && c.length > 0)
+    const requestBody = { conditions: sanitised } as BespokeConditionsRequest
+    return new LicenceApiClient(token).updateBespokeConditions(id, requestBody)
   }
 
   getLicenceStub(): Record<string, unknown> {

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -13,7 +13,6 @@ import {
 import LicenceApiClient from '../data/licenceApiClient'
 import { getStandardConditions } from '../utils/conditionsProvider'
 import { simpleDateTimeToJson, addressObjectToString } from '../utils/utils'
-import logger from '../../logger'
 import PersonName from '../routes/creatingLicences/types/personName'
 import SimpleDateTime from '../routes/creatingLicences/types/simpleDateTime'
 import Telephone from '../routes/creatingLicences/types/telephone'
@@ -172,7 +171,6 @@ export default class LicenceService {
    *   - licenceService - pull back licences matching these people, assembled into a licence[]
    */
   getCaseload(username: string, staffId: number): Record<string, unknown> {
-    logger.debug(`getCaseload for ${username}  staffId: ${staffId}`)
     const content = [
       {
         nomsId: 'A1234AC',

--- a/server/views/pages/create/bespokeConditions.njk
+++ b/server/views/pages/create/bespokeConditions.njk
@@ -11,7 +11,7 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">Create a bespoke condition for {{ offender.name }}</h1>
+            <h1 class="govuk-heading-l">Create bespoke conditions for {{ licence.forename }} {{ licence.surname }}</h1>
         </div>
     </div>
     <form method="POST">
@@ -19,22 +19,39 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-two-thirds">
                 <div data-module="moj-add-another">
-                    {% call govukFieldset({
-                        classes: 'moj-add-another__item'
-                    }) %}
-
-                        {{ govukTextarea({
-                            id: 'condition[0]',
-                            name: 'condition[0]',
-                            label: {
-                                html: 'Bespoke condition',
-                                classes: 'govuk-visually-hidden'
-                            },
-                            attributes: {
-                                'data-name': 'condition[%index%]',
-                                'data-id': 'condition[%index%]'
-                            }
-                        }) }}
+                    {% call govukFieldset({ classes: 'moj-add-another__item' }) %}
+                        {# Show the existing bespoke conditions #}
+                        {% if conditions and conditions.length > 0 %}
+                            {%  for c in conditions %}
+                                {{ govukTextarea({
+                                    id: 'conditions[' + loop.index + ']',
+                                    name: 'conditions[' + loop.index + ']',
+                                    label: {
+                                        html: 'Bespoke condition',
+                                        classes: 'govuk-visually-hidden'
+                                    },
+                                    attributes: {
+                                        'data-name': 'conditions[%index%]',
+                                        'data-id': 'condition[%index%]'
+                                    },
+                                    value: c
+                                }) }}
+                            {% endfor  %}
+                        {%  else %}
+                            {# Show an empty text area to accept a new condition #}
+                            {{ govukTextarea({
+                                id: 'conditions[0]',
+                                name: 'conditions[0]',
+                                label: {
+                                    html: 'Bespoke condition',
+                                    classes: 'govuk-visually-hidden'
+                                },
+                                attributes: {
+                                    'data-name': 'conditions[%index%]',
+                                    'data-id': 'condition[%index%]'
+                                }
+                            }) }}
+                        {% endif %}
 
                     {% endcall %}
 

--- a/server/views/pages/create/bespokeConditions.njk
+++ b/server/views/pages/create/bespokeConditions.njk
@@ -24,7 +24,7 @@
                         {% if conditions and conditions.length > 0 %}
                             {%  for c in conditions %}
                                 {{ govukTextarea({
-                                    id: 'conditions[' + loop.index + ']',
+                                    id: 'conditions['+ loop.index + ']',
                                     name: 'conditions[' + loop.index + ']',
                                     label: {
                                         html: 'Bespoke condition',
@@ -32,7 +32,7 @@
                                     },
                                     attributes: {
                                         'data-name': 'conditions[%index%]',
-                                        'data-id': 'condition[%index%]'
+                                        'data-id': 'conditions[%index%]'
                                     },
                                     value: c
                                 }) }}
@@ -48,7 +48,7 @@
                                 },
                                 attributes: {
                                     'data-name': 'conditions[%index%]',
-                                    'data-id': 'condition[%index%]'
+                                    'data-id': 'conditions[%index%]'
                                 }
                             }) }}
                         {% endif %}
@@ -58,7 +58,8 @@
                     <div class="moj-button-action">
                         {{ govukButton({
                             text: 'Add another bespoke condition',
-                            classes: 'govuk-button--secondary moj-add-another__add-button govuk-!-margin-bottom-4'
+                            classes: 'govuk-button--secondary moj-add-another__add-button govuk-!-margin-bottom-4',
+                            attributes: { 'data-qa': 'add-another' }
                         }) }}
                     </div>
                 </div>

--- a/server/views/pages/create/bespokeConditionsQuestion.njk
+++ b/server/views/pages/create/bespokeConditionsQuestion.njk
@@ -13,6 +13,7 @@
         </div>
     </div>
     <form method="POST">
+        {% set checked = true if licence.bespokeConditions.length > 0 else false %}
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
@@ -30,10 +31,14 @@
                         }
                     },
                     errorMessage: validationErrors | findError('answer'),
+                    hint: {
+                        text: "You must have Public Protection Casework Section (PPCS) approval to add a bespoke condition."
+                    },
                     items: [
                         {
                             value: "yes",
-                            text: "Yes"
+                            text: "Yes",
+                            checked: checked
                         },
                         {
                             value: "no",


### PR DESCRIPTION
Includes:
* Prepopulating multiple bespoke conditions where they exist for a licence
* Storing bespoke conditions into the DB via the API
* Using the `fetchLicence` middleware for this route
* Allowing the addition of one or more bespoke conditions
* Filtering any blank / empty conditions
* Unit tests
* Integration test - incorporate into the main flow for creating a licence