### PR TITLE
CVSL-208: Integration test for view and print licence journey.

### DIFF
--- a/integration_tests/integration/approveLicence.spec.ts
+++ b/integration_tests/integration/approveLicence.spec.ts
@@ -9,7 +9,7 @@ context('Approve a licence', () => {
     cy.task('stubGetPrisonUserDetails')
     cy.task('stubGetPrisonUserCaseloads')
     cy.task('stubGetCompletedLicence', 'SUBMITTED')
-    cy.task('stubGetLicencesForApproval')
+    cy.task('stubGetLicencesForStatus', 'SUBMITTED')
     cy.task('stubUpdateLicenceStatus', 1)
     cy.signIn()
   })

--- a/integration_tests/integration/rejectLicence.spec.ts
+++ b/integration_tests/integration/rejectLicence.spec.ts
@@ -9,7 +9,7 @@ context('Reject a licence', () => {
     cy.task('stubGetPrisonUserDetails')
     cy.task('stubGetPrisonUserCaseloads')
     cy.task('stubGetCompletedLicence', 'SUBMITTED')
-    cy.task('stubGetLicencesForApproval')
+    cy.task('stubGetLicencesForStatus', 'SUBMITTED')
     cy.task('stubUpdateLicenceStatus', 1)
     cy.signIn()
   })

--- a/integration_tests/integration/viewAndPrintLicence.spec.ts
+++ b/integration_tests/integration/viewAndPrintLicence.spec.ts
@@ -1,0 +1,23 @@
+import Page from '../pages/page'
+import IndexPage from '../pages'
+
+context('View and print licence', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubPrisonSignIn')
+    cy.task('stubAuthUser')
+    cy.task('stubGetPrisonUserDetails')
+    cy.task('stubGetPrisonUserCaseloads')
+    cy.task('stubGetCompletedLicence', 'APPROVED')
+    cy.task('stubGetLicencesForStatus', 'APPROVED')
+    cy.signIn()
+  })
+
+  it('should click through the view and print a licence journey', () => {
+    const indexPage = Page.verifyOnPage(IndexPage)
+    const viewCasesList = indexPage.clickViewAndPrintALicence()
+    const viewLicencePage = viewCasesList.clickALicence()
+    const printALicencePage = viewLicencePage.printALicence()
+    printALicencePage.checkPrintTemplate()
+  })
+})

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -173,7 +173,7 @@ export default {
       favicon(),
       redirect(),
       signOut(),
-      token(['ROLE_LICENCE_DM'], 'nomis'),
+      token(['ROLE_LICENCE_DM', 'ROLE_LICENCE_CA'], 'nomis'),
       tokenVerification.stubVerifyToken(),
     ]),
   stubUser: (): Promise<[Response, Response, Response]> =>

--- a/integration_tests/mockApis/licence.ts
+++ b/integration_tests/mockApis/licence.ts
@@ -355,7 +355,7 @@ export default {
     })
   },
 
