### PR TITLE
CVSL-279: Fixed allowed URLs (again) - missing asterisk to match with multiple digits, not one.

### DIFF
--- a/server/utils/urlAccessByStatus.test.ts
+++ b/server/utils/urlAccessByStatus.test.ts
@@ -28,7 +28,7 @@ describe('URL access checks for licence statuses', () => {
     })
 
     it('should allow access to confirmation page after submitting', () => {
-      path = '/licence/create/id/1/confirmation'
+      path = '/licence/create/id/123/confirmation'
       expect(getUrlAccessByStatus(path, 1, 'SUBMITTED', username)).toEqual(true)
     })
 

--- a/server/utils/urlAccessByStatus.ts
+++ b/server/utils/urlAccessByStatus.ts
@@ -10,7 +10,7 @@ const allowedPaths = [
     allowed: [
       '/licence/create/id/(\\d)*/check-your-answers.*',
       '/licence/create/id/(\\d)*/edit.*',
-      '/licence/create/id/(\\d)/confirmation.*',
+      '/licence/create/id/(\\d)*/confirmation.*',
       '/licence/view/id/(\\d)*/.*',
       '/licence/approve/id/(\\d)*/.*',
     ],


### PR DESCRIPTION
RegExp not quite right. Now fixed & test to confirm.