### PR TITLE
CVSL-220: Remove "Add another" from social services department fields in additional conditions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     image: quay.io/hmpps/create-and-vary-a-licence-api:latest
     networks:
       - hmpps
-    container_name: creare-and-vary-a-licence-api
+    container_name: create-and-vary-a-licence-api
     restart: always
     ports:
       - "8089:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,19 +11,6 @@ services:
     ports:
       - '6379:6379'
 
-  hmpps-auth:
-    image: quay.io/hmpps/hmpps-auth:latest
-    networks:
-      - hmpps
-    container_name: hmpps-auth 
-    ports:
-      - "9090:8080"
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/auth/health"]
-    environment:
-      - SPRING_PROFILES_ACTIVE=dev
-      - DELIUS_ENABLED=false
-
   # For the API to seed & interact with - there is no direct connection from the UI service
   licences-db:
     image: postgres
@@ -38,17 +25,19 @@ services:
       - POSTGRES_USER=create-and-vary-a-licence
       - POSTGRES_DB=create-and-vary-a-licence-db
 
-  prison-api:
-    image: quay.io/hmpps/prison-api:latest
+  create-and-vary-a-licence-api:
+    image: quay.io/hmpps/create-and-vary-a-licence-api
     networks:
       - hmpps
-    container_name: prison-api
+    container_name: creare-and-vary-a-licence-api
+    restart: always
     ports:
-      - "8080:8080"
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+      - "8089:8080"
     environment:
-      - SPRING_PROFILES_ACTIVE=nomis-hsqldb
+      - DB_USER=create-and-vary-a-licence
+      - DB_PASS=create-and-vary-a-licence
+      - HMPPS_AUTH_URL=https://sign-in-dev.hmpps.service.justice.gov.uk/auth
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://host.docker.internal/create-and-vary-a-licence-db
 
   gotenberg:
     image: thecodingmachine/gotenberg:6.4.3
@@ -60,6 +49,18 @@ services:
     restart: always
     healthcheck:
       test: [ 'CMD', 'curl', '-f', 'http://localhost:3000/ping' ]
+
+  delius-wiremock:
+    image: smcveigh941/delius-wiremock
+    networks:
+      - hmpps
+    container_name: delius-wiremock
+    env_file:
+      - ./.env
+    ports:
+      - "5000:5000"
+    healthcheck:
+      test: [ 'CMD', 'curl', '-f', 'http://localhost:5000/actuator/health' ]
 
 networks:
   hmpps:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - POSTGRES_DB=create-and-vary-a-licence-db
 
   create-and-vary-a-licence-api:
-    image: quay.io/hmpps/create-and-vary-a-licence-api
+    image: quay.io/hmpps/create-and-vary-a-licence-api:latest
     networks:
       - hmpps
     container_name: creare-and-vary-a-licence-api

--- a/server/config/conditions.ts
+++ b/server/config/conditions.ts
@@ -239,10 +239,6 @@ export default {
           label: 'Enter social services department (optional)',
           name: 'socialServicesDepartment',
           case: 'capitalise',
-          listType: 'AND',
-          addAnother: {
-            label: 'Add another social services department',
-          },
         },
       ],
       type: NoContactWithVictim,
@@ -289,10 +285,6 @@ export default {
           label: 'Enter social services department (optional)',
           name: 'socialServicesDepartment',
           case: 'capitalise',
-          listType: 'AND',
-          addAnother: {
-            label: 'Add another social services department',
-          },
         },
       ],
       type: UnsupervisedContact,

--- a/server/routes/creatingLicences/types/additionalConditionInputs/noContactWithVictim.ts
+++ b/server/routes/creatingLicences/types/additionalConditionInputs/noContactWithVictim.ts
@@ -9,8 +9,7 @@ class NoContactWithVictim {
   name: string[]
 
   @Expose()
-  @RemoveEmptyArrayItems()
-  socialServicesDepartment: string[]
+  socialServicesDepartment: string
 }
 
 export default NoContactWithVictim

--- a/server/routes/creatingLicences/types/additionalConditionInputs/unsupervisedContact.ts
+++ b/server/routes/creatingLicences/types/additionalConditionInputs/unsupervisedContact.ts
@@ -1,6 +1,5 @@
 import { Expose } from 'class-transformer'
 import { IsNotEmpty } from 'class-validator'
-import RemoveEmptyArrayItems from '../../../../transformers/removeEmptyArrayItems'
 
 class UnsupervisedContact {
   @Expose()
@@ -12,8 +11,7 @@ class UnsupervisedContact {
   age: string
 
   @Expose()
-  @RemoveEmptyArrayItems()
-  socialServicesDepartment: string[]
+  socialServicesDepartment: string
 }
 
 export default UnsupervisedContact

--- a/server/routes/creatingLicences/types/address.ts
+++ b/server/routes/creatingLicences/types/address.ts
@@ -24,8 +24,7 @@ class Address extends Stringable {
   addressPostcode: string
 
   stringify(): string {
-    if (Object.values(this).join('').length > 0) return Object.values(this).join(', ')
-    return ''
+    return Object.values(this).join(', ')
   }
 
   static fromString(value: string): Address {

--- a/server/routes/creatingLicences/types/address.ts
+++ b/server/routes/creatingLicences/types/address.ts
@@ -24,7 +24,8 @@ class Address extends Stringable {
   addressPostcode: string
 
   stringify(): string {
-    return Object.values(this).join(', ')
+    if (Object.values(this).join('').length > 0) return Object.values(this).join(', ')
+    return ''
   }
 
   static fromString(value: string): Address {

--- a/server/routes/creatingLicences/types/time.ts
+++ b/server/routes/creatingLicences/types/time.ts
@@ -25,10 +25,7 @@ class SimpleTime extends Stringable {
   ampm: AmPm
 
   stringify(): string {
-    if (this.hour && this.minute && this.ampm) {
-      return this.toMoment().format('hh:mm a')
-    }
-    return ''
+    return this.toMoment().format('hh:mm a')
   }
 
   toMoment(): Moment {

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -20,6 +20,7 @@ import {
   convertDateFormat,
   convertToTitleCase,
   filterCentralCaseload,
+  objectIsEmpty,
   simpleDateTimeToJson,
 } from '../utils/utils'
 import PersonName from '../routes/creatingLicences/types/personName'
@@ -163,7 +164,7 @@ export default class LicenceService {
 
     const requestBody = {
       data: Object.keys(formData)
-        .filter(key => formData[key])
+        .filter(key => formData[key] && !objectIsEmpty(formData[key]))
         .flatMap((key, index) => {
           // The POST request to the API will only accept an array of objects where value is a string.
           // Therefore, if the type of data entered from the form is an array or an object, we need to convert that to a string type.


### PR DESCRIPTION
- Removed "Add another" options from social services department as agreed
- Do not persist empty date/time/address in the case that they are optional fields
- Configured `docker-compose.yml` to run `create-and-vary-a-licence-api` as a container locally for convenience & local dev (still uses auth in dev)