### PR TITLE
CVSL-206 - use the approvers full name in signatures

### DIFF
--- a/server/@types/licenceApiImport/index.d.ts
+++ b/server/@types/licenceApiImport/index.d.ts
@@ -70,6 +70,8 @@ export interface components {
       status: 'IN_PROGRESS' | 'SUBMITTED' | 'APPROVED' | 'ACTIVE' | 'REJECTED' | 'INACTIVE' | 'RECALLED'
       /** The username of the person who is updating this status */
       username: string
+      /** The full name of the person who is updating this status */
+      fullName?: string
     }
     ErrorResponse: {
       status: number
@@ -331,6 +333,8 @@ export interface components {
       approvedDate?: string
       /** The username who approved the licence on behalf of the prison governor */
       approvedByUsername?: string
+      /** The full name of the person who approved the licence on behalf of the prison governor */
+      approvedByName?: string
       /** The date and time that this licence was superseded by a new variant */
       supersededDate?: string
       /** The date and time that this licence was first created */

--- a/server/config/conditions.ts
+++ b/server/config/conditions.ts
@@ -194,12 +194,14 @@ export default {
       code: '4858cd8b-bca6-4f11-b6ee-439e27216d7d',
       category: 'Making or maintaining contact with a person',
       text: 'Not to seek to approach or communicate with [INSERT NAME OF VICTIM AND / OR FAMILY MEMBERS] without the prior approval of your supervising officer and / or [INSERT NAME OF APPROPRIATE SOCIAL SERVICES DEPARTMENT].',
+      tpl: 'Not to seek to approach or communicate with {name} without the prior approval of your supervising officer and / or {socialServicesDepartment}.',
       requiresInput: true,
       inputs: [
         {
           type: InputTypes.TEXT,
           label: 'Enter name of victim or family member',
           name: 'name',
+          case: 'capitalise',
           addAnother: {
             label: 'Add another person',
           },
@@ -208,6 +210,7 @@ export default {
           type: InputTypes.TEXT,
           label: 'Enter the social services department',
           name: 'socialServicesDepartment',
+          case: 'capitalise',
           addAnother: {
             label: 'Add another social services department',
           },
@@ -265,12 +268,14 @@ export default {
       code: '355700a9-6184-40c0-9759-0dfed1994e1e',
       category: 'Making or maintaining contact with a person',
       text: 'Not to contact or associate with [NAMED OFFENDER(S) / NAMED INDIVIDUAL(S)] without the prior approval of your supervising officer.',
+      tpl: 'Not to contact or associate with {nameOfIndividual} without the prior approval of your supervising officer.',
       requiresInput: true,
       inputs: [
         {
           type: InputTypes.TEXT,
           label: 'Enter name of offender or individual',
           name: 'nameOfIndividual',
+          case: 'capitalise',
           addAnother: {
             label: 'Add another person',
           },
@@ -294,6 +299,7 @@ export default {
       code: '18b69f61-800f-46b2-95c4-2019d33e34d6',
       category: 'Making or maintaining contact with a person',
       text: 'Not to associate with any person currently or formerly associated with [NAMES OF SPECIFIC GROUPS OR ORGANISATIONS] without the prior approval of your supervising officer.',
+      tpl: 'Not to associate with any person currently or formerly associated with {nameOfOrganisation} without the prior approval of your supervising officer.',
       requiresInput: true,
       inputs: [
         {
@@ -423,6 +429,7 @@ export default {
       code: '3932e5c9-4d21-4251-a747-ce6dc52dc9c0',
       category: 'Possession, ownership, control or inspection of specified items or documents',
       text: 'Not to own or possess a [SPECIFIED ITEM] without the prior approval of your supervising officer.',
+      tpl: 'Not to own or possess a {item} without the prior approval of your supervising officer.',
       requiresInput: true,
       inputs: [
         {
@@ -538,6 +545,7 @@ export default {
       code: 'c2435d4a-20a0-47de-b080-e1e740d1514c',
       category: 'Curfew arrangement',
       text: 'Confine yourself to remain at [CURFEW ADDRESS] initially from [START OF CURFEW HOURS] until [END OF CURFEW HOURS] each day, and, thereafter, for such a period as may be reasonably notified to you by your supervising officer; and comply with such arrangements as may be reasonably put in place and notified to you by your supervising officer so as to allow for your whereabouts and your compliance with your curfew requirement be monitored (whether by electronic means involving your wearing an electronic tag or otherwise).',
+      tpl: 'Confine yourself to remain at {curfewAddress} initially from {curfewStart} until {curfewEnd} each day, and, thereafter, for such a period as may be reasonably notified to you by your supervising officer; and comply with such arrangements as may be reasonably put in place and notified to you by your supervising officer so as to allow for your whereabouts and your compliance with your curfew requirement be monitored (whether by electronic means involving your wearing an electronic tag or otherwise).',
       subtext: 'You must have PPCS approval if the curfew time is longer than 12 hours.',
       requiresInput: true,
       inputs: [
@@ -627,12 +635,14 @@ export default {
       category:
         'Supervision in the community by the supervising officer, or other responsible officer, or organisation',
       text: 'Report to staff at [NAME OF APPROVED PREMISES] at [TIME / DAILY], unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a [WEEKLY / MONTHLY / ETC] basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.',
+      tpl: 'Report to staff at {approvedPremises} at {reportingTime}, unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a {reviewPeriod} {alternativeReviewPeriod} basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.',
       requiresInput: true,
       inputs: [
         {
           type: InputTypes.TEXT,
           label: 'Enter name of approved premises',
           name: 'approvedPremises',
+          case: 'capitalised',
         },
         {
           type: InputTypes.TIME,
@@ -643,6 +653,7 @@ export default {
           type: InputTypes.RADIO,
           label: 'Select a review period',
           name: 'reviewPeriod',
+          case: 'lower',
           options: [
             {
               value: 'Weekly',

--- a/server/data/licenceApiClient.test.ts
+++ b/server/data/licenceApiClient.test.ts
@@ -247,22 +247,27 @@ describe('Licence API client tests', () => {
 
   describe('Licence status updates', () => {
     describe('Approved', () => {
-      const statusUpdateRequest = { status: LicenceStatus.APPROVED, username } as StatusUpdateRequest
+      const statusUpdateRequest = {
+        status: LicenceStatus.APPROVED,
+        username,
+        fullName: 'Joe Bloggs',
+      } as StatusUpdateRequest
+
       it('Update the licence to APPROVED', async () => {
         hmppsAuthClient.getSystemClientToken.mockResolvedValue('a token')
         fakeApi.put('/licence/id/1/status', statusUpdateRequest).reply(200)
-        await licenceService.updateStatus('1', LicenceStatus.APPROVED, username)
+        await licenceService.updateStatus('1', LicenceStatus.APPROVED, username, 'Joe Bloggs')
         expect(nock.isDone()).toBe(true)
         expect(hmppsAuthClient.getSystemClientToken).toBeCalled()
       })
     })
 
     describe('Rejected', () => {
-      const statusUpdateRequest = { status: LicenceStatus.REJECTED, username } as StatusUpdateRequest
+      const statusUpdateRequest = { status: LicenceStatus.REJECTED, username, fullName: null } as StatusUpdateRequest
       it('Update the licence to REJECTED', async () => {
         hmppsAuthClient.getSystemClientToken.mockResolvedValue('a token')
         fakeApi.put('/licence/id/1/status', statusUpdateRequest).reply(200)
-        await licenceService.updateStatus('1', LicenceStatus.REJECTED, username)
+        await licenceService.updateStatus('1', LicenceStatus.REJECTED, username, null)
         expect(nock.isDone()).toBe(true)
         expect(hmppsAuthClient.getSystemClientToken).toBeCalled()
       })

--- a/server/routes/approvingLicences/handlers/approvalView.test.ts
+++ b/server/routes/approvingLicences/handlers/approvalView.test.ts
@@ -6,6 +6,7 @@ import LicenceStatus from '../../../enumeration/licenceStatus'
 
 const licenceService = new LicenceService(null, null, null) as jest.Mocked<LicenceService>
 const username = 'joebloggs'
+const displayName = 'Joe Bloggs'
 
 describe('Route - view and approve a licence', () => {
   const handler = new ApprovalViewRoutes(licenceService)
@@ -28,7 +29,7 @@ describe('Route - view and approve a licence', () => {
         render: jest.fn(),
         redirect: jest.fn(),
         locals: {
-          user: { username },
+          user: { username, displayName },
           licence: {
             id: 1,
             statusCode: LicenceStatus.SUBMITTED,
@@ -49,7 +50,7 @@ describe('Route - view and approve a licence', () => {
         render: jest.fn(),
         redirect: jest.fn(),
         locals: {
-          user: { username },
+          user: { username, displayName },
           licence: {
             id: 1,
             statusCode: LicenceStatus.APPROVED,
@@ -70,7 +71,7 @@ describe('Route - view and approve a licence', () => {
     res = {
       render: jest.fn(),
       redirect: jest.fn(),
-      locals: { user: { username } },
+      locals: { user: { username, displayName } },
     } as unknown as Response
 
     it('should approve a licence', async () => {
@@ -79,7 +80,7 @@ describe('Route - view and approve a licence', () => {
       } as unknown as Request
 
       await handler.POST(req, res)
-      expect(licenceService.updateStatus).toHaveBeenCalledWith('1', LicenceStatus.APPROVED, username)
+      expect(licenceService.updateStatus).toHaveBeenCalledWith('1', LicenceStatus.APPROVED, username, displayName)
       expect(res.redirect).toHaveBeenCalledWith('/licence/approve/id/1/confirm-approved')
     })
 

--- a/server/routes/approvingLicences/handlers/approvalView.ts
+++ b/server/routes/approvingLicences/handlers/approvalView.ts
@@ -17,7 +17,7 @@ export default class ApprovalViewRoutes {
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {
-    const { username } = res.locals.user
+    const { username, displayName } = res.locals.user
     const { licenceId, result } = req.body
     switch (result) {
       case 'reject': {
@@ -26,7 +26,7 @@ export default class ApprovalViewRoutes {
         break
       }
       case 'approve': {
-        await this.licenceService.updateStatus(licenceId, LicenceStatus.APPROVED, username)
+        await this.licenceService.updateStatus(licenceId, LicenceStatus.APPROVED, username, displayName)
         res.redirect(`/licence/approve/id/${licenceId}/confirm-approved`)
         break
       }

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -200,9 +200,9 @@ export default class LicenceService {
     return new LicenceApiClient(token).updateBespokeConditions(id, requestBody)
   }
 
-  async updateStatus(id: string, newStatus: LicenceStatus, username: string): Promise<void> {
+  async updateStatus(id: string, newStatus: LicenceStatus, username: string, fullName: string = null): Promise<void> {
     const token = await this.hmppsAuthClient.getSystemClientToken(username)
-    const requestBody = { status: newStatus, username } as StatusUpdateRequest
+    const requestBody = { status: newStatus, username, fullName } as StatusUpdateRequest
     return new LicenceApiClient(token).updateLicenceStatus(id, requestBody)
   }
 

--- a/server/views/pages/licence/AP.njk
+++ b/server/views/pages/licence/AP.njk
@@ -23,9 +23,6 @@
 {% set offenderName = licence.forename + " " + licence.surname %}
 {% set pageTitle = offenderName %}
 
-{# TODO: Store the approver's full name at time of approval #}
-{% set approverName = licence.approvedByUsername %}
-
 {% block content %}
     {{ title(offenderName) }}
     {{ offender(licence.dateOfBirth, licence.licenceExpiryDate, licence.nomsId, imageData, htmlPrint) }}
@@ -37,6 +34,6 @@
     {{ cancellation() }}
     {{ recall() }}
     {{ failureToComply() }}
-    {{ signatures(licence.actualReleaseDate, approverName, licence.approvedDate, offenderName) }}
+    {{ signatures(licence.actualReleaseDate, licence.approvedByName, licence.approvedDate, offenderName) }}
     {{ footer(licence.nomsId, licence.pnc, licence.cro, licence.bookingNo, licence.typeCode, licence.id, licence.version, licence.prisonCode) }}
 {% endblock %}

--- a/server/views/pages/licence/AP_PSS.njk
+++ b/server/views/pages/licence/AP_PSS.njk
@@ -22,9 +22,6 @@
 {% set offenderName = licence.forename + " " + licence.surname %}
 {% set pageTitle = offenderName %}
 
-{# TODO: Store the approver's full name at time of approval #}
-{% set approverName = licence.approvedByUsername %}
-
 {% block content %}
     {{ title(offenderName) }}
     {{ offender(licence.dateOfBirth, licence.licenceExpiryDate, licence.nomsId, imageData, htmlPrint) }}
@@ -36,6 +33,6 @@
     {{ cancellation() }}
     {{ recall() }}
     {{ failureToComply() }}
-    {{ signatures(licence.actualReleaseDate, approverName, licence.approvedDate, offenderName) }}
+    {{ signatures(licence.actualReleaseDate, licence.approvedByName, licence.approvedDate, offenderName) }}
     {{ footer(licence.nomsId, licence.pnc, licence.cro, licence.bookingNo, licence.typeCode, licence.id, licence.version, licence.prisonCode) }}
 {% endblock %}

--- a/server/views/pages/licence/PSS.njk
+++ b/server/views/pages/licence/PSS.njk
@@ -23,9 +23,6 @@
 {% set offenderName = licence.forename + " " + licence.surname %}
 {% set pageTitle = offenderName %}
 
-{# TODO: Store the approver's full name at time of approval #}
-{% set approverName = licence.approvedByUsername %}
-
 {% block content %}
     {{ title(offenderName) }}
     {{ offender(licence.dateOfBirth, licence.licenceExpiryDate, licence.nomsId, imageData, htmlPrint) }}
@@ -37,6 +34,6 @@
     {{ cancellation() }}
     {{ recall() }}
     {{ failureToComply() }}
-    {{ signatures(licence.actualReleaseDate, approverName, licence.approvedDate, offenderName) }}
+    {{ signatures(licence.actualReleaseDate, licence.approvedByName, licence.approvedDate, offenderName) }}
     {{ footer(licence.nomsId, licence.pnc, licence.cro, licence.bookingNo, licence.typeCode, licence.id, licence.version, licence.prisonCode) }}
 {% endblock %}


### PR DESCRIPTION
* Use stored approver's name in signatures
* Supply approvers full name in status change for approval.
* Add missing .tpl templates for newly entered conditions.