### PR TITLE
CVSL-160: Revert hmpps-helm-charts version from 1.0.16 to 1.0.10 for subcharts

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,10 +139,11 @@ GOTENBERG_API_URL=http://localhost:3001
 
 ## Helm
 
-There are three services associated with this UI service:
+There are four services associated with this UI service:
 
 * create-and-vary-a-licence  (generic-service)
 * gotenberg (generic-service)
+* delius-wiremock (generic-service)
 * generic-prometheus-alerts
 
 ## Dependency Checks

--- a/helm_deploy/create-and-vary-a-licence/Chart.yaml
+++ b/helm_deploy/create-and-vary-a-licence/Chart.yaml
@@ -9,12 +9,12 @@ dependencies:
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-service
     alias: gotenberg
-    version: 1.0.16
+    version: 1.0.10
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-service
     alias: delius-wiremock
-    version: 1.0.16
+    version: 1.0.10
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 0.1.5
+    version: 0.1.4
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
Trial to see if hmpps-helm-charts v.1.0.16 has affected sub charts.