### PR TITLE
CVSL-218 Check your answers, view, print and approve a licence.

### DIFF
--- a/integration_tests/integration/createLicence.spec.ts
+++ b/integration_tests/integration/createLicence.spec.ts
@@ -46,7 +46,7 @@ context('Create a licence', () => {
 
     const bespokeConditionsQuestionPage = additionalConditionsInputPage
       .withContext(additionalConditionsPage.getContext())
-      .selectOption('London')
+      .selectOption('London Probation Region')
       .nextInput()
       .selectRadios()
       .nextInput()

--- a/integration_tests/mockApis/licence.ts
+++ b/integration_tests/mockApis/licence.ts
@@ -120,7 +120,7 @@ export default {
             {
               id: 3,
               code: 'a7c57e4e-30fe-4797-9fe7-70a35dbd7b65',
-              category: 'Participation in, or co-operation with, a programme or set of activities',
+              category: 'Programmes or activities',
               sequence: 2,
               text: 'To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your [ALCOHOL / DRUG / SEXUAL / VIOLENT / GAMBLING / SOLVENT ABUSE / ANGER / DEBT / PROLIFIC / OFFENDING BEHAVIOUR] problems.',
               data: [
@@ -141,7 +141,7 @@ export default {
             {
               id: 4,
               code: 'a7c57e4e-30fe-4797-9fe7-70a35dbd7b65',
-              category: 'Participation in, or co-operation with, a programme or set of activities',
+              category: 'Programmes or activities',
               sequence: 3,
               text: 'Confine yourself to an address approved by your supervising officer between the hours of [TIME] and [TIME] daily unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a [WEEKLY / MONTHLY / ETC] basis and may be amended or removed if it is felt that the level of risk that you present has reduced appropriately.',
               data: [
@@ -174,7 +174,7 @@ export default {
             {
               id: 5,
               code: '3932e5c9-4d21-4251-a747-ce6dc52dc9c0',
-              category: 'Possession, ownership, control or inspection of specified items or documents',
+              category: 'Items and documents',
               sequence: 4,
               text: 'Not to own or possess a [SPECIFIED ITEM] without the prior approval of your supervising officer.',
               data: [

--- a/integration_tests/pages/approvalView.ts
+++ b/integration_tests/pages/approvalView.ts
@@ -17,7 +17,8 @@ export default class ApprovalViewPage extends Page {
   }
 
   clickReject = (): ConfirmRejectPage => {
-    cy.get(this.rejectLicenceButtonId).click()
+    // Force: true will click even if a hidden element
+    cy.get(this.rejectLicenceButtonId).click({ force: true })
     return Page.verifyOnPage(ConfirmRejectPage)
   }
 }

--- a/integration_tests/pages/viewALicence.ts
+++ b/integration_tests/pages/viewALicence.ts
@@ -8,7 +8,7 @@ export default class ViewALicencePage extends Page {
 
   printALicence = (): PrintLicenceHtmlPage => {
     // This checks the print button and overrides its attributes to reference a html page rather than a PDF
-    cy.contains('a', 'Print licence')
+    cy.contains('a', 'Print')
       .should($a => {
         expect($a.attr('href'), 'href').to.equal('/licence/view/id/1/pdf-print')
         expect($a.attr('target'), 'target').to.equal('_blank')

--- a/server/config/conditions.ts
+++ b/server/config/conditions.ts
@@ -109,8 +109,8 @@ export default {
       {
         code: '5db26ab3-9b6f-4bee-b2aa-53aa3f3be7dd',
         category: 'Residence at a specific place',
-        text: 'You must reside within the [INSERT REGION] probation region while of no fixed abode, unless otherwise approved by your supervising officer.',
-        tpl: 'You must reside within the {probationRegion} probation region while of no fixed abode, unless otherwise approved by your supervising officer.',
+        text: 'You must reside within the [INSERT REGION] while of no fixed abode, unless otherwise approved by your supervising officer.',
+        tpl: 'You must reside within the {probationRegion} while of no fixed abode, unless otherwise approved by your supervising officer.',
         requiresInput: true,
         inputs: [
           {
@@ -120,28 +120,40 @@ export default {
             case: 'capitalised',
             options: [
               {
-                value: 'London',
+                value: 'North East Probation Region',
               },
               {
-                value: 'Midlands',
+                value: 'North West Probation Region',
               },
               {
-                value: 'North East',
+                value: 'Greater Manchester Probation Region',
               },
               {
-                value: 'North West',
+                value: 'Yorkshire and Humberside Probation Region',
               },
               {
-                value: 'South East',
+                value: 'East Midlands Probation Region',
               },
               {
-                value: 'South West',
+                value: 'West Midlands Probation Region',
               },
               {
-                value: 'South Central',
+                value: 'East of England Probation Region',
               },
               {
-                value: 'Wales',
+                value: 'South West Probation Region',
+              },
+              {
+                value: 'South Central Probation Region',
+              },
+              {
+                value: 'London Probation Region',
+              },
+              {
+                value: 'Kent, Surrey and Sussex Probation Region',
+              },
+              {
+                value: 'Wales Probation Region',
               },
             ],
           },
@@ -191,6 +203,7 @@ export default {
       {
         code: 'b72fdbf2-0dc9-4e7f-81e4-c2ccb5d1bc90',
         category: 'Making or maintaining contact with a person',
+        categoryShort: 'Contact with a person',
         text: 'Attend all appointments arranged for you with a [PSYCHIATRIST / PSYCHOLOGIST / MEDICAL PRACTITIONER].',
         tpl: 'Attend all appointments arranged for you with a {appointmentType}.',
         requiresInput: true,
@@ -219,12 +232,14 @@ export default {
       {
         code: '9ae2a336-3491-4667-aaed-dd852b09b4b9',
         category: 'Making or maintaining contact with a person',
+        categoryShort: 'Contact with a person',
         text: 'Receive home visits from a Mental Health Worker.',
         requiresInput: false,
       },
       {
         code: 'a7c57e4e-30fe-4797-9fe7-70a35dbd7b65',
         category: 'Making or maintaining contact with a person',
+        categoryShort: 'Contact with a person',
         text: 'Attend [INSERT APPOINTMENT TIME DATE AND ADDRESS], as directed, to address your dependency on, or propensity to misuse, a controlled drug.',
         tpl: 'Attend {appointmentAddress}{appointmentDate}{appointmentTime}, as directed, to address your dependency on, or propensity to misuse, a controlled drug.',
         requiresInput: true,
@@ -252,12 +267,14 @@ export default {
       {
         code: '75a6aac6-02a7-4414-af14-942be6736892',
         category: 'Making or maintaining contact with a person',
+        categoryShort: 'Contact with a person',
         text: 'Should you return to the UK and Islands before the expiry date of your licence then your licence conditions will be in force and you must report within two working days to your supervising officer.',
         requiresInput: false,
       },
       {
         code: '4858cd8b-bca6-4f11-b6ee-439e27216d7d',
         category: 'Making or maintaining contact with a person',
+        categoryShort: 'Contact with a person',
         text: 'Not to seek to approach or communicate with [INSERT NAME OF VICTIM AND / OR FAMILY MEMBERS] without the prior approval of your supervising officer and / or [INSERT NAME OF APPROPRIATE SOCIAL SERVICES DEPARTMENT].',
         tpl: 'Not to seek to approach or communicate with {name} without the prior approval of your supervising officer{socialServicesDepartment}.',
         requiresInput: true,
@@ -285,6 +302,7 @@ export default {
       {
         code: '4a5fed48-0fb9-4711-8ddf-b46ddfd90246',
         category: 'Making or maintaining contact with a person',
+        categoryShort: 'Contact with a person',
         text: 'Not to have unsupervised contact with [ANY / ANY FEMALE / ANY MALE] children under the age of [INSERT AGE] without the prior approval of your supervising officer and / or [INSERT NAME OF APPROPRIATE SOCIAL SERVICES DEPARTMENT] except where that contact is inadvertent and not reasonably avoidable in the course of lawful daily life.',
         tpl: 'Not to have unsupervised contact with {gender} children under the age of {age} without the prior approval of your supervising officer{socialServicesDepartment} except where that contact is inadvertent and not reasonably avoidable in the course of lawful daily life.',
         requiresInput: true,
@@ -332,6 +350,7 @@ export default {
       {
         code: '355700a9-6184-40c0-9759-0dfed1994e1e',
         category: 'Making or maintaining contact with a person',
+        categoryShort: 'Contact with a person',
         text: 'Not to contact or associate with [NAMED OFFENDER(S) / NAMED INDIVIDUAL(S)] without the prior approval of your supervising officer.',
         tpl: 'Not to contact or associate with {nameOfIndividual} without the prior approval of your supervising officer.',
         requiresInput: true,
@@ -352,18 +371,21 @@ export default {
       {
         code: '0aa669bf-db8a-4b8e-b8ba-ca82fc245b94',
         category: 'Making or maintaining contact with a person',
+        categoryShort: 'Contact with a person',
         text: 'Not to contact or associate with a known sex offender other than when compelled by attendance at a Treatment Programme or when residing at Approved Premises without the prior approval of your supervising officer.',
         requiresInput: false,
       },
       {
         code: 'cc80d02b-0b62-4940-bac6-0bcd374c725e',
         category: 'Making or maintaining contact with a person',
+        categoryShort: 'Contact with a person',
         text: 'Not to contact directly or indirectly any person who is a serving or remand prisoner or detained in State custody, without the prior approval of your supervising officer.',
         requiresInput: false,
       },
       {
         code: '18b69f61-800f-46b2-95c4-2019d33e34d6',
         category: 'Making or maintaining contact with a person',
+        categoryShort: 'Contact with a person',
         text: 'Not to associate with any person currently or formerly associated with [NAMES OF SPECIFIC GROUPS OR ORGANISATIONS] without the prior approval of your supervising officer.',
         tpl: 'Not to associate with any person currently or formerly associated with {nameOfOrganisation} without the prior approval of your supervising officer.',
         requiresInput: true,
@@ -383,6 +405,7 @@ export default {
       {
         code: '89e656ec-77e8-4832-acc4-6ec05d3e9a98',
         category: 'Participation in, or co-operation with, a programme or set of activities',
+        categoryShort: 'Programmes or activities',
         text: 'To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your alcohol / drug / sexual / violent / gambling / solvent abuse / anger / debt / prolific / offending behaviour problems at [NAME OF COURSE / CENTRE].',
         tpl: 'To comply with any requirements specified by your supervising officer for the purpose of ensuring that you address your {behaviourProblems} problems{course}.',
         requiresInput: true,
@@ -437,6 +460,7 @@ export default {
       {
         code: '9da214a3-c6ae-45e1-a465-12e22adf7c87',
         category: 'Participation in, or co-operation with, a programme or set of activities',
+        categoryShort: 'Programmes or activities',
         text: 'Not to undertake work or other organised activity which will involve a person under the age of [INSERT AGE], either on a paid or unpaid basis without the prior approval of your supervising officer.',
         tpl: 'Not to undertake work or other organised activity which will involve a person under the age of {age}, either on a paid or unpaid basis without the prior approval of your supervising officer.',
         requiresInput: true,
@@ -460,48 +484,56 @@ export default {
       {
         code: '8e52e16e-1abf-4251-baca-2fabfcb243d0',
         category: 'Possession, ownership, control or inspection of specified items or documents',
+        categoryShort: 'Items and documents',
         text: 'Not to own or possess more than one mobile phone or SIM card without the prior approval of your supervising officer and to provide your supervising officer with details of that mobile telephone or one you have regular use of, including the IMEI number and the SIM card that you possess.',
         requiresInput: false,
       },
       {
         code: '72d281c3-b194-43ab-812d-fea0683ada65',
         category: 'Possession, ownership, control or inspection of specified items or documents',
+        categoryShort: 'Items and documents',
         text: 'Not to own or possess a mobile phone with a photographic function without the prior approval of your supervising officer.',
         requiresInput: false,
       },
       {
         code: 'ed607a91-fe3a-4816-8eb9-b447c945935c',
         category: 'Possession, ownership, control or inspection of specified items or documents',
+        categoryShort: 'Items and documents',
         text: 'Not to own or use a camera without the prior approval of your supervising officer.',
         requiresInput: false,
       },
       {
         code: '680b3b27-43cc-46c6-9ba6-b10d4aba6531',
         category: 'Possession, ownership, control or inspection of specified items or documents',
+        categoryShort: 'Items and documents',
         text: 'To make any device capable of making or storing digital images (including a camera and a mobile phone with a camera function) available for inspection on request by your supervising officer and/or a police officer.',
         requiresInput: false,
       },
       {
         code: '5fa04bbf-6b7c-4b65-9388-a0115cd365a6',
         category: 'Possession, ownership, control or inspection of specified items or documents',
+        categoryShort: 'Items and documents',
         text: 'To surrender your passport(s) to your supervising officer and to notify your supervising officer of any intention to apply for a new passport.',
         requiresInput: false,
       },
       {
         code: 'bfbc693c-ab65-4042-920e-ddb085bc7aba',
         category: 'Possession, ownership, control or inspection of specified items or documents',
+        categoryShort: 'Items and documents',
         text: 'Not to use or access any computer or device which is internet enabled without the prior approval of your supervising officer; and only for the purpose, and only at a specific location, as specified by that officer.',
         requiresInput: false,
       },
       {
         code: '2d67f68a-8adf-47a9-a68d-a6fc9f2c4556',
         category: 'Possession, ownership, control or inspection of specified items or documents',
+        categoryShort: 'Items and documents',
         text: 'Not to delete the usage history on any internet enabled device or computer used and to allow such items to be inspected as required by the police or your supervising officer. Such inspection may include removal of the device for inspection and the installation of monitoring software.',
         requiresInput: false,
       },
       {
         code: '3932e5c9-4d21-4251-a747-ce6dc52dc9c0',
         category: 'Possession, ownership, control or inspection of specified items or documents',
+        categoryShort: 'Items and documents',
         text: 'Not to own or possess a [SPECIFIED ITEM] without the prior approval of your supervising officer.',
         tpl: 'Not to own or possess a {item} without the prior approval of your supervising officer.',
         requiresInput: true,
@@ -710,6 +742,7 @@ export default {
         code: '4673ebe4-9fc0-4e48-87c9-eb17d5280867',
         category:
           'Supervision in the community by the supervising officer, or other responsible officer, or organisation',
+        categoryShort: 'Supervision in the community',
         text: 'Report to staff at [NAME OF APPROVED PREMISES] at [TIME / DAILY], unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a [WEEKLY / MONTHLY / ETC] basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.',
         tpl: 'Report to staff at {approvedPremises} at {reportingTime}, unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a {alternativeReviewPeriod || reviewPeriod} basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.',
         requiresInput: true,
@@ -759,6 +792,7 @@ export default {
         code: '2027ae19-04a2-4fa6-8d1b-a62dffba2e62',
         category:
           'Supervision in the community by the supervising officer, or other responsible officer, or organisation',
+        categoryShort: 'Supervision in the community',
         text: 'Report to staff at [NAME OF POLICE STATION] at [TIME / DAILY], unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a [WEEKLY / MONTHLY / ETC] basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.',
         tpl: 'Report to staff at {policeStation} at {reportingTime}, unless otherwise authorised by your supervising officer. This condition will be reviewed by your supervising officer on a {alternativeReviewPeriod || reviewPeriod} basis and may be amended or removed if it is felt that the level of risk you present has reduced appropriately.',
         requiresInput: true,
@@ -807,6 +841,7 @@ export default {
       {
         code: '7a9ca3bb-922a-433a-9601-1e475c6c0095',
         category: 'Restriction of specified conduct or specified acts',
+        categoryShort: 'Restriction of conduct or acts',
         text: 'Not to participate directly or indirectly in organising and/or contributing to any demonstration, meeting, gathering or website without the prior approval of your supervising officer. This condition will be reviewed on a monthly basis and may be amended or removed if your risk is assessed as having changed.',
         requiresInput: false,
       },

--- a/server/routes/approvingLicences/handlers/approvalView.test.ts
+++ b/server/routes/approvingLicences/handlers/approvalView.test.ts
@@ -36,13 +36,19 @@ describe('Route - view and approve a licence', () => {
             surname: 'Bobson',
             forename: 'Bob',
             appointmentTime: '12/12/2022 14:16',
+            additionalLicenceConditions: [],
+            additionalPssConditions: [],
+            bespokeConditions: [],
           },
         },
       } as unknown as Response
 
       await handler.GET(req, res)
 
-      expect(res.render).toHaveBeenCalledWith('pages/approve/view')
+      expect(res.render).toHaveBeenCalledWith('pages/approve/view', {
+        expandedLicenceConditions: res.locals.licence.additionalLicenceConditions,
+        expandedPssConditions: res.locals.licence.additionalPssConditions,
+      })
     })
 
     it('should check status is SUBMITTED else redirect to case list', async () => {
@@ -57,6 +63,9 @@ describe('Route - view and approve a licence', () => {
             surname: 'Bobson',
             forename: 'Bob',
             appointmentTime: '12/12/2022 14:16',
+            additionalLicenceConditions: [],
+            additionalPssConditions: [],
+            bespokeConditions: [],
           },
         },
       } as unknown as Response

--- a/server/routes/approvingLicences/handlers/approvalView.ts
+++ b/server/routes/approvingLicences/handlers/approvalView.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import LicenceService from '../../../services/licenceService'
 import LicenceStatus from '../../../enumeration/licenceStatus'
+import { expandAdditionalConditions } from '../../../utils/conditionsProvider'
 
 export default class ApprovalViewRoutes {
   constructor(private readonly licenceService: LicenceService) {}
@@ -10,7 +11,9 @@ export default class ApprovalViewRoutes {
 
     // Check whether this licence is still in a SUBMITTED state - back button pressed - avoid re-approval
     if (licence?.statusCode === LicenceStatus.SUBMITTED) {
-      res.render('pages/approve/view')
+      const expandedLicenceConditions = expandAdditionalConditions(licence.additionalLicenceConditions)
+      const expandedPssConditions = expandAdditionalConditions(licence.additionalPssConditions)
+      res.render('pages/approve/view', { expandedLicenceConditions, expandedPssConditions })
     } else {
       res.redirect(`/licence/approve/cases`)
     }

--- a/server/routes/creatingLicences/handlers/additionalLicenceConditions.ts
+++ b/server/routes/creatingLicences/handlers/additionalLicenceConditions.ts
@@ -15,6 +15,7 @@ export default class AdditionalLicenceConditionsRoutes {
     const { licenceId } = req.params
     const { username } = req.user
 
+    // The LicenceType.AP is specified to differentiate the conditions from PSS conditions (ok for AP or AP_PSS)
     await this.licenceService.updateAdditionalConditions(licenceId, LicenceType.AP, req.body, username)
 
     return res.redirect(

--- a/server/routes/creatingLicences/handlers/additionalLicenceConditionsQuestion.ts
+++ b/server/routes/creatingLicences/handlers/additionalLicenceConditionsQuestion.ts
@@ -12,7 +12,6 @@ export default class AdditionalLicenceConditionsQuestionRoutes {
     if (answer === YesOrNo.YES) {
       return res.redirect(`/licence/create/id/${licenceId}/additional-licence-conditions`)
     }
-
     return res.redirect(`/licence/create/id/${licenceId}/bespoke-conditions-question`)
   }
 }

--- a/server/routes/creatingLicences/handlers/checkAnswers.test.ts
+++ b/server/routes/creatingLicences/handlers/checkAnswers.test.ts
@@ -33,6 +33,9 @@ describe('Route Handlers - Create Licence - Check Answers', () => {
           appointmentAddress: 'Down the road, over there',
           comTelephone: '07891245678',
           appointmentTime: '01/12/2021 00:34',
+          additionalLicenceConditions: [],
+          additionalPssConditions: [],
+          bespokeConditions: [],
         },
       },
     } as unknown as Response
@@ -41,7 +44,10 @@ describe('Route Handlers - Create Licence - Check Answers', () => {
   describe('GET', () => {
     it('should render view', async () => {
       await handler.GET(req, res)
-      expect(res.render).toHaveBeenCalledWith('pages/create/checkAnswers')
+      expect(res.render).toHaveBeenCalledWith('pages/create/checkAnswers', {
+        expandedLicenceConditions: res.locals.licence.additionalLicenceConditions,
+        expandedPssConditions: res.locals.licence.additionalPssConditions,
+      })
     })
   })
 

--- a/server/routes/creatingLicences/handlers/checkAnswers.ts
+++ b/server/routes/creatingLicences/handlers/checkAnswers.ts
@@ -6,12 +6,16 @@ import LicenceStatus from '../../../enumeration/licenceStatus'
 import { Licence } from '../../../@types/licenceApiClientTypes'
 import LicenceToSubmit from '../types/licenceToSubmit'
 import { FieldValidationError } from '../../../middleware/validationMiddleware'
+import { expandAdditionalConditions } from '../../../utils/conditionsProvider'
 
 export default class CheckAnswersRoutes {
   constructor(private readonly licenceService: LicenceService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
-    res.render('pages/create/checkAnswers')
+    const { licence } = res.locals
+    const expandedLicenceConditions = expandAdditionalConditions(licence.additionalLicenceConditions)
+    const expandedPssConditions = expandAdditionalConditions(licence.additionalPssConditions)
+    res.render('pages/create/checkAnswers', { expandedLicenceConditions, expandedPssConditions })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {

--- a/server/routes/viewingLicences/handlers/viewLicence.test.ts
+++ b/server/routes/viewingLicences/handlers/viewLicence.test.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 
 import ViewAndPrintLicenceRoutes from './viewLicence'
 import LicenceStatus from '../../../enumeration/licenceStatus'
+import { Licence } from '../../../@types/licenceApiClientTypes'
 
 const username = 'joebloggs'
 
@@ -9,6 +10,17 @@ describe('Route - view and approve a licence', () => {
   const handler = new ViewAndPrintLicenceRoutes()
   let req: Request
   let res: Response
+
+  const licence = {
+    id: 1,
+    statusCode: LicenceStatus.ACTIVE,
+    surname: 'Bobson',
+    forename: 'Bob',
+    appointmentTime: '12/12/2022 14:16',
+    additionalLicenceConditions: [],
+    additionalPssConditions: [],
+    bespokeConditions: [],
+  } as Licence
 
   beforeEach(() => {
     req = {
@@ -25,19 +37,16 @@ describe('Route - view and approve a licence', () => {
         redirect: jest.fn(),
         locals: {
           user: { username },
-          licence: {
-            id: 1,
-            statusCode: LicenceStatus.ACTIVE,
-            surname: 'Bobson',
-            forename: 'Bob',
-            appointmentTime: '12/12/2022 14:16',
-          },
+          licence,
         },
       } as unknown as Response
 
       await handler.GET(req, res)
 
-      expect(res.render).toHaveBeenCalledWith('pages/view/view')
+      expect(res.render).toHaveBeenCalledWith('pages/view/view', {
+        expandedLicenceConditions: res.locals.licence.additionalLicenceConditions,
+        expandedPssConditions: res.locals.licence.additionalPssConditions,
+      })
     })
 
     it('should render a single licence view for printing when APPROVED', async () => {
@@ -46,19 +55,16 @@ describe('Route - view and approve a licence', () => {
         redirect: jest.fn(),
         locals: {
           user: { username },
-          licence: {
-            id: 1,
-            statusCode: LicenceStatus.APPROVED,
-            surname: 'Bobson',
-            forename: 'Bob',
-            appointmentTime: '12/12/2022 14:16',
-          },
+          licence: { ...licence, statusCode: LicenceStatus.APPROVED },
         },
       } as unknown as Response
 
       await handler.GET(req, res)
 
-      expect(res.render).toHaveBeenCalledWith('pages/view/view')
+      expect(res.render).toHaveBeenCalledWith('pages/view/view', {
+        expandedLicenceConditions: res.locals.licence.additionalLicenceConditions,
+        expandedPssConditions: res.locals.licence.additionalPssConditions,
+      })
     })
 
     it('should not render view when status is IN_PROGRESS', async () => {
@@ -67,13 +73,7 @@ describe('Route - view and approve a licence', () => {
         redirect: jest.fn(),
         locals: {
           user: { username },
-          licence: {
-            id: 1,
-            statusCode: LicenceStatus.IN_PROGRESS,
-            surname: 'Bobson',
-            forename: 'Bob',
-            appointmentTime: '12/12/2022 14:16',
-          },
+          licence: { ...licence, statusCode: LicenceStatus.IN_PROGRESS },
         },
       } as unknown as Response
 

--- a/server/routes/viewingLicences/handlers/viewLicence.ts
+++ b/server/routes/viewingLicences/handlers/viewLicence.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express'
 import LicenceStatus from '../../../enumeration/licenceStatus'
+import { expandAdditionalConditions } from '../../../utils/conditionsProvider'
 
 export default class ViewAndPrintLicenceRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {
@@ -10,7 +11,9 @@ export default class ViewAndPrintLicenceRoutes {
       licence?.statusCode === LicenceStatus.SUBMITTED ||
       licence?.statusCode === LicenceStatus.REJECTED
     ) {
-      res.render('pages/view/view')
+      const expandedLicenceConditions = expandAdditionalConditions(licence.additionalLicenceConditions)
+      const expandedPssConditions = expandAdditionalConditions(licence.additionalPssConditions)
+      res.render('pages/view/view', { expandedLicenceConditions, expandedPssConditions })
     } else {
       res.redirect(`/licence/view/cases`)
     }

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -159,7 +159,9 @@ export default class LicenceService {
           return {
             code: conditionCode,
             sequence: index,
-            category: getAdditionalConditionByCode(conditionCode)?.category,
+            category:
+              getAdditionalConditionByCode(conditionCode)?.categoryShort ||
+              getAdditionalConditionByCode(conditionCode)?.category,
             text: getAdditionalConditionByCode(conditionCode)?.text,
           }
         }) || [],

--- a/server/utils/conditionsProviderExpand.test.ts
+++ b/server/utils/conditionsProviderExpand.test.ts
@@ -33,13 +33,13 @@ describe('Conditions Provider - expansions', () => {
           category: 'Residence at a specific place',
           sequence: 0,
           text: 'You must reside within [INSERT REGION] while of no fixed abode, unless otherwise approved by your supervising officer.',
-          data: [{ id: 1, field: 'probationRegion', value: 'london', sequence: 0 }],
+          data: [{ id: 1, field: 'probationRegion', value: 'london probation region', sequence: 0 }],
         },
       ]
       const listOfConditions = expandAdditionalConditions(conditions)
       expect(listOfConditions).toHaveLength(1)
       expect(listOfConditions[0].text).toEqual(
-        'You must reside within the London probation region while of no fixed abode, unless otherwise approved by your supervising officer.'
+        'You must reside within the London Probation Region while of no fixed abode, unless otherwise approved by your supervising officer.'
       )
     })
 
@@ -58,7 +58,7 @@ describe('Conditions Provider - expansions', () => {
       expect(listOfConditions).toHaveLength(1)
       // The two consecutive spaces are expected here
       expect(listOfConditions[0].text).toEqual(
-        'You must reside within the  probation region while of no fixed abode, unless otherwise approved by your supervising officer.'
+        'You must reside within the  while of no fixed abode, unless otherwise approved by your supervising officer.'
       )
     })
 

--- a/server/views/pages/approve/view.njk
+++ b/server/views/pages/approve/view.njk
@@ -13,7 +13,15 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">Approve a licence for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% if licence.typeCode === 'AP' %}
+                <h1 class="govuk-heading-l">Approve licence for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% elseif licence.typeCode === 'AP_PSS' %}
+                <h1 class="govuk-heading-l">Approve licence and post sentence supervision order for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% elseif licence.typeCode === 'PSS' %}
+                <h1 class="govuk-heading-l">Approve post sentence supervision order for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% else %}
+                <h1 class="govuk-heading-l">Approve licence type {{ licence.typeCode }} for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% endif %}
         </div>
     </div>
 
@@ -23,11 +31,11 @@
             {{ inductionMeetingDetails(licence) }}
 
             {% if licence.typeCode === 'AP' or licence.typeCode === 'AP_PSS' %}
-                {{ additionalLicenceConditions(licence) }}
+                {{ additionalLicenceConditions(licence, expandedLicenceConditions) }}
                 {{ bespokeConditions(licence) }}
             {% endif %}
             {% if licence.typeCode === 'PSS' or licence.typeCode === 'AP_PSS' %}
-                {{ additionalPssConditions(licence) }}
+                {{ additionalPssConditions(licence, expandedPssConditions) }}
             {% endif %}
 
             <form method="POST">
@@ -43,7 +51,8 @@
                     attributes: { 'data-qa': 'approve-licence' }
                 }) }}
 
-                <button type="submit" name="result" value="reject" class="govuk-body link-button govuk-!-margin-top-2" data-qa="reject-licence">
+                {#  Visually hidden for now so available to the integration but not shown on screen #}
+                <button type="submit" name="result" value="reject" class="govuk-body link-button govuk-!-margin-top-2 govuk-visually-hidden" data-qa="reject-licence">
                     Reject and send back to probation
                 </button>
             </form>

--- a/server/views/pages/create/checkAnswers.njk
+++ b/server/views/pages/create/checkAnswers.njk
@@ -14,8 +14,15 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <span class="govuk-caption-m">{{ licence.forename + " " + licence.surname }}</span>
-            <h1 class="govuk-heading-l">Check your answers</h1>
+            {% if licence.typeCode === 'AP' %}
+                <h1 class="govuk-heading-l">Check licence details for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% elseif licence.typeCode === 'AP_PSS' %}
+                <h1 class="govuk-heading-l">Check licence and post sentence supervision order details for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% elseif licence.typeCode === 'PSS' %}
+                <h1 class="govuk-heading-l">Check post sentence supervision order details for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% else %}
+                <h1 class="govuk-heading-l">Check licence type {{ licence.typeCode }} for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% endif %}
         </div>
     </div>
     <div class="govuk-grid-row">
@@ -24,12 +31,12 @@
             {{ inductionMeetingDetails(licence, isEditable) }}
 
             {% if licence.typeCode === 'AP' or licence.typeCode === 'AP_PSS' %}
-                {{ additionalLicenceConditions(licence, isEditable) }}
+                {{ additionalLicenceConditions(licence, expandedLicenceConditions, isEditable) }}
                 {{ bespokeConditions(licence, isEditable) }}
             {% endif %}
 
             {% if licence.typeCode === 'PSS' or licence.typeCode === 'AP_PSS' %}
-                {{ additionalPssConditions(licence, isEditable) }}
+                {{ additionalPssConditions(licence, expandedPssConditions, isEditable) }}
             {% endif %}
 
             {% if isEditable %}

--- a/server/views/pages/create/checkAnswers.test.ts
+++ b/server/views/pages/create/checkAnswers.test.ts
@@ -4,6 +4,7 @@ import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../utils/nunjucksSetup'
 
 import * as conditionsProvider from '../../../utils/conditionsProvider'
+import { Licence } from '../../../@types/licenceApiClientTypes'
 
 const additionalCondition = { code: 'condition1', inputRequired: true }
 
@@ -17,109 +18,132 @@ describe('Create a Licence Views - Check Answers', () => {
 
   const njkEnv = registerNunjucks()
 
+  const licence = {
+    id: 1,
+    typeCode: 'AP_PSS',
+    statusCode: 'IN_PROGRESS',
+    additionalLicenceConditions: [
+      {
+        code: 'condition1',
+        category: 'Category 1',
+        text: 'Template 1',
+        data: [
+          {
+            field: 'field1',
+            value: 'Data 1',
+          },
+        ],
+      },
+      {
+        code: 'condition2',
+        category: 'Category 2',
+        text: 'Template 2',
+        data: [
+          {
+            field: 'field2',
+            value: 'Data 2A',
+          },
+          {
+            field: 'field2',
+            value: 'Data 2B',
+          },
+          {
+            field: 'field3',
+            value: 'Data 2C',
+          },
+        ],
+      },
+    ],
+    additionalPssConditions: [
+      {
+        code: 'condition1',
+        category: 'Category 1',
+        text: 'Template 1',
+        data: [
+          {
+            field: 'field1',
+            value: 'Data 1',
+          },
+        ],
+      },
+      {
+        code: 'condition2',
+        category: 'Category 2',
+        text: 'Template 2',
+        data: [
+          {
+            field: 'field2',
+            value: 'Data 2A',
+          },
+          {
+            field: 'field2',
+            value: 'Data 2B',
+          },
+          {
+            field: 'field3',
+            value: 'Data 2C',
+          },
+        ],
+      },
+    ],
+    bespokeConditions: [{ text: 'Bespoke condition 1' }, { text: 'Bespoke condition 2' }],
+  } as Licence
+
   beforeEach(() => {
     compiledTemplate = nunjucks.compile(snippet.toString(), njkEnv)
     viewContext = {}
   })
 
   it('should display additional licence conditions section if licence type is AP', () => {
-    viewContext = {
-      licence: {
-        typeCode: 'AP',
-      },
-    }
-
+    viewContext = { licence: { ...licence, typeCode: 'AP' } }
     const $ = cheerio.load(compiledTemplate.render(viewContext))
-
-    expect($('#additional-licence-conditions-heading').text()).toBe('Additional licence conditions details')
+    expect($('#additional-licence-conditions-heading').text()).toBe('Additional conditions details')
   })
 
-  it('should display additional licence conditions section if licence type is AP+PSS', () => {
-    viewContext = {
-      licence: {
-        typeCode: 'AP_PSS',
-      },
-    }
-
+  it('should display additional licence conditions section if licence type is AP_PSS', () => {
+    viewContext = { licence }
     const $ = cheerio.load(compiledTemplate.render(viewContext))
-
-    expect($('#additional-licence-conditions-heading').text()).toBe('Additional licence conditions details')
+    expect($('#additional-licence-conditions-heading').text()).toBe('Additional conditions details')
   })
 
   it('should not display additional licence conditions section if licence type is PSS', () => {
-    viewContext = {
-      licence: {
-        typeCode: 'PSS',
-      },
-    }
-
+    viewContext = { licence: { ...licence, typeCode: 'PSS' } }
     const $ = cheerio.load(compiledTemplate.render(viewContext))
-
     expect($('#additional-licence-conditions-heading').length).toBe(0)
   })
 
   it('should display a table containing the additional licence conditions', () => {
     viewContext = {
-      licence: {
-        typeCode: 'AP',
-        additionalLicenceConditions: [
-          {
-            code: 'condition1',
-            category: 'Category 1',
-            text: 'Template 1',
-            data: [
-              {
-                field: 'field1',
-                value: 'Data 1',
-              },
-            ],
-          },
-          {
-            code: 'condition2',
-            category: 'Category 2',
-            text: 'Template 2',
-            data: [
-              {
-                field: 'field2',
-                value: 'Data 2A',
-              },
-              {
-                field: 'field2',
-                value: 'Data 2B',
-              },
-              {
-                field: 'field3',
-                value: 'Data 2C',
-              },
-            ],
-          },
-        ],
-      },
+      licence,
+      expandedLicenceConditions: licence.additionalLicenceConditions,
+      expandedPssConditions: licence.additionalLicenceConditions,
     }
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('#additional-licence-conditions-details > .govuk-summary-list__row').length).toBe(2)
+    expect($('#additional-licence-conditions-details > .govuk-summary-list__row').length).toBe(3)
 
-    expect($('#additional-licence-conditions-details > div:nth-child(1) > dt').text().trim()).toBe('Category 1')
-    expect($('#additional-licence-conditions-details > div:nth-child(1) > dd > div:nth-child(1)').text().trim()).toBe(
+    // Check actual condition wording - 1st
+    expect($('#additional-licence-conditions-details > div:nth-child(2) > dt').text().trim()).toBe('Category 1')
+    expect($('#additional-licence-conditions-details > div:nth-child(2) > dd > div:nth-child(1)').text().trim()).toBe(
       'Template 1'
     )
     expect(
-      $('#additional-licence-conditions-details > div:nth-child(1) > dd > div:nth-child(2) > span').text().trim()
+      $('#additional-licence-conditions-details > div:nth-child(2) > dd > div:nth-child(2) > span').text().trim()
     ).toBe('Data 1')
 
-    expect($('#additional-licence-conditions-details > div:nth-child(2) > dt').text().trim()).toBe('Category 2')
-    expect($('#additional-licence-conditions-details > div:nth-child(2) > dd > div:nth-child(1)').text().trim()).toBe(
+    // Check actual condition wording - 2nd
+    expect($('#additional-licence-conditions-details > div:nth-child(3) > dt').text().trim()).toBe('Category 2')
+    expect($('#additional-licence-conditions-details > div:nth-child(3) > dd > div:nth-child(1)').text().trim()).toBe(
       'Template 2'
     )
     expect(
-      $('#additional-licence-conditions-details > div:nth-child(2) > dd > div:nth-child(2) > span:nth-child(1)')
+      $('#additional-licence-conditions-details > div:nth-child(3) > dd > div:nth-child(2) > span:nth-child(1)')
         .text()
         .trim()
     ).toBe('Data 2A, Data 2B')
     expect(
-      $('#additional-licence-conditions-details > div:nth-child(2) > dd > div:nth-child(2) > span:nth-child(2)')
+      $('#additional-licence-conditions-details > div:nth-child(3) > dd > div:nth-child(2) > span:nth-child(2)')
         .text()
         .trim()
     ).toBe('Data 2C')
@@ -127,144 +151,101 @@ describe('Create a Licence Views - Check Answers', () => {
 
   it('should display additional PSS conditions section if licence type is PSS', () => {
     viewContext = {
-      licence: {
-        typeCode: 'PSS',
-      },
+      licence: { ...licence, typeCode: 'PSS' },
+      expandedLicenceConditions: licence.additionalLicenceConditions,
+      expandedPssConditions: licence.additionalLicenceConditions,
     }
-
     const $ = cheerio.load(compiledTemplate.render(viewContext))
-
-    expect($('#additional-pss-conditions-heading').text()).toBe('Additional post sentence requirements details')
+    expect($('#additional-pss-conditions-heading').text()).toBe('Additional post-sentence requirements details')
   })
 
-  it('should display additional PSS conditions section if licence type is AP+PSS', () => {
+  it('should display additional PSS conditions section if licence type is AP_PSS', () => {
     viewContext = {
-      licence: {
-        typeCode: 'AP_PSS',
-      },
+      licence,
+      expandedLicenceConditions: licence.additionalLicenceConditions,
+      expandedPssConditions: licence.additionalLicenceConditions,
     }
-
     const $ = cheerio.load(compiledTemplate.render(viewContext))
-
-    expect($('#additional-pss-conditions-heading').text()).toBe('Additional post sentence requirements details')
+    expect($('#additional-pss-conditions-heading').text()).toBe('Additional post-sentence requirements details')
   })
 
   it('should not display additional licence conditions section if licence type is AP', () => {
-    viewContext = {
-      licence: {
-        typeCode: 'AP',
-      },
-    }
-
+    viewContext = { licence: { ...licence, typeCode: 'AP' } }
     const $ = cheerio.load(compiledTemplate.render(viewContext))
-
     expect($('#additional-pss-conditions-heading').length).toBe(0)
   })
 
   it('should display a table containing the additional PSS conditions', () => {
     viewContext = {
-      licence: {
-        typeCode: 'PSS',
-        additionalPssConditions: [
-          {
-            code: 'condition1',
-            category: 'Category 1',
-            text: 'Template 1',
-            data: [
-              {
-                field: 'field1',
-                value: 'Data 1',
-              },
-            ],
-          },
-          {
-            code: 'condition2',
-            category: 'Category 2',
-            text: 'Template 2',
-            data: [
-              {
-                field: 'field2',
-                value: 'Data 2A',
-              },
-              {
-                field: 'field2',
-                value: 'Data 2B',
-              },
-              {
-                field: 'field3',
-                value: 'Data 2C',
-              },
-            ],
-          },
-        ],
-      },
+      licence: { ...licence, typeCode: 'PSS' },
+      expandedLicenceConditions: licence.additionalLicenceConditions,
+      expandedPssConditions: licence.additionalLicenceConditions,
     }
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('#additional-pss-conditions-details > .govuk-summary-list__row').length).toBe(2)
+    expect($('#additional-pss-conditions-details > .govuk-summary-list__row').length).toBe(3)
 
-    expect($('#additional-pss-conditions-details > div:nth-child(1) > dt').text().trim()).toBe('Category 1')
-    expect($('#additional-pss-conditions-details > div:nth-child(1) > dd > div:nth-child(1)').text().trim()).toBe(
+    expect($('#additional-pss-conditions-details > div:nth-child(2) > dt').text().trim()).toBe('Category 1')
+    expect($('#additional-pss-conditions-details > div:nth-child(2) > dd > div:nth-child(1)').text().trim()).toBe(
       'Template 1'
     )
     expect(
-      $('#additional-pss-conditions-details > div:nth-child(1) > dd > div:nth-child(2) > span').text().trim()
+      $('#additional-pss-conditions-details > div:nth-child(2) > dd > div:nth-child(2) > span').text().trim()
     ).toBe('Data 1')
 
-    expect($('#additional-pss-conditions-details > div:nth-child(2) > dt').text().trim()).toBe('Category 2')
-    expect($('#additional-pss-conditions-details > div:nth-child(2) > dd > div:nth-child(1)').text().trim()).toBe(
+    expect($('#additional-pss-conditions-details > div:nth-child(3) > dt').text().trim()).toBe('Category 2')
+    expect($('#additional-pss-conditions-details > div:nth-child(3) > dd > div:nth-child(1)').text().trim()).toBe(
       'Template 2'
     )
     expect(
-      $('#additional-pss-conditions-details > div:nth-child(2) > dd > div:nth-child(2) > span:nth-child(1)')
+      $('#additional-pss-conditions-details > div:nth-child(3) > dd > div:nth-child(2) > span:nth-child(1)')
         .text()
         .trim()
     ).toBe('Data 2A, Data 2B')
     expect(
-      $('#additional-pss-conditions-details > div:nth-child(2) > dd > div:nth-child(2) > span:nth-child(2)')
+      $('#additional-pss-conditions-details > div:nth-child(3) > dd > div:nth-child(2) > span:nth-child(2)')
         .text()
         .trim()
     ).toBe('Data 2C')
   })
 
-  it('should display a table containing the bespoke conditions', () => {
+  it('should display a table containing the bespoke conditions for AP licences', () => {
     viewContext = {
-      licence: {
-        typeCode: 'AP',
-        bespokeConditions: [{ text: 'Bespoke condition 1' }, { text: 'Bespoke condition 2' }],
-      },
+      licence: { ...licence, typeCode: 'AP' },
+      expandedLicenceConditions: licence.additionalLicenceConditions,
+      expandedPssConditions: licence.additionalLicenceConditions,
     }
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('#bespoke-conditions-details > .govuk-summary-list__row').length).toBe(2)
-    expect($('#bespoke-conditions-details > div:nth-child(1) > dd').text().trim()).toBe('Bespoke condition 1')
-    expect($('#bespoke-conditions-details > div:nth-child(2) > dd').text().trim()).toBe('Bespoke condition 2')
+    expect($('#bespoke-conditions-details > .govuk-summary-list__row').length).toBe(3)
+    expect($('#bespoke-conditions-details > div:nth-child(2) > dd').text().trim()).toBe('Bespoke condition 1')
+    expect($('#bespoke-conditions-details > div:nth-child(3) > dd').text().trim()).toBe('Bespoke condition 2')
   })
 
   it('should show change links and submit button when licence status is IN_PROGRESS', () => {
     viewContext = {
-      licence: {
-        typeCode: 'AP_PSS',
-        statusCode: 'IN_PROGRESS',
-      },
+      licence: { ...licence, statusCode: 'IN_PROGRESS' },
+      expandedLicenceConditions: licence.additionalLicenceConditions,
+      expandedPssConditions: licence.additionalLicenceConditions,
     }
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
-    expect($('.govuk-summary-list__actions').length).toBe(5)
-    expect($('.check-answers-header__change-link').length).toBe(3)
+
+    expect($('.govuk-summary-list__actions').length).toBe(14)
     expect($('[data-qa="send-licence-conditions"]').length).toBe(1)
   })
 
   it('should hide change links and submit button when licence status is not IN_PROGRESS', () => {
     viewContext = {
-      licence: {
-        statusCode: 'SUBMITTED',
-      },
+      licence: { ...licence, statusCode: 'SUBMITTED' },
+      expandedLicenceConditions: licence.additionalLicenceConditions,
+      expandedPssConditions: licence.additionalLicenceConditions,
     }
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
+
     expect($('.govuk-summary-list__actions').length).toBe(0)
     expect($('.check-answers-header__change-link').length).toBe(0)
     expect($('[data-qa="send-licence-conditions"]').length).toBe(0)

--- a/server/views/pages/create/checkAnswers.test.ts
+++ b/server/views/pages/create/checkAnswers.test.ts
@@ -220,8 +220,19 @@ describe('Create a Licence Views - Check Answers', () => {
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
     expect($('#bespoke-conditions-details > .govuk-summary-list__row').length).toBe(3)
-    expect($('#bespoke-conditions-details > div:nth-child(2) > dd').text().trim()).toBe('Bespoke condition 1')
-    expect($('#bespoke-conditions-details > div:nth-child(3) > dd').text().trim()).toBe('Bespoke condition 2')
+    expect($('#bespoke-conditions-details > div:nth-child(1) > .govuk-summary-list__key').text().trim()).toBe(
+      'Select bespoke conditions'
+    )
+    expect($('#bespoke-conditions-details > div:nth-child(1) > .govuk-summary-list__value').text().trim()).toBe(
+      '2 conditions selected'
+    )
+
+    expect($('#bespoke-conditions-details > div:nth-child(2) > .govuk-summary-list__value').text().trim()).toBe(
+      'Bespoke condition 1'
+    )
+    expect($('#bespoke-conditions-details > div:nth-child(3) > .govuk-summary-list__value').text().trim()).toBe(
+      'Bespoke condition 2'
+    )
   })
 
   it('should show change links and submit button when licence status is IN_PROGRESS', () => {

--- a/server/views/pages/view/view.njk
+++ b/server/views/pages/view/view.njk
@@ -6,20 +6,36 @@
 {% from "partials/additionalPssConditionsSummary.njk" import additionalPssConditions %}
 {% from "partials/bespokeConditionsSummary.njk" import bespokeConditions %}
 
-{% set pageTitle = applicationName + " - Print a licence" %}
+{% if licence.statusCode === "APPROVED" or licence.statusCode === "ACTIVE" %}
+  {% set actionWord = "Print" %}
+  {% set isPrintable = true %}
+{% else %}
+  {% set actionWord = "View" %}
+  {% set isPrintable = false %}
+{% endif %}
+
+{% set pageTitle = applicationName + " - {{ actionWord }} a licence" %}
 {% set pageId = "print-view-page" %}
 {% set backLinkHref = "/licence/view/cases" %}
 
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">Print a licence for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% if licence.typeCode === 'AP' %}
+               <h1 class="govuk-heading-l">{{ actionWord }} licence for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% elseif licence.typeCode === 'AP_PSS' %}
+                <h1 class="govuk-heading-l">{{ actionWord }} licence and post sentence supervision order for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% elseif licence.typeCode === 'PSS' %}
+                <h1 class="govuk-heading-l">{{ actionWord }} post sentence supervision order for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% else %}
+                <h1 class="govuk-heading-l">{{ actionWord }} licence type {{ licence.typeCode }} for {{ licence.forename }} {{ licence.surname }}</h1>
+            {% endif %}
         </div>
     </div>
 
-    {% if licence.statusCode == 'APPROVED' or licence.statusCode == 'ACTIVE' %}
+    {% if isPrintable %}
         {{ govukButton({
-            text: "Print licence",
+            text: "Print",
             classes: "govuk-button--primary",
             href: '/licence/view/id/' + licence.id + '/pdf-print',
             attributes: { 'data-qa': 'print-licence', 'target': "_blank" }
@@ -30,22 +46,23 @@
         <div class="govuk-grid-column-two-thirds-from-desktop">
             {{ inductionMeetingDetails(licence) }}
             {% if licence.typeCode === 'AP' or licence.typeCode === 'AP_PSS' %}
-                {{ additionalLicenceConditions(licence) }}
+                {{ additionalLicenceConditions(licence, expandedLicenceConditions) }}
                 {{ bespokeConditions(licence) }}
             {% endif %}
             {% if licence.typeCode === 'PSS' or licence.typeCode === 'AP_PSS' %}
-                {{ additionalPssConditions(licence) }}
+                {{ additionalPssConditions(licence, expandedPssConditions) }}
             {% endif %}
 
             <div class="govuk-body">
-                {% if licence.statusCode == 'APPROVED' or licence.statusCode == 'ACTIVE' %}
+                {% if isPrintable %}
                     {{ govukButton({
-                        text: "Print licence",
+                        text: "Print",
                         classes: "govuk-button--primary govuk-!-margin-right-1",
                         href: '/licence/view/id/' + licence.id + '/pdf-print',
                         attributes: { 'data-qa': 'print-licence', 'target': "_blank" }
                     }) }}
                 {% endif %}
+
                 {{ govukButton({
                    text: "Return to case list",
                    classes: "govuk-button--secondary govuk-!-margin-bottom-0",

--- a/server/views/partials/additionalLicenceConditionsSummary.njk
+++ b/server/views/partials/additionalLicenceConditionsSummary.njk
@@ -1,9 +1,9 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% macro additionalLicenceConditions(licence, isEditable) %}
-    {% macro additionalConditionHtml(template, data) %}
+{% macro additionalLicenceConditions(licence, expandedLicenceConditions, isEditable) %}
+    {% macro additionalConditionHtml(expandedConditionText, data) %}
         <div>
-            {{ template }}
+            {{ expandedConditionText }}
         </div>
         {% if data.length %}
             <div class="govuk-!-font-weight-bold govuk-!-margin-top-3">
@@ -16,18 +16,30 @@
 
     <div class="govuk-grid-row check-answers-header">
         <div class="govuk-grid-column-three-quarters">
-            <h2 id="additional-licence-conditions-heading" class="govuk-heading-m">Additional licence conditions details</h2>
+            <h2 id="additional-licence-conditions-heading" class="govuk-heading-m">Additional conditions details</h2>
         </div>
-        {% if isEditable %}
-            <div class="govuk-grid-column-one-quarter check-answers-header__change-link">
-                <a href="{{ '/licence/create/id/' + licence.id + '/additional-licence-conditions?fromReview=true'}}" class="govuk-link govuk-!-font-size-19">Change</a>
-            </div>
-        {% endif %}
     </div>
 
     {% set additionalLicenceConditions = [] %}
 
-    {% for condition in licence.additionalLicenceConditions %}
+    {# Add select additional conditions and count of existing conditions #}
+    {% set conditionWord = "condition" if expandedLicenceConditions.length === 1 else "conditions" %}
+    {% set additionalLicenceConditions = (additionalLicenceConditions.push({
+        key: {  text: "Select additional conditions" },
+        value: { text: "" + expandedLicenceConditions.length + " " + conditionWord + " selected" },
+        actions: {
+            items: [
+                {
+                    href: "/licence/create/id/" + licence.id + "/additional-licence-conditions?fromReview=true",
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+            ]
+        } if isEditable
+    }), additionalLicenceConditions) %}
+
+    {# Show the entered additional conditions in the remainder of this summary list #}
+    {% for condition in expandedLicenceConditions %}
         {% set additionalLicenceConditions = (additionalLicenceConditions.push({
             key: {  text: condition.category },
             value: { html: additionalConditionHtml(condition.text, condition.data) },
@@ -35,7 +47,7 @@
                 items: [
                     {
                         href: "/licence/create/id/" + licence.id + "/additional-licence-conditions/condition/" + condition.id + "?fromReview=true",
-                        text: "Edit",
+                        text: "Change",
                         visuallyHiddenText: "name"
                     }
                 ]
@@ -44,12 +56,10 @@
     {% endfor %}
 
     {% if additionalLicenceConditions.length > 0 %}
-    {{ govukSummaryList({
+      {{ govukSummaryList({
         attributes: { id: 'additional-licence-conditions-details' },
         classes: 'govuk-!-margin-bottom-9',
         rows: additionalLicenceConditions
-    }) }}
-    {% else %}
-        <p class="govuk-body govuk-!-margin-bottom-9">No additional licence conditions have been added to this licence</p>
+      }) }}
     {% endif %}
 {% endmacro %}

--- a/server/views/partials/additionalLicenceConditionsSummary.njk
+++ b/server/views/partials/additionalLicenceConditionsSummary.njk
@@ -22,8 +22,8 @@
 
     {% set additionalLicenceConditions = [] %}
 
-    {# Add select additional conditions and count of existing conditions #}
     {% set conditionWord = "condition" if expandedLicenceConditions.length === 1 else "conditions" %}
+
     {% set additionalLicenceConditions = (additionalLicenceConditions.push({
         key: {  text: "Select additional conditions" },
         value: { text: "" + expandedLicenceConditions.length + " " + conditionWord + " selected" },
@@ -32,13 +32,12 @@
                 {
                     href: "/licence/create/id/" + licence.id + "/additional-licence-conditions?fromReview=true",
                     text: "Change",
-                    visuallyHiddenText: "name"
+                    visuallyHiddenText: "Add or remove conditions"
                 }
             ]
         } if isEditable
     }), additionalLicenceConditions) %}
 
-    {# Show the entered additional conditions in the remainder of this summary list #}
     {% for condition in expandedLicenceConditions %}
         {% set additionalLicenceConditions = (additionalLicenceConditions.push({
             key: {  text: condition.category },
@@ -48,18 +47,18 @@
                     {
                         href: "/licence/create/id/" + licence.id + "/additional-licence-conditions/condition/" + condition.id + "?fromReview=true",
                         text: "Change",
-                        visuallyHiddenText: "name"
+                        visuallyHiddenText: "Change condition"
                     }
                 ]
             } if condition | checkConditionRequiresInput and isEditable
         }), additionalLicenceConditions) %}
     {% endfor %}
 
-    {% if additionalLicenceConditions.length > 0 %}
-      {{ govukSummaryList({
+
+    {{ govukSummaryList({
         attributes: { id: 'additional-licence-conditions-details' },
         classes: 'govuk-!-margin-bottom-9',
         rows: additionalLicenceConditions
-      }) }}
-    {% endif %}
+    }) }}
+
 {% endmacro %}

--- a/server/views/partials/additionalPssConditionsSummary.njk
+++ b/server/views/partials/additionalPssConditionsSummary.njk
@@ -1,9 +1,9 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% macro additionalPssConditions(licence, isEditable) %}
-    {% macro additionalConditionHtml(template, data) %}
+{% macro additionalPssConditions(licence, expandedPssConditions, isEditable) %}
+    {% macro additionalConditionHtml(expandedConditionText, data) %}
         <div>
-            {{ template }}
+            {{ expandedConditionText }}
         </div>
         {% if data.length %}
             <div class="govuk-!-font-weight-bold govuk-!-margin-top-3">
@@ -16,18 +16,29 @@
 
     <div class="govuk-grid-row check-answers-header">
         <div class="govuk-grid-column-three-quarters">
-            <h2 id="additional-pss-conditions-heading" class="govuk-heading-m">Additional post sentence requirements details</h2>
+            <h2 id="additional-pss-conditions-heading" class="govuk-heading-m">Additional post-sentence requirements details</h2>
         </div>
-        {% if isEditable %}
-            <div class="govuk-grid-column-one-quarter check-answers-header__change-link">
-                <a href="{{ '/licence/create/id/' + licence.id + '/additional-pss-conditions?fromReview=true'}}" class="govuk-link govuk-!-font-size-19">Change</a>
-            </div>
-        {% endif %}
     </div>
 
     {% set additionalPssConditions = [] %}
 
-    {% for condition in licence.additionalPssConditions %}
+    {# Add select additional PSS requirements + count of existing requirements #}
+    {% set conditionWord = "requirement" if expandedPssConditions.length === 1 else "requirements" %}
+    {% set additionalPssConditions = (additionalPssConditions.push({
+        key: {  text: "Select additional requirements" },
+        value: { text: "" + expandedPssConditions.length + " " + conditionWord + " selected" },
+        actions: {
+            items: [
+                {
+                    href: "/licence/create/id/" + licence.id + "/additional-pss-conditions?fromReview=true",
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+            ]
+        } if isEditable
+    }), additionalPssConditions) %}
+
+    {% for condition in expandedPssConditions %}
         {% set additionalPssConditions = (additionalPssConditions.push({
             key: {  text: condition.category },
             value: { html: additionalConditionHtml(condition.text, condition.data) },
@@ -35,7 +46,7 @@
                 items: [
                     {
                         href: "/licence/create/id/" + licence.id + "/additional-pss-conditions/condition/" + condition.id + "?fromReview=true",
-                        text: "Edit",
+                        text: "Change",
                         visuallyHiddenText: "name"
                     }
                 ]
@@ -44,12 +55,10 @@
     {% endfor %}
 
     {% if additionalPssConditions.length > 0 %}
-    {{ govukSummaryList({
+      {{ govukSummaryList({
         attributes: { id: 'additional-pss-conditions-details' },
         classes: 'govuk-!-margin-bottom-9',
         rows: additionalPssConditions
-    }) }}
-    {% else %}
-        <p class="govuk-body govuk-!-margin-bottom-9">No additional post sentence requirements have been added to this licence</p>
+      }) }}
     {% endif %}
 {% endmacro %}

--- a/server/views/partials/additionalPssConditionsSummary.njk
+++ b/server/views/partials/additionalPssConditionsSummary.njk
@@ -32,7 +32,7 @@
                 {
                     href: "/licence/create/id/" + licence.id + "/additional-pss-conditions?fromReview=true",
                     text: "Change",
-                    visuallyHiddenText: "name"
+                    visuallyHiddenText: "Add or remove requirements"
                 }
             ]
         } if isEditable
@@ -47,7 +47,7 @@
                     {
                         href: "/licence/create/id/" + licence.id + "/additional-pss-conditions/condition/" + condition.id + "?fromReview=true",
                         text: "Change",
-                        visuallyHiddenText: "name"
+                        visuallyHiddenText: "Change requirement"
                     }
                 ]
             } if condition | checkConditionRequiresInput and isEditable

--- a/server/views/partials/bespokeConditionsSummary.njk
+++ b/server/views/partials/bespokeConditionsSummary.njk
@@ -3,16 +3,27 @@
 {%  macro bespokeConditions(licence, isEditable) %}
     <div class="govuk-grid-row check-answers-header">
         <div class="govuk-grid-column-three-quarters">
-            <h2 class="govuk-heading-m">Bespoke licence conditions details</h2>
+            <h2 class="govuk-heading-m">Bespoke licence condition details</h2>
         </div>
-        {% if isEditable %}
-            <div class="govuk-grid-column-one-quarter check-answers-header__change-link">
-                <a href="{{ '/licence/create/id/' + licence.id + '/bespoke-conditions?fromReview=true'}}" class="govuk-link govuk-!-font-size-19">Change</a>
-            </div>
-        {% endif %}
     </div>
 
     {% set bespokeConditions = [] %}
+
+    {# Add select bespoke conditions and count of existing bespoke conditions #}
+    {% set conditionWord = "condition" if licence.bespokeConditions.length === 1 else "conditions" %}
+    {% set bespokeConditions = (bespokeConditions.push({
+        key: {  text: "Select bespoke conditions" },
+        value: { text: "" + licence.bespokeConditions.length + " " + conditionWord + " selected" },
+        actions: {
+            items: [
+                {
+                    href: "/licence/create/id/" + licence.id + "/bespoke-conditions?fromReview=true",
+                    text: "Change",
+                    visuallyHiddenText: "name"
+                }
+            ]
+        } if isEditable
+    }), bespokeConditions) %}
 
     {% for condition in licence.bespokeConditions %}
         {% set bespokeConditions = (bespokeConditions.push({
@@ -27,7 +38,5 @@
             classes: 'govuk-!-margin-bottom-9',
             rows: bespokeConditions
         }) }}
-    {% else %}
-        <p class="govuk-body govuk-!-margin-bottom-9">No bespoke conditions have been added to this licence</p>
     {% endif %}
 {% endmacro %}

--- a/server/views/partials/bespokeConditionsSummary.njk
+++ b/server/views/partials/bespokeConditionsSummary.njk
@@ -9,8 +9,8 @@
 
     {% set bespokeConditions = [] %}
 
-    {# Add select bespoke conditions and count of existing bespoke conditions #}
     {% set conditionWord = "condition" if licence.bespokeConditions.length === 1 else "conditions" %}
+
     {% set bespokeConditions = (bespokeConditions.push({
         key: {  text: "Select bespoke conditions" },
         value: { text: "" + licence.bespokeConditions.length + " " + conditionWord + " selected" },
@@ -19,7 +19,7 @@
                 {
                     href: "/licence/create/id/" + licence.id + "/bespoke-conditions?fromReview=true",
                     text: "Change",
-                    visuallyHiddenText: "name"
+                    visuallyHiddenText: "Change bespoke conditions"
                 }
             ]
         } if isEditable
@@ -28,15 +28,24 @@
     {% for condition in licence.bespokeConditions %}
         {% set bespokeConditions = (bespokeConditions.push({
             key: { text: 'Bespoke condition' },
-            value: { text: condition.text }
+            value: { text: condition.text },
+            actions: {
+                items: [
+                    {
+                        href: "/licence/create/id/" + licence.id + "/bespoke-conditions?fromReview=true",
+                        text: "Change",
+                        visuallyHiddenText: "Change bespoke conditions"
+                    }
+                ]
+            } if isEditable
         }), bespokeConditions) %}
     {% endfor %}
 
-    {% if bespokeConditions.length > 0 %}
-        {{ govukSummaryList({
-            attributes: { id: 'bespoke-conditions-details' },
-            classes: 'govuk-!-margin-bottom-9',
-            rows: bespokeConditions
-        }) }}
-    {% endif %}
+
+    {{ govukSummaryList({
+        attributes: { id: 'bespoke-conditions-details' },
+        classes: 'govuk-!-margin-bottom-9',
+        rows: bespokeConditions
+    }) }}
+
 {% endmacro %}

--- a/server/views/partials/inductionMeetingDetailsSummary.njk
+++ b/server/views/partials/inductionMeetingDetailsSummary.njk
@@ -3,7 +3,7 @@
 {% macro inductionMeetingDetails(licence, isEditable) %}
     <div class="govuk-grid-row check-answers-header">
         <div class="govuk-grid-column-three-quarters">
-            <h2 class="govuk-heading-m">Induction meeting details</h2>
+            <h2 class="govuk-heading-m">Initial meeting details</h2>
         </div>
     </div>
 


### PR DESCRIPTION
* Lots of content changes (titles, condition counters, change links and wording).
* Expanded condition text with in-line values shown on all summary screens.
* Removed rejection link (hidden) - but integration test forces its use.
* Updated unit and integration tests for all content changes.
* Use of short-names for some categories on summary pages (replaces full category, if present, and written to DB via API)
* Adds missing probation regions, and appends `..Probation Region`" to all e.g. `London Probation Region` - so condition sentences don't need to be changed.
* Simplified tests by defining and re-using a single licence object (using spread syntax to change type/status).
