### PR TITLE
CVSL-98: Update config to port 80 for delius-wiremock service.

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,7 +24,7 @@ generic-service:
     GOTENBERG_API_URL: "http://create-and-vary-a-licence-gotenberg"
 
     # A temporary reference to a local container which provides a stubbed Delius caseload
-    COMMUNITY_API_URL: "http://create-and-vary-a-licence-delius-wiremock:5000"
+    COMMUNITY_API_URL: "http://create-and-vary-a-licence-delius-wiremock"
 
     # A reference to the CVL service - for links in HTML to get images/stylesheets (internal within namespace)
     LICENCES_URL: "http://create-and-vary-a-licence"


### PR DESCRIPTION
Change to port 80 for `delius-wiremock` service.