-  stubGetLicencesForApproval: (): SuperAgentRequest => {
+  stubGetLicencesForStatus: (status: string): SuperAgentRequest => {
     return stubFor({
       request: {
         method: 'GET',
@@ -376,7 +376,7 @@ export default {
           {
             licenceId: licencePlaceholder.id,
             licenceType: licencePlaceholder.typeCode,
-            licenceStatus: 'SUBMITTED',
+            licenceStatus: status,
             nomisId: licencePlaceholder.nomsId,
             surname: licencePlaceholder.surname,
             forename: licencePlaceholder.forename,

--- a/integration_tests/pages/index.ts
+++ b/integration_tests/pages/index.ts
@@ -1,11 +1,14 @@
 import Page from './page'
 import CaseloadPage from './caseload'
 import ApprovalCasesPage from './approvalCases'
+import ViewCasesPage from './viewCases'
 
 export default class IndexPage extends Page {
   private createLicenceTileId = '#createLicenceCard'
 
   private approveLicenceTileId = '#approveLicenceCard'
+
+  private viewAndPrintTiledId = '#viewLicenceCard'
 
   constructor() {
     super('index-page')
@@ -25,5 +28,10 @@ export default class IndexPage extends Page {
   clickApproveALicence = (): ApprovalCasesPage => {
     cy.get(this.approveLicenceTileId).click()
     return Page.verifyOnPage(ApprovalCasesPage)
+  }
+
+  clickViewAndPrintALicence = (): ViewCasesPage => {
+    cy.get(this.viewAndPrintTiledId).click()
+    return Page.verifyOnPage(ViewCasesPage)
   }
 }

--- a/integration_tests/pages/printLicenceHtmlPage.ts
+++ b/integration_tests/pages/printLicenceHtmlPage.ts
@@ -1,0 +1,26 @@
+import Page from './page'
+
+export default class PrintLicenceHtmlPage extends Page {
+  constructor() {
+    // No specific page id on printed document so uses the first mandatory section id to verify
+    super('supervision', false)
+  }
+
+  checkPrintTemplate = (): PrintLicenceHtmlPage => {
+    // Verify the structure and key details of the licence document
+    cy.get('#title').should('contain', 'Licence for Bob Zimmer')
+    cy.get('#offender').should('be.visible').should('contain', '12th February 1980')
+    cy.get('#offender-image').should('be.visible')
+    cy.get('#objectives').should('be.visible')
+    cy.get('#supervision').should('be.visible')
+    cy.get('#induction').should('be.visible')
+    cy.get('#released-to-other').should('be.visible')
+    cy.get('#conditions').should('be.visible')
+    cy.get('.condition').should('have.length', 10)
+    cy.get('#cancellation').should('be.visible')
+    cy.get('#recall').should('be.visible')
+    cy.get('#failure-to-comply').should('be.visible')
+    cy.get('.boxed .signatures').should('be.visible')
+    return this
+  }
+}

--- a/integration_tests/pages/viewALicence.ts
+++ b/integration_tests/pages/viewALicence.ts
@@ -1,0 +1,21 @@
+import Page from './page'
+import PrintLicenceHtmlPage from './printLicenceHtmlPage'
+
+export default class ViewALicencePage extends Page {
+  constructor() {
+    super('print-view-page')
+  }
+
+  printALicence = (): PrintLicenceHtmlPage => {
+    // This checks the print button and overrides its attributes to reference a html page rather than a PDF
+    cy.contains('a', 'Print licence')
+      .should($a => {
+        expect($a.attr('href'), 'href').to.equal('/licence/view/id/1/pdf-print')
+        expect($a.attr('target'), 'target').to.equal('_blank')
+        $a.attr('target', '_self')
+        $a.attr('href', '/licence/view/id/1/html-print')
+      })
+      .click()
+    return Page.verifyOnPage(PrintLicenceHtmlPage)
+  }
+}

--- a/integration_tests/pages/viewCases.ts
+++ b/integration_tests/pages/viewCases.ts
@@ -1,0 +1,13 @@
+import Page from './page'
+import ViewALicencePage from './viewALicence'
+
+export default class ViewCasesPage extends Page {
+  constructor() {
+    super('view-cases-page')
+  }
+
+  clickALicence = (): ViewALicencePage => {
+    cy.contains('td button', 'Bob Zimmer').click()
+    return Page.verifyOnPage(ViewALicencePage)
+  }
+}

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -32,7 +32,7 @@ export default (on: (string, Record) => void): void => {
     stubPutAdditionalConditionData: licence.stubPutAdditionalConditionData,
     stubGetLicencesByStaffIdAndStatus: licence.stubGetLicencesByStaffIdAndStatus,
     stubUpdateLicenceStatus: licence.stubUpdateLicenceStatus,
-    stubGetLicencesForApproval: licence.stubGetLicencesForApproval,
+    stubGetLicencesForStatus: licence.stubGetLicencesForStatus,
     stubGetCompletedLicence: licence.stubGetCompletedLicence,
 
     stubGetStaffDetails: community.stubGetStaffDetails,


### PR DESCRIPTION
This PR:
* Creates page objects for view cases, view licence and HTML printed licence
* Implements a click-through journey to view and print a licence
* Verifies accessibility of pages
* Verifies that the printed licence contains key structure and data items.
* It overrides the PDF print link with the HTML version (same stylesheet, structure and content, just easier to verify :-) )