### PR TITLE
CVSL-184: Added conditional radio button

### DIFF
--- a/integration_tests/integration/createLicence.spec.ts
+++ b/integration_tests/integration/createLicence.spec.ts
@@ -40,6 +40,7 @@ context('Create a licence', () => {
       .selectCondition('fce34fb2-02f4-4eb0-9b8d-d091e11451fa')
       .selectCondition('a7c57e4e-30fe-4797-9fe7-70a35dbd7b65')
       .selectCondition('89e656ec-77e8-4832-acc4-6ec05d3e9a98')
+      .selectCondition('0a370862-5426-49c1-b6d4-3d074d78a81a')
       .clickContinue()
 
     const bespokeConditionsQuestionPage = additionalConditionsInputPage
@@ -53,6 +54,11 @@ context('Create a licence', () => {
       .enterAddress()
       .nextInput()
       .checkBoxes()
+      .nextInput(false) // aria-expanded attribute causes issues with Axe
+      .enterTime('10', '30', 'curfewStart')
+      .enterTime('11', '30', 'curfewEnd')
+      .selectRadios(3)
+      .enterText('Annually', 'alternativeReviewPeriod')
       .clickContinue()
 
     const bespokeConditionsPage = bespokeConditionsQuestionPage.selectYes().clickContinue()

--- a/integration_tests/mockApis/licence.ts
+++ b/integration_tests/mockApis/licence.ts
@@ -130,6 +130,39 @@ export default {
                 },
               ],
             },
+            {
+              id: 4,
+              code: 'a7c57e4e-30fe-4797-9fe7-70a35dbd7b65',
+              category: 'Participation in, or co-operation with, a programme or set of activities',
+              sequence: 3,
+              text: 'Confine yourself to an address approved by your supervising officer between the hours of [TIME] and [TIME] daily unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a [WEEKLY / MONTHLY / ETC] basis and may be amended or removed if it is felt that the level of risk that you present has reduced appropriately.',
+              data: [
+                {
+                  id: 6,
+                  sequence: 0,
+                  field: 'curfewStart',
+                  value: '7:30pm',
+                },
+                {
+                  id: 7,
+                  sequence: 1,
+                  field: 'curfewEnd',
+                  value: '7:30am',
+                },
+                {
+                  id: 8,
+                  sequence: 2,
+                  field: 'reviewPeriod',
+                  value: 'Other',
+                },
+                {
+                  id: 9,
+                  sequence: 3,
+                  field: 'alternativeReviewPeriod',
+                  value: 'Annually',
+                },
+              ],
+            },
           ],
           bespokeConditions: [
             {
@@ -265,7 +298,6 @@ export default {
             {
               id: 1,
               code,
-              text: 'Condition text',
               data: [],
             },
           ],

--- a/integration_tests/pages/additionalConditionInput.ts
+++ b/integration_tests/pages/additionalConditionInput.ts
@@ -9,7 +9,7 @@ export default class AdditionalConditionsInputPage extends Page {
   private additionalConditionsToInput = []
 
   constructor() {
-    super('additional-condition-input-page', false)
+    super('additional-condition-input-page')
   }
 
   withContext = (context: Context): AdditionalConditionsInputPage => {
@@ -17,20 +17,30 @@ export default class AdditionalConditionsInputPage extends Page {
     return this
   }
 
-  enterText = (text: string): AdditionalConditionsInputPage => {
-    cy.get('.govuk-form-group > input').type(text)
+  enterText = (text: string, fieldId?: string): AdditionalConditionsInputPage => {
+    if (fieldId) {
+      cy.get(`#${fieldId}`).type(text)
+    } else {
+      cy.get('.govuk-form-group > input').type(text)
+    }
     return this
   }
 
-  selectRadios = (): AdditionalConditionsInputPage => {
-    cy.get('.govuk-radios div:nth-child(1) > input').click({ multiple: true })
+  selectRadios = (radioIndex = 1): AdditionalConditionsInputPage => {
+    cy.get(`.govuk-radios div:nth-child(${radioIndex}) > input`).click({ multiple: true })
     return this
   }
 
-  enterTime = (): AdditionalConditionsInputPage => {
-    cy.get("input[name*='hour']").type('11')
-    cy.get("input[name*='minute']").type('30')
-    cy.get("select[name*='ampm']").select('am')
+  enterTime = (hour = '11', minute = '30', fieldId?: string): AdditionalConditionsInputPage => {
+    if (fieldId) {
+      cy.get(`#${fieldId}-hour`).type(hour)
+      cy.get(`#${fieldId}-minute`).type(minute)
+      cy.get(`#${fieldId}-ampm`).select('am')
+    } else {
+      cy.get("input[name*='hour']").type(hour)
+      cy.get("input[name*='minute']").type(minute)
+      cy.get("select[name*='ampm']").select('am')
+    }
     return this
   }
 
@@ -54,12 +64,14 @@ export default class AdditionalConditionsInputPage extends Page {
     return this
   }
 
-  nextInput = (): AdditionalConditionsInputPage => {
+  nextInput = (runAxe = true): AdditionalConditionsInputPage => {
     cy.task('stubPutAdditionalConditionData')
     cy.task('stubGetLicenceWithConditionToComplete', this.additionalConditionsToInput.shift())
     cy.get(this.continueButtonId).click()
     this.checkOnPage()
-    this.runAxe()
+    if (runAxe) {
+      this.runAxe()
+    }
     return this
   }
 

--- a/server/config/conditions.ts
+++ b/server/config/conditions.ts
@@ -15,6 +15,7 @@ import ElectronicMonitoringTypes from '../routes/creatingLicences/types/addition
 import ElectronicMonitoringPeriod from '../routes/creatingLicences/types/additionalConditionInputs/electronicMonitoringPeriod'
 import ApprovedAddress from '../routes/creatingLicences/types/additionalConditionInputs/approvedAddress'
 import AlcoholMonitoringPeriod from '../routes/creatingLicences/types/additionalConditionInputs/alcoholMonitoringPeriod'
+import CurfewTerms from '../routes/creatingLicences/types/additionalConditionInputs/curfewTerms'
 
 export default {
   version: '1.0',
@@ -157,10 +158,12 @@ export default {
       inputs: [
         {
           type: InputTypes.TIME,
+          label: 'Enter time',
           name: 'appointmentTime',
         },
         {
           type: InputTypes.DATE,
+          label: 'Enter date',
           name: 'appointmentDate',
         },
         {
@@ -414,12 +417,51 @@ export default {
       text: 'Provide your supervising officer with the details of any bank accounts to which you are a signatory and of any credit cards you possess. You must also notify your supervising officer when becoming a signatory to any new bank account or credit card, and provide the account/card details. This condition will be reviewed on a monthly basis and may be amended or removed if it is felt that the level of risk that you present has reduced appropriately.',
       requiresInput: false,
     },
-    // {
-    //   code: '0a370862-5426-49c1-b6d4-3d074d78a81a',
-    //   category: 'Curfew arrangement',
-    //   text: 'Confine yourself to an address approved by your supervising officer between the hours of [TIME] and [TIME] daily unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a [WEEKLY / MONTHLY / ETC] basis and may be amended or removed if it is felt that the level of risk that you present has reduced appropriately.',
-    //   requiresInput: true,
-    // },
+    {
+      code: '0a370862-5426-49c1-b6d4-3d074d78a81a',
+      category: 'Curfew arrangement',
+      text: 'Confine yourself to an address approved by your supervising officer between the hours of [TIME] and [TIME] daily unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a [WEEKLY / MONTHLY / ETC] basis and may be amended or removed if it is felt that the level of risk that you present has reduced appropriately.',
+      subtext: 'You must have PPCS approval if the curfew time is longer than 12 hours.',
+      requiresInput: true,
+      inputs: [
+        {
+          type: InputTypes.TIME,
+          label: 'Enter the curfew start time',
+          name: 'curfewStart',
+        },
+        {
+          type: InputTypes.TIME,
+          label: 'Enter the curfew end time',
+          name: 'curfewEnd',
+        },
+        {
+          type: InputTypes.RADIO,
+          label: 'Select a review period',
+          name: 'reviewPeriod',
+          options: [
+            {
+              value: 'Weekly',
+            },
+            {
+              value: 'Monthly',
+            },
+            {
+              value: 'Other',
+              conditional: {
+                inputs: [
+                  {
+                    type: InputTypes.TEXT,
+                    label: 'Enter a review period',
+                    name: 'alternativeReviewPeriod',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      type: CurfewTerms,
+    },
     // {
     //   code: 'c2435d4a-20a0-47de-b080-e1e740d1514c',
     //   category: 'Curfew arrangement',
@@ -598,6 +640,7 @@ export default {
         },
         {
           type: InputTypes.DATE,
+          label: 'Enter end date',
           name: 'endDate',
         },
       ],
@@ -629,6 +672,7 @@ export default {
         },
         {
           type: InputTypes.DATE,
+          label: 'Enter end date',
           name: 'endDate',
         },
       ],

--- a/server/routes/creatingLicences/types/additionalConditionInputs/curfewTerms.ts
+++ b/server/routes/creatingLicences/types/additionalConditionInputs/curfewTerms.ts
@@ -2,7 +2,6 @@ import { Expose, Transform, Type } from 'class-transformer'
 import { IsNotEmpty, Validate, ValidateIf } from 'class-validator'
 import SimpleTime from '../time'
 import ValidSimpleTime from '../../../../validators/simpleTimeValidator'
-import IsSimpleTimeAfter from '../../../../validators/decorators'
 
 class CurfewTerms {
   @Expose()
@@ -13,7 +12,6 @@ class CurfewTerms {
   @Expose()
   @Type(() => SimpleTime)
   @Validate(ValidSimpleTime)
-  @IsSimpleTimeAfter('curfewStart', { message: 'Curfew end time should be after the start time' })
   curfewEnd: SimpleTime
 
   @Expose()

--- a/server/routes/creatingLicences/types/additionalConditionInputs/curfewTerms.ts
+++ b/server/routes/creatingLicences/types/additionalConditionInputs/curfewTerms.ts
@@ -2,7 +2,7 @@ import { Expose, Transform, Type } from 'class-transformer'
 import { IsNotEmpty, Validate, ValidateIf } from 'class-validator'
 import SimpleTime from '../time'
 import ValidSimpleTime from '../../../../validators/simpleTimeValidator'
-import IsSimpleTimeAfter from '../../../../validators/isSimpleTimeAfter'
+import IsSimpleTimeAfter from '../../../../validators/decorators'
 
 class CurfewTerms {
   @Expose()

--- a/server/routes/creatingLicences/types/additionalConditionInputs/curfewTerms.ts
+++ b/server/routes/creatingLicences/types/additionalConditionInputs/curfewTerms.ts
@@ -1,0 +1,32 @@
+import { Expose, Transform, Type } from 'class-transformer'
+import { IsNotEmpty, Validate, ValidateIf } from 'class-validator'
+import SimpleTime from '../time'
+import ValidSimpleTime from '../../../../validators/simpleTimeValidator'
+import IsSimpleTimeAfter from '../../../../validators/isSimpleTimeAfter'
+
+class CurfewTerms {
+  @Expose()
+  @Type(() => SimpleTime)
+  @Validate(ValidSimpleTime)
+  curfewStart: SimpleTime
+
+  @Expose()
+  @Type(() => SimpleTime)
+  @Validate(ValidSimpleTime)
+  @IsSimpleTimeAfter('curfewStart', { message: 'Curfew end time should be after the start time' })
+  curfewEnd: SimpleTime
+
+  @Expose()
+  @IsNotEmpty({ message: 'Select a review period' })
+  reviewPeriod: string
+
+  @Expose()
+  @Transform(({ obj, value }) => {
+    return obj.reviewPeriod === 'Other' ? value : undefined
+  })
+  @ValidateIf(o => o.reviewPeriod === 'Other')
+  @IsNotEmpty({ message: 'Enter a review period' })
+  alternativeReviewPeriod: string
+}
+
+export default CurfewTerms

--- a/server/routes/creatingLicences/types/time.ts
+++ b/server/routes/creatingLicences/types/time.ts
@@ -1,5 +1,5 @@
 import { Expose } from 'class-transformer'
-import moment from 'moment'
+import moment, { Moment } from 'moment'
 import Stringable from './abstract/stringable'
 
 export enum AmPm {
@@ -25,7 +25,11 @@ class SimpleTime extends Stringable {
   ampm: AmPm
 
   stringify(): string {
-    return moment([this.hour, this.minute, this.ampm].join('-'), ['hh-mm-a'], true).format('hh:mm a')
+    return this.toMoment().format('hh:mm a')
+  }
+
+  toMoment(): Moment {
+    return moment([this.hour, this.minute, this.ampm].join('-'), ['hh-mm-a'], true)
   }
 
   static fromString(value: string): SimpleTime {

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -160,27 +160,29 @@ export default class LicenceService {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
 
     const requestBody = {
-      data: Object.keys(formData).flatMap((key, index) => {
-        // The POST request to the API will only accept an array of objects where value is a string.
-        // Therefore, if the type of data entered from the form is an array or an object, we need to convert that to a string type.
-        // For arrays, we can just split it into multiple objects each with a value from each member of that array.
-        // For objects, the objects needs to be converted into a string representation. Types which need to be represented as a string
-        // should extend Stringable and implement the stringify() method
+      data: Object.keys(formData)
+        .filter(key => formData[key])
+        .flatMap((key, index) => {
+          // The POST request to the API will only accept an array of objects where value is a string.
+          // Therefore, if the type of data entered from the form is an array or an object, we need to convert that to a string type.
+          // For arrays, we can just split it into multiple objects each with a value from each member of that array.
+          // For objects, the objects needs to be converted into a string representation. Types which need to be represented as a string
+          // should extend Stringable and implement the stringify() method
 
-        const build = (value: unknown, i?: number) => {
-          return {
-            field: key,
-            value: value instanceof Stringable ? value.stringify() : value,
-            sequence: i || index,
+          const build = (value: unknown, i?: number) => {
+            return {
+              field: key,
+              value: value instanceof Stringable ? value.stringify() : value,
+              sequence: i || index,
+            }
           }
-        }
-        if (Array.isArray(formData[key])) {
-          return formData[key].map((v: string, i: number) => {
-            return build(v, i)
-          })
-        }
-        return build(formData[key])
-      }),
+          if (Array.isArray(formData[key])) {
+            return formData[key].map((v: string, i: number) => {
+              return build(v, i + index)
+            })
+          }
+          return build(formData[key])
+        }),
     } as UpdateAdditionalConditionDataRequest
 
     return new LicenceApiClient(token).updateAdditionalConditionData(licenceId, additionalConditionId, requestBody)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -107,7 +107,17 @@ export function registerNunjucks(app?: express.Express): Environment {
   njkEnv.addFilter(
     'additionalConditionDataContainsValue',
     (additionalConditionData: AdditionalConditionData[], fieldName: string, value: string) => {
-      return additionalConditionData.find(data => data.field === fieldName && data.value === value) !== undefined
+      return (
+        additionalConditionData &&
+        additionalConditionData.find(data => data.field === fieldName && data.value === value) !== undefined
+      )
+    }
+  )
+
+  njkEnv.addFilter(
+    'formResponsesContainsValue',
+    (formResponses: Record<string, unknown>, fieldName: string, value: string) => {
+      return formResponses && formResponses[fieldName] === value
     }
   )
 

--- a/server/validators/decorators.ts
+++ b/server/validators/decorators.ts
@@ -1,0 +1,15 @@
+import { registerDecorator, ValidationOptions } from 'class-validator'
+import isSimpleTimeAfter from './isSimpleTimeAfter'
+
+export default function IsSimpleTimeAfter(property: string, validationOptions?: ValidationOptions) {
+  return (object: unknown, propertyName: string) => {
+    registerDecorator({
+      name: 'isSimpleTimeAfter',
+      target: object.constructor,
+      propertyName,
+      constraints: [property],
+      options: validationOptions,
+      validator: { validate: isSimpleTimeAfter },
+    })
+  }
+}

--- a/server/validators/isSimpleTimeAfter.test.ts
+++ b/server/validators/isSimpleTimeAfter.test.ts
@@ -1,0 +1,42 @@
+import { ValidationArguments } from 'class-validator'
+import isSimpleTimeAfter from './isSimpleTimeAfter'
+import SimpleTime, { AmPm } from '../routes/creatingLicences/types/time'
+
+describe('isSimpleTimeAfter', () => {
+  it('should throw an exception if the field supplied for comparison is not an instance of SimpleTime', () => {
+    const value = new SimpleTime('11', '00', <AmPm>'am')
+    const fn = () =>
+      isSimpleTimeAfter(value, {
+        constraints: ['fieldForComparison'],
+        object: {
+          fieldForComparison: {},
+        },
+      } as ValidationArguments)
+
+    expect(fn).toThrow('The field supplied for comparison was not of the required type i.e. SimpleTime')
+  })
+
+  it('should return true if the field being validated is a time after the field supplied for comparison', () => {
+    const value = new SimpleTime('11', '00', <AmPm>'am')
+    const result = isSimpleTimeAfter(value, {
+      constraints: ['fieldForComparison'],
+      object: {
+        fieldForComparison: new SimpleTime('10', '00', <AmPm>'am'),
+      },
+    } as ValidationArguments)
+
+    expect(result).toBe(true)
+  })
+
+  it('should return false if the field being validated is a time after the field supplied for comparison', () => {
+    const value = new SimpleTime('10', '00', <AmPm>'am')
+    const result = isSimpleTimeAfter(value, {
+      constraints: ['fieldForComparison'],
+      object: {
+        fieldForComparison: new SimpleTime('11', '00', <AmPm>'am'),
+      },
+    } as ValidationArguments)
+
+    expect(result).toBe(false)
+  })
+})

--- a/server/validators/isSimpleTimeAfter.ts
+++ b/server/validators/isSimpleTimeAfter.ts
@@ -1,0 +1,25 @@
+import { registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator'
+import SimpleTime from '../routes/creatingLicences/types/time'
+
+export default function IsSimpleTimeAfter(property: string, validationOptions?: ValidationOptions) {
+  return (object: unknown, propertyName: string) => {
+    registerDecorator({
+      name: 'isSimpleTimeAfter',
+      target: object.constructor,
+      propertyName,
+      constraints: [property],
+      options: validationOptions,
+      validator: {
+        validate(value: SimpleTime, args: ValidationArguments) {
+          const [relatedPropertyName] = args.constraints
+          const relatedValue = (args.object as SimpleTime)[relatedPropertyName]
+          return (
+            value instanceof SimpleTime &&
+            relatedValue instanceof SimpleTime &&
+            value.toMoment().isAfter(relatedValue.toMoment())
+          )
+        },
+      },
+    })
+  }
+}

--- a/server/validators/isSimpleTimeAfter.ts
+++ b/server/validators/isSimpleTimeAfter.ts
@@ -1,25 +1,13 @@
-import { registerDecorator, ValidationOptions, ValidationArguments } from 'class-validator'
+import { ValidationArguments } from 'class-validator'
 import SimpleTime from '../routes/creatingLicences/types/time'
 
-export default function IsSimpleTimeAfter(property: string, validationOptions?: ValidationOptions) {
-  return (object: unknown, propertyName: string) => {
-    registerDecorator({
-      name: 'isSimpleTimeAfter',
-      target: object.constructor,
-      propertyName,
-      constraints: [property],
-      options: validationOptions,
-      validator: {
-        validate(value: SimpleTime, args: ValidationArguments) {
-          const [relatedPropertyName] = args.constraints
-          const relatedValue = (args.object as SimpleTime)[relatedPropertyName]
-          return (
-            value instanceof SimpleTime &&
-            relatedValue instanceof SimpleTime &&
-            value.toMoment().isAfter(relatedValue.toMoment())
-          )
-        },
-      },
-    })
+export default function isSimpleTimeAfter(value: SimpleTime, args: ValidationArguments) {
+  const [relatedPropertyName] = args.constraints
+  const relatedValue = args.object[relatedPropertyName]
+
+  if (!(relatedValue instanceof SimpleTime)) {
+    throw new Error('The field supplied for comparison was not of the required type i.e. SimpleTime')
   }
+
+  return value.toMoment().isAfter(relatedValue.toMoment())
 }

--- a/server/views/formBuilder.njk
+++ b/server/views/formBuilder.njk
@@ -5,162 +5,175 @@
 {% from "partials/datePicker.njk" import datePicker %}
 {% from "partials/timePicker.njk" import timePicker %}
 
-{% for input in config.inputs %}
+{%  macro formBuilder(config, additionalCondition, validationErrors, formResponses) %}
 
-    {% if input.type == 'text' %}
-        {{ govukInput({
-            label: {
-                text: input.label
-            },
-            id: input.name,
-            name: input.name,
-            classes: "govuk-!-width-one-half",
-            errorMessage: validationErrors | findError(input.name),
-            value: additionalCondition.data | getAdditionalConditionDataValue(input.name) | fillFormResponse(formResponses[input.name])
-        }) }}
-    {% endif %}
+    {% for input in config.inputs %}
 
-    {% if input.type == 'radio' %}
-        {% set options = [] %}
-        {% for option in input.options %}
-            {% set options = (options.push({
-                text: option.value,
-                value: option.value,
-                checked: additionalCondition.data | additionalConditionDataContainsValue(input.name, option.value)
-            }), options) %}
-        {% endfor %}
-
-        {{ govukRadios({
-            idPrefix: input.name,
-            name: input.name,
-            fieldset: {
-                legend: {
-                    text: input.label
-                }
-            },
-            items: options,
-            errorMessage: validationErrors | findError(input.name)
-        }) }}
-    {% endif %}
-
-    {% if input.type == 'datePicker' %}
-        {{ datePicker({
-            id: input.name,
-            label: {
-                text: "Date"
-            },
-            hint: {
-                text: "For example, 12 11 2022"
-            },
-            errorMessage: validationErrors | findError(input.name),
-            formResponses: additionalCondition.data | getAdditionalConditionSimpleDateValue(input.name) | fillFormResponse(formResponses)
-        }) }}
-    {% endif %}
-
-    {% if input.type == 'timePicker' %}
-        {{ timePicker({
-            id: input.name,
-            label: {
-                text: "Time"
-            },
-            hint: {
-                text: "For example, 9:30am or 2:55pm"
-            },
-            errorMessage: validationErrors | findError(input.name),
-            formResponses: additionalCondition.data | getAdditionalConditionSimpleTimeValue(input.name) | fillFormResponse(formResponses)
-        }) }}
-    {% endif %}
-
-    {% if input.type == 'address' %}
-        {% call govukFieldset({
-            legend: {
-                text: "Enter address",
-                classes: "govuk-fieldset__legend--s"
-            },
-            classes: 'govuk-!-margin-top-9'
-        }) %}
+        {% if input.type == 'text' %}
             {{ govukInput({
-                id: 'addressLine1',
                 label: {
-                    html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
-                },
-                name: input.name + "[addressLine1]",
-                autocomplete: "address-line1",
-                classes: 'govuk-!-width-one-half',
-                classes: 'govuk-!-width-one-half',
-                errorMessage: validationErrors | findError('addressLine1'),
-                value: additionalCondition.data | getAdditionalConditionAddressValue(input.name, 'addressLine1') | fillFormResponse(formResponses[input.name]['addressLine1'])
-            }) }}
-
-            {{ govukInput({
-                id: 'addressLine2',
-                label: {
-                    html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
-                },
-                name: input.name + "[addressLine2]",
-                autocomplete: "address-line2",
-                classes: 'govuk-!-width-one-half',
-                errorMessage: validationErrors | findError('addressLine2'),
-                value: additionalCondition.data | getAdditionalConditionAddressValue(input.name, 'addressLine2') | fillFormResponse(formResponses[input.name]['addressLine2'])
-            }) }}
-
-            {{ govukInput({
-                id: 'addressTown',
-                label: {
-                    text: "Town or city"
-                },
-                name: input.name + "[addressTown]",
-                classes: "govuk-!-width-one-third",
-                autocomplete: "address-level2",
-                errorMessage: validationErrors | findError('addressTown'),
-                value: additionalCondition.data | getAdditionalConditionAddressValue(input.name, 'addressTown') | fillFormResponse(formResponses[input.name]['addressTown'])
-            }) }}
-
-            {{ govukInput({
-                id: 'addressCounty',
-                label: {
-                    text: "County"
-                },
-                name: input.name + "[addressCounty]",
-                classes: "govuk-!-width-one-third",
-                errorMessage: validationErrors | findError('addressCounty'),
-                value: additionalCondition.data | getAdditionalConditionAddressValue(input.name, 'addressCounty') | fillFormResponse(formResponses[input.name]['addressCounty'])
-            }) }}
-
-            {{ govukInput({
-                id: 'addressPostcode',
-                label: {
-                    text: "Postcode"
-                },
-                name: input.name + "[addressPostcode]",
-                classes: "govuk-input--width-10",
-                autocomplete: "postal-code",
-                errorMessage: validationErrors | findError('addressPostcode'),
-                value: additionalCondition.data | getAdditionalConditionAddressValue(input.name, 'addressPostcode') | fillFormResponse(formResponses[input.name]['addressPostcode'])
-            }) }}
-        {% endcall %}
-    {% endif %}
-
-    {% if input.type == 'check' %}
-        {% set options = [] %}
-        {% for option in input.options %}
-            {% set options = (options.push({
-                text: option.value,
-                value: option.value,
-                checked: additionalCondition.data | additionalConditionDataContainsValue(input.name, option.value)
-            }), options) %}
-        {% endfor %}
-
-        {{ govukCheckboxes({
-            name: input.name,
-            fieldset: {
-                legend: {
                     text: input.label,
-                    isPageHeading: false
-                }
-            },
-            items: options
-        }) }}
-    {% endif %}
+                    classes: "govuk-!-font-weight-bold"
+                },
+                id: input.name,
+                name: input.name,
+                classes: "govuk-!-width-one-half",
+                errorMessage: validationErrors | findError(input.name),
+                value: additionalCondition.data | getAdditionalConditionDataValue(input.name) | fillFormResponse(formResponses[input.name])
+            }) }}
+        {% endif %}
 
-{% endfor %}
+        {% if input.type == 'radio' %}
+            {% set options = [] %}
+            {% for option in input.options %}
+                {% set options = (options.push({
+                    text: option.value,
+                    value: option.value,
+                    checked: formResponses | formResponsesContainsValue(input.name, option.value) or additionalCondition.data | additionalConditionDataContainsValue(input.name, option.value),
+                    conditional: {
+                        html: formBuilder(option.conditional, additionalCondition, validationErrors, formResponses)
+                    } if option.conditional
+                }), options) %}
+            {% endfor %}
+
+            {{ govukRadios({
+                idPrefix: input.name,
+                name: input.name,
+                fieldset: {
+                    legend: {
+                        text: input.label,
+                        classes: "govuk-!-font-weight-bold"
+                    }
+                },
+                items: options,
+                errorMessage: validationErrors | findError(input.name)
+            }) }}
+        {% endif %}
+
+        {% if input.type == 'datePicker' %}
+            {{ datePicker({
+                id: input.name,
+                label: {
+                    text: input.label,
+                    classes: "govuk-!-font-weight-bold"
+                },
+                hint: {
+                    text: "For example, 12 11 2022"
+                },
+                errorMessage: validationErrors | findError(input.name),
+                formResponses: additionalCondition.data | getAdditionalConditionSimpleDateValue(input.name) | fillFormResponse(formResponses)
+            }) }}
+        {% endif %}
+
+        {% if input.type == 'timePicker' %}
+            {{ timePicker({
+                id: input.name,
+                label: {
+                    text: input.label,
+                    classes: "govuk-!-font-weight-bold"
+                },
+                hint: {
+                    text: "For example, 9:30am or 2:55pm"
+                },
+                errorMessage: validationErrors | findError(input.name),
+                formResponses: additionalCondition.data | getAdditionalConditionSimpleTimeValue(input.name) | fillFormResponse(formResponses)
+            }) }}
+        {% endif %}
+
+        {% if input.type == 'address' %}
+            {% call govukFieldset({
+                legend: {
+                    text: "Enter address",
+                    classes: "govuk-!-font-weight-bold"
+                },
+                classes: 'govuk-!-margin-top-9'
+            }) %}
+                {{ govukInput({
+                    id: 'addressLine1',
+                    label: {
+                        html: 'Building and street <span class="govuk-visually-hidden">line 1 of 2</span>'
+                    },
+                    name: input.name + "[addressLine1]",
+                    autocomplete: "address-line1",
+                    classes: 'govuk-!-width-one-half',
+                    classes: 'govuk-!-width-one-half',
+                    errorMessage: validationErrors | findError('addressLine1'),
+                    value: additionalCondition.data | getAdditionalConditionAddressValue(input.name, 'addressLine1') | fillFormResponse(formResponses[input.name]['addressLine1'])
+                }) }}
+
+                {{ govukInput({
+                    id: 'addressLine2',
+                    label: {
+                        html: '<span class="govuk-visually-hidden">Building and street line 2 of 2</span>'
+                    },
+                    name: input.name + "[addressLine2]",
+                    autocomplete: "address-line2",
+                    classes: 'govuk-!-width-one-half',
+                    errorMessage: validationErrors | findError('addressLine2'),
+                    value: additionalCondition.data | getAdditionalConditionAddressValue(input.name, 'addressLine2') | fillFormResponse(formResponses[input.name]['addressLine2'])
+                }) }}
+
+                {{ govukInput({
+                    id: 'addressTown',
+                    label: {
+                        text: "Town or city"
+                    },
+                    name: input.name + "[addressTown]",
+                    classes: "govuk-!-width-one-third",
+                    autocomplete: "address-level2",
+                    errorMessage: validationErrors | findError('addressTown'),
+                    value: additionalCondition.data | getAdditionalConditionAddressValue(input.name, 'addressTown') | fillFormResponse(formResponses[input.name]['addressTown'])
+                }) }}
+
+                {{ govukInput({
+                    id: 'addressCounty',
+                    label: {
+                        text: "County"
+                    },
+                    name: input.name + "[addressCounty]",
+                    classes: "govuk-!-width-one-third",
+                    errorMessage: validationErrors | findError('addressCounty'),
+                    value: additionalCondition.data | getAdditionalConditionAddressValue(input.name, 'addressCounty') | fillFormResponse(formResponses[input.name]['addressCounty'])
+                }) }}
+
+                {{ govukInput({
+                    id: 'addressPostcode',
+                    label: {
+                        text: "Postcode"
+                    },
+                    name: input.name + "[addressPostcode]",
+                    classes: "govuk-input--width-10",
+                    autocomplete: "postal-code",
+                    errorMessage: validationErrors | findError('addressPostcode'),
+                    value: additionalCondition.data | getAdditionalConditionAddressValue(input.name, 'addressPostcode') | fillFormResponse(formResponses[input.name]['addressPostcode'])
+                }) }}
+            {% endcall %}
+        {% endif %}
+
+        {% if input.type == 'check' %}
+            {% set options = [] %}
+            {% for option in input.options %}
+                {% set options = (options.push({
+                    text: option.value,
+                    value: option.value,
+                    checked: additionalCondition.data | additionalConditionDataContainsValue(input.name, option.value)
+                }), options) %}
+            {% endfor %}
+
+            {{ govukCheckboxes({
+                idPrefix: input.name,
+                name: input.name,
+                fieldset: {
+                    legend: {
+                        text: input.label,
+                        classes: "govuk-!-font-weight-bold"
+                    }
+                },
+                errorMessage: validationErrors | findError(input.name),
+                items: options
+            }) }}
+        {% endif %}
+
+    {% endfor %}
+
+{% endmacro %}

--- a/server/views/pages/create/additionalConditionInput.njk
+++ b/server/views/pages/create/additionalConditionInput.njk
@@ -20,7 +20,7 @@
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
                 <p class="govuk-body">
-                    {{ additionalCondition.text }}
+                    {{ config.text }}
                 </p>
                 {% if config.subtext %}
                     <span class="govuk-hint">{{ config.subtext }}</span>

--- a/server/views/pages/create/additionalConditionInput.njk
+++ b/server/views/pages/create/additionalConditionInput.njk
@@ -1,6 +1,7 @@
 {% extends "layout.njk" %}
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "formBuilder.njk" import formBuilder %}
 
 {% set pageTitle = applicationName + " - Create a licence - Additional Conditions" %}
 {% set pageId = "additional-condition-input-page" %}
@@ -18,11 +19,14 @@
         <input type="hidden" name="code" value="{{ config.code }}">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                <p class="govuk-body govuk-!-font-weight-bold">
+                <p class="govuk-body">
                     {{ additionalCondition.text }}
                 </p>
+                {% if config.subtext %}
+                    <span class="govuk-hint">{{ config.subtext }}</span>
+                {% endif %}
 
-                {% include "formBuilder.njk" %}
+                {{ formBuilder(config, additionalCondition, validationErrors, formResponses) }}
 
                 {{ govukButton({
                     text: "Continue",

--- a/server/views/partials/datePicker.njk
+++ b/server/views/partials/datePicker.njk
@@ -11,7 +11,8 @@
         errorMessage: params.errorMessage,
         fieldset: {
             legend: {
-                text: params.label.text
+                text: params.label.text,
+                classes: params.label.classes
             }
         },
         items: [

--- a/server/views/partials/timePicker.njk
+++ b/server/views/partials/timePicker.njk
@@ -1,9 +1,9 @@
 {% macro timePicker(params) %}
     <div class="govuk-form-group {% if params.errorMessage %}govuk-form-group--error{% endif %}">
         {% if params.label %}
-            <label id="{{ params.id }}-label" class="govuk-label {{ params.label.classes }}">
+            <legend class="govuk-fieldset__legend {{ params.label.classes }}">
                 {{ params.label.text }}
-            </label>
+            </legend>
         {% endif %}
         {% if params.hint %}
             <div id="{{ params.id }}-hint" class="govuk-hint {{ params.hint.classes }}">

--- a/server/views/partials/timePicker.test.ts
+++ b/server/views/partials/timePicker.test.ts
@@ -21,7 +21,7 @@ describe('View Partials - Time Picker', () => {
     compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('#id-label').text().trim()).toBe('Label')
+    expect($('legend').text().trim()).toBe('Label')
   })
 
   it('should not show label when label is not provided in context', () => {
@@ -34,7 +34,7 @@ describe('View Partials - Time Picker', () => {
     compiledTemplate = nunjucks.compile(nunjucksString, njkEnv)
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('#id-label').length).toBe(0)
+    expect($('legend').length).toBe(0)
   })
 
   it('should show hint when hint is provided in context', () => {


### PR DESCRIPTION
- Added conditional reveal inputs nested beneath radio buttons
- Recursive formBuilder nunjucks macro which passes in the conditional reveal inputs
- Added a field decorator for validating that a time entered is after another time entered
- Conditional reveal field inputs have their parent's value stored in DB and displayed on the check your answers page, as below. Cannot easily overwrite the value of the radio button with the value of the conditional reveal because then it's hard to reconstruct the form when arriving from the change links.

![screencapture-localhost-3000-licence-create-id-1-additional-conditions-condition-87-2021-11-04-21_14_48](https://user-images.githubusercontent.com/30229564/140421139-9584fa6f-8513-4912-982c-b7a041946b00.png)
![Screenshot 2021-11-04 at 21 12 52](https://user-images.githubusercontent.com/30229564/140420894-87f01e09-917a-4de2-a462-79e6364c0c61.png)
![screencapture-localhost-3000-licence-create-id-1-additional-conditions-condition-87-2021-11-04-21_17_05](https://user-images.githubusercontent.com/30229564/140421384-c9440c35-0d75-4407-8dc4-2384abdcca1d.png)

