### PR TITLE
CVSL-171: Add back links to the create a licence journey

### DIFF
--- a/assets/js/govukFrontendInit.js
+++ b/assets/js/govukFrontendInit.js
@@ -1,1 +1,7 @@
 window.GOVUKFrontend.initAll()
+
+// Initiate the back links
+$('[class$=govuk-back-link]').click(e => {
+  e.preventDefault()
+  window.history.go(-1)
+})

--- a/server/routes/creatingLicences/handlers/additionalConditionsQuestion.ts
+++ b/server/routes/creatingLicences/handlers/additionalConditionsQuestion.ts
@@ -12,6 +12,7 @@ export default class AdditionalConditionsQuestionRoutes {
     if (answer === YesOrNo.YES) {
       res.redirect(`/licence/create/id/${licenceId}/additional-conditions`)
     } else {
+      // TODO Remove any additional conditions which may exist on the licence - i.e. if they arrive here from check answers page
       res.redirect(`/licence/create/id/${licenceId}/bespoke-conditions-question`)
     }
   }

--- a/server/routes/creatingLicences/handlers/bespokeConditionsQuestion.test.ts
+++ b/server/routes/creatingLicences/handlers/bespokeConditionsQuestion.test.ts
@@ -1,16 +1,25 @@
 import { Request, Response } from 'express'
 
 import BespokeConditionsQuestionRoutes from './bespokeConditionsQuestion'
