### PR TITLE
CVSL-281: Fixed missing URLs in allowed list.

### DIFF
--- a/server/utils/urlAccessByStatus.test.ts
+++ b/server/utils/urlAccessByStatus.test.ts
@@ -54,6 +54,11 @@ describe('URL access checks for licence statuses', () => {
       expect(getUrlAccessByStatus(path, 1, 'APPROVED', username)).toEqual(false)
     })
 
+    it('should allow access to approval confirmation', () => {
+      path = '/licence/approve/id/1/confirm-approved'
+      expect(getUrlAccessByStatus(path, 1, 'APPROVED', username)).toEqual(true)
+    })
+
     it('should allow access to licence viewing', () => {
       path = '/licence/view/id/1/show'
       expect(getUrlAccessByStatus(path, 1, 'APPROVED', username)).toEqual(true)
@@ -79,6 +84,11 @@ describe('URL access checks for licence statuses', () => {
     it('should deny access to approval flow', () => {
       path = '/licence/approve/id/1/view'
       expect(getUrlAccessByStatus(path, 1, 'REJECTED', username)).toEqual(false)
+    })
+
+    it('should allow access to rejection confirmation', () => {
+      path = '/licence/approve/id/1/confirm-rejected'
+      expect(getUrlAccessByStatus(path, 1, 'REJECTED', username)).toEqual(true)
     })
   })
 

--- a/server/utils/urlAccessByStatus.ts
+++ b/server/utils/urlAccessByStatus.ts
@@ -20,6 +20,7 @@ const allowedPaths = [
     allowed: [
       '/licence/create/id/(\\d)*/check-your-answers.*',
       '/licence/create/id/(\\d)*/edit.*',
+      '/licence/approve/id/(\\d)*/confirm-approved.*',
       '/licence/view/id/(\\d)*/.*',
     ],
   },
@@ -28,6 +29,7 @@ const allowedPaths = [
     allowed: [
       '/licence/create/id/(\\d)*/check-your-answers.*',
       '/licence/create/id/(\\d)*/edit.*',
+      '/licence/approve/id/(\\d)*/confirm-rejected.*',
       '/licence/view/id/(\\d)*/.*',
     ],
   },


### PR DESCRIPTION
Approval flow sets the status to APPROVED and then shows the confirmation - needed confirmation URL in allow list for APPROVED.
Approval flow sets the status to REJECTED and then shows a rejected confirmation - needed confirmation URL in allow list for REJECTED.