### PR TITLE
CVSL-27: Add google tag manager id to the service

### DIFF
--- a/helm_deploy/create-and-vary-a-licence/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence/values.yaml
@@ -40,6 +40,7 @@ generic-service:
       SYSTEM_CLIENT_ID: "SYSTEM_CLIENT_ID"
       SYSTEM_CLIENT_SECRET: "SYSTEM_CLIENT_SECRET"
       SESSION_SECRET: "SESSION_SECRET"
+      TAG_MANAGER_CONTAINER_ID: "TAG_MANAGER_CONTAINER_ID"
     elasticache-redis:
       REDIS_HOST: "primary_endpoint_address"
       REDIS_AUTH_TOKEN: "auth_token"

--- a/server/config.ts
+++ b/server/config.ts
@@ -140,4 +140,7 @@ export default {
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   exitSurveyLink: get('EXIT_SURVEY_LINK', 'https://exit-survey-placeholder-link', requiredInProduction),
   phaseBannerLink: get('PHASE_BANNER_LINK', 'https://phase-banner-placeholder-link', requiredInProduction),
+  analytics: {
+    tagManagerContainerId: get('TAG_MANAGER_CONTAINER_ID', ''),
+  },
 }

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -15,6 +15,8 @@ export default function setUpWebSecurity(): Router {
           defaultSrc: ["'self'"],
           // Hash allows inline script pulled in from https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/template.njk
           scriptSrc: ["'self'", 'code.jquery.com', "'sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU='"],
+          imgSrc: ["'self'", 'www.googletagmanager.com', 'www.googleanalytics.com', 'https://code.jquery.com'],
+          connectSrc: ["'self'", 'www.googletagmanager.com', 'www.google-analytics.com'],
           styleSrc: ["'self'", 'code.jquery.com'],
           fontSrc: ["'self'"],
         },

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -53,6 +53,13 @@ export function registerNunjucks(app?: express.Express): Environment {
     }
   )
 
+  // Expose the google tag manager container ID to the nunjucks environment
+  const {
+    analytics: { tagManagerContainerId },
+  } = config
+
+  njkEnv.addGlobal('tagManagerContainerId', tagManagerContainerId)
+
   njkEnv.addFilter('initialiseName', (fullName: string) => {
     // this check is for the authError page
     if (!fullName) {

--- a/server/views/layout.njk
+++ b/server/views/layout.njk
@@ -5,6 +5,17 @@
 {% set continueOrReturnToCheckAnswers = "Return to check your answers" if fromReview else "Continue" %}
 
 {% block head %}
+
+  {% if tagManagerContainerId %}
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+              j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+              'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','{{tagManagerContainerId}}');</script>
+    <!-- End Google Tag Manager -->
+  {% endif %}
+
   <!--[if !IE 8]><!-->
   <link href="/assets/stylesheets/application.css?{{ version }}" rel="stylesheet"/>
   <!--<![endif]-->
@@ -29,6 +40,13 @@
 {% endblock %}
 
 {% block bodyStart %}
+  {% if tagManagerContainerId %}
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe src="https://www.googletagmanager.com/ns.html?id={{tagManagerContainerId}} | safe }}"height="0" width="0" style="display:none;visibility:hidden"></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+  {% endif %}
 {% endblock %}
 
 {% block beforeContent %}


### PR DESCRIPTION
* Also added TAG_MANAGER_CONTAINER_ID into dev K8s secrets.
* Setup two GA properties (CVL-prod, CVL-non-prod)
* Setup two GTM containers (CVL-dev, CVL-preprod)
* Setup two data streams in GA to send GA4 analytics to GA non-prod property.
* Only one way to see if all this works.. 