### PR TITLE
CVSL-234: Fix add another validation + back link from error

### DIFF
--- a/assets/js/govukFrontendInit.js
+++ b/assets/js/govukFrontendInit.js
@@ -3,5 +3,9 @@ window.GOVUKFrontend.initAll()
 // Initiate the back links
 $('[class$=js-backlink]').click(e => {
   e.preventDefault()
-  window.history.go(-1)
+  if ($('ul.govuk-error-summary__list').length > 0) {
+    window.history.go(-2)
+  } else {
+    window.history.go(-1)
+  }
 })

--- a/server/routes/creatingLicences/types/additionalConditionInputs/drugTestLocation.ts
+++ b/server/routes/creatingLicences/types/additionalConditionInputs/drugTestLocation.ts
@@ -5,7 +5,7 @@ import { Either } from '../../../../validators/decorators'
 
 class DrugTestLocation {
   @Expose()
-  @IsNotEmpty({ message: 'Enter the name of the meeting' })
+  @IsNotEmpty({ message: 'Enter a name' })
   @Either('address')
   name: string
 

--- a/server/routes/creatingLicences/types/additionalConditionInputs/namedIndividuals.ts
+++ b/server/routes/creatingLicences/types/additionalConditionInputs/namedIndividuals.ts
@@ -1,9 +1,9 @@
 import { Expose } from 'class-transformer'
-import { ArrayNotEmpty } from 'class-validator'
+import { HasAtLeastOne } from '../../../../validators/decorators'
 
 class NamedIndividuals {
   @Expose()
-  @ArrayNotEmpty({ message: 'Add at least one offender or individual' })
+  @HasAtLeastOne({ message: 'Add at least one offender or individual' })
   nameOfIndividual: string[]
 }
 

--- a/server/routes/creatingLicences/types/additionalConditionInputs/namedOrganisation.ts
+++ b/server/routes/creatingLicences/types/additionalConditionInputs/namedOrganisation.ts
@@ -1,9 +1,9 @@
 import { Expose } from 'class-transformer'
-import { ArrayNotEmpty } from 'class-validator'
+import { HasAtLeastOne } from '../../../../validators/decorators'
 
 class NamedOrganisation {
   @Expose()
-  @ArrayNotEmpty({ message: 'Add at least one group or organisation' })
+  @HasAtLeastOne({ message: 'Add at least one group or organisation' })
   nameOfOrganisation: string[]
 }
 

--- a/server/routes/creatingLicences/types/additionalConditionInputs/noContactWithVictim.ts
+++ b/server/routes/creatingLicences/types/additionalConditionInputs/noContactWithVictim.ts
@@ -1,9 +1,9 @@
 import { Expose } from 'class-transformer'
-import { ArrayNotEmpty } from 'class-validator'
+import { HasAtLeastOne } from '../../../../validators/decorators'
 
 class NoContactWithVictim {
   @Expose()
-  @ArrayNotEmpty({ message: 'Add at least one victim or family member name' })
+  @HasAtLeastOne({ message: 'Add at least one victim or family member name' })
   name: string[]
 
   @Expose()

--- a/server/routes/creatingLicences/types/additionalConditionInputs/specifiedItem.ts
+++ b/server/routes/creatingLicences/types/additionalConditionInputs/specifiedItem.ts
@@ -1,9 +1,9 @@
 import { Expose } from 'class-transformer'
-import { ArrayNotEmpty } from 'class-validator'
+import { HasAtLeastOne } from '../../../../validators/decorators'
 
 class SpecifiedItem {
   @Expose()
-  @ArrayNotEmpty({ message: 'Add at least one item' })
+  @HasAtLeastOne({ message: 'Add at least one item' })
   item: string[]
 }
 

--- a/server/validators/decorators.ts
+++ b/server/validators/decorators.ts
@@ -1,6 +1,7 @@
 import { registerDecorator, ValidateIf, ValidationOptions } from 'class-validator'
 import isSimpleTimeAfter from './isSimpleTimeAfter'
 import { objectIsEmpty } from '../utils/utils'
+import hasAtLeastOne from './hasAtLeastOne'
 
 export function IsSimpleTimeAfter(property: string, validationOptions?: ValidationOptions) {
   return (object: unknown, propertyName: string) => {
@@ -11,6 +12,18 @@ export function IsSimpleTimeAfter(property: string, validationOptions?: Validati
       constraints: [property],
       options: validationOptions,
       validator: { validate: isSimpleTimeAfter },
+    })
+  }
+}
+
+export function HasAtLeastOne(validationOptions?: ValidationOptions) {
+  return (object: unknown, propertyName: string) => {
+    registerDecorator({
+      name: 'hasAtLeastOne',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: { validate: hasAtLeastOne },
     })
   }
 }

--- a/server/validators/hasAtLeastOne.test.ts
+++ b/server/validators/hasAtLeastOne.test.ts
@@ -1,0 +1,38 @@
+import hasAtLeastOne from './hasAtLeastOne'
+
+describe('hasAtLeastOne', () => {
+  it('should return false if the field being validated is an empty array', () => {
+    const value: string[] = []
+    const result = hasAtLeastOne(value)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false if the field being validated is null', () => {
+    const value: string[] = null
+    const result = hasAtLeastOne(value)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false if the field being validated is an array of nulls', () => {
+    const value: string[] = [null, null]
+    const result = hasAtLeastOne(value)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return false if the field being validated is an array of empty strings', () => {
+    const value: string[] = ['', '']
+    const result = hasAtLeastOne(value)
+
+    expect(result).toBe(false)
+  })
+
+  it('should return true if the field being validated is an array with at least one non empty string', () => {
+    const value: string[] = ['', 'test']
+    const result = hasAtLeastOne(value)
+
+    expect(result).toBe(true)
+  })
+})

--- a/server/validators/hasAtLeastOne.ts
+++ b/server/validators/hasAtLeastOne.ts
@@ -1,0 +1,3 @@
+export default function hasAtLeastOne(value: string[]) {
+  return value?.filter(v => v).length > 0
+}


### PR DESCRIPTION
- Add another validation had been accepting `[""]` as a valid input
- New decorator filters out empty values before checking that the array is empty
- Also clicking the back link from a page with a validation error will direct to the page before, wheras it had been directing to the same page with the error message cleared