+import LicenceService from '../../../services/licenceService'
+import BespokeConditions from '../types/bespokeConditions'
+
+const licenceService = new LicenceService(null, null, null) as jest.Mocked<LicenceService>
+
+jest.mock('../../../services/licenceService')
 
 describe('Route Handlers - Create Licence - Bespoke Conditions Question', () => {
-  const handler = new BespokeConditionsQuestionRoutes()
+  const handler = new BespokeConditionsQuestionRoutes(licenceService)
   let req: Request
   let res: Response
 
   beforeEach(() => {
     req = {
       params: {
-        licenceId: 1,
+        licenceId: '1',
+      },
+      user: {
+        username: 'joebloggs',
       },
     } as unknown as Request
 
@@ -37,6 +46,21 @@ describe('Route Handlers - Create Licence - Bespoke Conditions Question', () => 
       } as unknown as Request
       await handler.POST(req, res)
       expect(res.redirect).toHaveBeenCalledWith('/licence/create/id/1/bespoke-conditions')
+    })
+
+    it('should clear any existing bespoke conditions on the licence when the answer is NO', async () => {
+      req = {
+        ...req,
+        body: {
+          answer: 'no',
+        },
+      } as unknown as Request
+      await handler.POST(req, res)
+      expect(licenceService.updateBespokeConditions).toHaveBeenCalledWith(
+        '1',
+        { conditions: [] } as BespokeConditions,
+        'joebloggs'
+      )
     })
 
     it('should redirect to the check answers page when answer is NO', async () => {

--- a/server/routes/creatingLicences/handlers/bespokeConditionsQuestion.ts
+++ b/server/routes/creatingLicences/handlers/bespokeConditionsQuestion.ts
@@ -1,17 +1,23 @@
 import { Request, Response } from 'express'
 import YesOrNo from '../../../enumeration/yesOrNo'
+import LicenceService from '../../../services/licenceService'
+import BespokeConditions from '../types/bespokeConditions'
 
 export default class BespokeConditionsQuestionRoutes {
+  constructor(private readonly licenceService: LicenceService) {}
+
   GET = async (req: Request, res: Response): Promise<void> => {
     res.render('pages/create/bespokeConditionsQuestion')
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
     const { licenceId } = req.params
+    const { username } = req.user
     const { answer } = req.body
     if (answer === YesOrNo.YES) {
       res.redirect(`/licence/create/id/${licenceId}/bespoke-conditions`)
     } else {
+      await this.licenceService.updateBespokeConditions(licenceId, { conditions: [] } as BespokeConditions, username)
       res.redirect(`/licence/create/id/${licenceId}/check-your-answers`)
     }
   }

--- a/server/routes/creatingLicences/index.ts
+++ b/server/routes/creatingLicences/index.ts
@@ -46,7 +46,7 @@ export default function Index({ licenceService, caseloadService }: Services): Ro
   const initialMeetingTimeHandler = new InitialMeetingTimeRoutes(licenceService)
   const additionalConditionsQuestionHandler = new AdditionalConditionsQuestionRoutes()
   const additionalConditionsHandler = new AdditionalConditionsRoutes()
-  const bespokeConditionsQuestionHandler = new BespokeConditionsQuestionRoutes()
+  const bespokeConditionsQuestionHandler = new BespokeConditionsQuestionRoutes(licenceService)
   const bespokeConditionsHandler = new BespokeConditionsRoutes(licenceService)
   const checkAnswersHandler = new CheckAnswersRoutes(licenceService)
   const confirmationHandler = new ConfirmationRoutes()

--- a/server/views/layout.njk
+++ b/server/views/layout.njk
@@ -1,5 +1,6 @@
 {% extends "govuk/template.njk" %}
 {% from "govuk/components/phase-banner/macro.njk" import govukPhaseBanner %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% block head %}
   <!--[if !IE 8]><!-->
@@ -40,6 +41,12 @@
     }) }}
   {% include 'partials/formError.njk' %}
   <span class="govuk-visually-hidden" id="{{ pageId }}"></span>
+  {% if backLinkHref %}
+    {{ govukBackLink({
+      text: "Back",
+      href: backLinkHref
+    }) }}
+  {% endif %}
 {% endblock %}
 
 {% block bodyEnd %}

--- a/server/views/pages/create/additionalConditions.njk
+++ b/server/views/pages/create/additionalConditions.njk
@@ -7,6 +7,7 @@
 
 {% set pageTitle = applicationName + " - Create a licence - Additional Conditions" %}
 {% set pageId = "additional-conditions-page" %}
+{% set backLinkHref = "/licence/create/id/" + licence.id + "/additional-conditions-question" %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/server/views/pages/create/additionalConditionsQuestion.njk
+++ b/server/views/pages/create/additionalConditionsQuestion.njk
@@ -5,6 +5,7 @@
 
 {% set pageTitle = applicationName + " - Create a licence - Additional Conditions" %}
 {% set pageId = "additional-conditions-question-page" %}
+{% set backLinkHref = "/licence/create/id/" + licence.id + "/initial-meeting-time" %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/server/views/pages/create/bespokeConditions.njk
+++ b/server/views/pages/create/bespokeConditions.njk
@@ -7,6 +7,7 @@
 
 {% set pageTitle = applicationName + " - Create a licence - Bespoke Conditions" %}
 {% set pageId = "bespoke-conditions-page" %}
+{% set backLinkHref = "/licence/create/id/" + licence.id + "/bespoke-conditions-question" %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/server/views/pages/create/bespokeConditionsQuestion.njk
+++ b/server/views/pages/create/bespokeConditionsQuestion.njk
@@ -5,6 +5,7 @@
 
 {% set pageTitle = applicationName + " - Create a licence - Bespoke Conditions" %}
 {% set pageId = "bespoke-conditions-question-page" %}
+{% set backLinkHref = "/licence/create/id/" + licence.id + "/additional-conditions-question" %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/server/views/pages/create/initialMeetingContact.njk
+++ b/server/views/pages/create/initialMeetingContact.njk
@@ -5,6 +5,7 @@
 
 {% set pageTitle = applicationName + " - Create a licence - Induction meeting" %}
 {% set pageId = "appointment-contact-page" %}
+{% set backLinkHref = "/licence/create/id/" + licence.id + "/initial-meeting-place" %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/server/views/pages/create/initialMeetingPerson.njk
+++ b/server/views/pages/create/initialMeetingPerson.njk
@@ -5,6 +5,7 @@
 
 {% set pageTitle = applicationName + " - Create a licence - Induction meeting" %}
 {% set pageId = "appointment-person-page" %}
+{% set backLinkHref = "/licence/create/caseload" %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/server/views/pages/create/initialMeetingPlace.njk
+++ b/server/views/pages/create/initialMeetingPlace.njk
@@ -6,6 +6,7 @@
 
 {% set pageTitle = applicationName + " - Create a licence - Induction meeting" %}
 {% set pageId = "appointment-place-page" %}
+{% set backLinkHref = "/licence/create/id/" + licence.id + "/initial-meeting-name" %}
 
 {% block content %}
     <div class="govuk-grid-row">

--- a/server/views/pages/create/initialMeetingTime.njk
+++ b/server/views/pages/create/initialMeetingTime.njk
@@ -12,6 +12,7 @@
 
 {% set pageTitle = applicationName + " - Create a licence - Induction meeting" %}
 {% set pageId = "appointment-time-page" %}
+{% set backLinkHref = "/licence/create/id/" + licence.id + "/initial-meeting-contact" %}
 
 {% block content %}
     <div class="govuk-grid-row">


### PR DESCRIPTION
- "Sensible" HREFs on each page when javascript is turned off
- When javascript is turned on, the back link triggers a method which will direct back to `window.history(-1)`
- Also cleared any existing bespoke conditions which may be on the licence when the user selected NO when asked if the licence requires bespoke conditions (i.e. for arriving from the check your answers page). The same will need done later for additional conditions