### PR TITLE
CVSL-196: Trim the request body before validation

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -19,6 +19,7 @@ import setUpAuthentication from './middleware/setUpAuthentication'
 import setUpHealthChecks from './middleware/setUpHealthChecks'
 import setUpWebRequestParsing from './middleware/setupRequestParsing'
 import authorisationMiddleware from './middleware/authorisationMiddleware'
+import trimRequestBody from './middleware/trimBodyMiddleware'
 
 const testMode = process.env.NODE_ENV === 'test'
 
@@ -37,6 +38,7 @@ export default function createApp(services: Services): express.Application {
   nunjucksSetup(app)
   app.use(setUpAuthentication())
   app.use(pdfRenderer(new GotenbergClient(config.apis.gotenberg.apiUrl)))
+  app.use(trimRequestBody())
 
   // CSRF protection
   if (!testMode) {

--- a/server/middleware/trimBodyMiddleware.test.ts
+++ b/server/middleware/trimBodyMiddleware.test.ts
@@ -1,0 +1,101 @@
+import { Request, Response } from 'express'
+import trimRequestBody from './trimBodyMiddleware'
+
+const req = {} as Request
+const res = {} as unknown as Response
+const next = jest.fn()
+
+const middleware = trimRequestBody()
+
+beforeEach(() => {
+  jest.resetAllMocks()
+  req.method = 'POST'
+})
+
+describe('trimRequestBody', () => {
+  it('should pass over a GET request unchanged', async () => {
+    req.method = 'GET'
+    middleware(req, res, next)
+    expect(next).toBeCalledTimes(1)
+    expect(req.body).toBeUndefined()
+  })
+
+  it('should trim all strings in an object', async () => {
+    req.body = {
+      test1: '  value1   ',
+      test2: '  value2   ',
+    }
+    middleware(req, res, next)
+    expect(next).toBeCalledTimes(1)
+    expect(req.body).toEqual({
+      test1: 'value1',
+      test2: 'value2',
+    })
+  })
+
+  it('should trim strings inside objects', async () => {
+    req.body = {
+      test1: {
+        test1: '   value1    ',
+        test2: '   value2   ',
+      },
+    }
+    middleware(req, res, next)
+    expect(next).toBeCalledTimes(1)
+    expect(req.body).toEqual({
+      test1: {
+        test1: 'value1',
+        test2: 'value2',
+      },
+    })
+  })
+
+  it('should trim strings inside arrays', async () => {
+    req.body = {
+      test1: ['   value1   ', '   value2   '],
+      test2: [
+        {
+          test1: '   value1    ',
+          test2: '   value2   ',
+        },
+      ],
+    }
+    middleware(req, res, next)
+    expect(next).toBeCalledTimes(1)
+    expect(req.body).toEqual({
+      test1: ['value1', 'value2'],
+      test2: [
+        {
+          test1: 'value1',
+          test2: 'value2',
+        },
+      ],
+    })
+  })
+
+  it('should handle booleans, numbers, null and undefined', async () => {
+    req.body = {
+      test1: true,
+      test2: 2,
+    }
+    middleware(req, res, next)
+    expect(next).toBeCalledTimes(1)
+    expect(req.body).toEqual({
+      test1: true,
+      test2: 2,
+    })
+  })
+
+  it('should handle null and undefined', async () => {
+    req.body = {
+      test1: null,
+      test2: undefined,
+    }
+    middleware(req, res, next)
+    expect(next).toBeCalledTimes(1)
+    expect(req.body).toEqual({
+      test1: null,
+      test2: undefined,
+    })
+  })
+})

--- a/server/middleware/trimBodyMiddleware.ts
+++ b/server/middleware/trimBodyMiddleware.ts
@@ -1,0 +1,25 @@
+import { RequestHandler } from 'express'
+
+export default function trimRequestBody(): RequestHandler {
+  // Recursively iterate into an object and trim any strings inside
+  const deepTrim = (object: object): object => {
+    const o = object
+    if (o) {
+      Object.keys(o).forEach(key => {
+        if (typeof o[key] === 'string') {
+          o[key] = o[key].trim()
+        } else if (typeof o[key] === 'object') {
+          o[key] = deepTrim(o[key])
+        }
+      })
+    }
+    return o as object
+  }
+
+  return (req, res, next) => {
+    if (req.method === 'POST') {
+      req.body = deepTrim(req.body)
+    }
+    next()
+  }
+}


### PR DESCRIPTION
- Validation was passing when user enters a space character
- Subsequently threw a 400 Bad Request error when it hit the API
- This middleware will trim all strings in `req.body` before hitting the validation layer