### PR TITLE
CVSL-98: Deployment of a container to stub the Community API caseload.

### DIFF
--- a/helm_deploy/create-and-vary-a-licence/Chart.yaml
+++ b/helm_deploy/create-and-vary-a-licence/Chart.yaml
@@ -11,6 +11,10 @@ dependencies:
     alias: gotenberg
     version: 1.0.10
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
+  - name: generic-service
+    alias: delius-wiremock
+    version: 1.0.10
+    repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 0.1.4
     repository: https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/create-and-vary-a-licence/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence/values.yaml
@@ -88,5 +88,45 @@ gotenberg:
     runAsUser: 1001
     runAsNonRoot: true
 
+delius-wiremock:
+  nameOverride: delius-wiremock
+  replicaCount: 2
+
+  image:
+    repository: smcveigh941/delius-wiremock
+    tag: latest
+    port: 5000
+
+  namespace_secrets:
+    create-and-vary-a-licence:
+      SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
+      SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
+
+  ingress:
+    enabled: false
+
+  livenessProbe:
+    httpGet:
+      path: /ping
+    periodSeconds: 30
+    initialDelaySeconds: 60
+    timeoutSeconds: 20
+    failureThreshold: 10
+
+  readinessProbe:
+    httpGet:
+      path: /ping
+    periodSeconds: 20
+    initialDelaySeconds: 60
+    timeoutSeconds: 30
+    failureThreshold: 15
+
+  podSecurityContext:
+    fsGroup: 1001
+
+  securityContext:
+    runAsUser: 1001
+    runAsNonRoot: true
+
 generic-prometheus-alerts:
   targetApplication: create-and-vary-a-licence

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -11,7 +11,7 @@ generic-service:
     INGRESS_URL: "https://create-and-vary-a-licence-dev.hmpps.service.justice.gov.uk"
     HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
     TOKEN_VERIFICATION_API_URL: "https://token-verification-api-dev.prison.service.justice.gov.uk"
-    COMMUNITY_API_URL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
+    # COMMUNITY_API_URL: "https://community-api-secure.test.delius.probation.hmpps.dsd.io"
     PRISON_API_URL: "https://api-dev.prison.service.justice.gov.uk"
     LICENCE_API_URL: "https://create-and-vary-a-licence-api-dev.hmpps.service.justice.gov.uk"
     PRISONER_SEARCH_API_URL: "https://prisoner-offender-search-dev.prison.service.justice.gov.uk"
@@ -22,6 +22,9 @@ generic-service:
 
     # A reference to the Gotenberg service - to submit HTML to PDF conversions (internal within namespace)
     GOTENBERG_API_URL: "http://create-and-vary-a-licence-gotenberg"
+
+    # A temporary reference to a local container which provides a stubbed Delius caseload
+    COMMUNITY_API_URL: "http://create-and-vary-a-licence-delius-wiremock:5000"
 
     # A reference to the CVL service - for links in HTML to get images/stylesheets (internal within namespace)
     LICENCES_URL: "http://create-and-vary-a-licence"
@@ -36,6 +39,13 @@ gotenberg:
     GOOGLE_CHROME_IGNORE_CERTIFICATE_ERRORS: 1
     DISABLE_UNOCONV: 1
     DEFAULT_WAIT_TIMEOUT: 30
+
+delius-wiremock:
+  replicaCount: 1
+
+  env:
+    HMPPS_AUTH_URL: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+    PRISONER_SEARCH_API_URL: "https://prisoner-offender-search-dev.prison.service.justice.gov.uk"
 
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
Part of a fiendish plan to avoid the data mismatch between Delius and Nomis.
This deploys a service in a container in the namespace which pretends to be the Community API for /staff and /managedOffenders, and returns a list of people who are known in Nomis via the prisoner offender search API. 
We know the Community API works well, but we cant setup the appropriate data there without breaking the Delius TEST environment for the Delius work, so this is the next best thing.