### PR TITLE
CVSL-273: Handle rejected promise in fetch licence middleware

### DIFF
--- a/server/data/hmppsRestClient.ts
+++ b/server/data/hmppsRestClient.ts
@@ -62,26 +62,26 @@ export default class HmppsRestClient {
     const signedWith = signedWithMethod?.token || (await this.tokenStore.getSystemToken(signedWithMethod?.username))
 
     logger.info(`Get using admin client credentials: calling ${this.name}: ${path}?${querystring.stringify(query)}`)
-    try {
-      const result = await superagent
-        .get(`${this.apiConfig.url}${path}`)
-        .agent(this.agent)
-        .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
-        .query(query)
-        .auth(signedWith, { type: 'bearer' })
-        .set(headers)
-        .responseType(responseType)
-        .timeout(this.apiConfig.timeout)
-
-      return raw ? result : result.body
-    } catch (error) {
-      const sanitisedError = sanitiseError(error)
-      logger.warn({ ...sanitisedError, query }, `Error calling ${this.name}, path: '${path}', verb: 'GET'`)
-      throw sanitisedError
-    }
+    return superagent
+      .get(`${this.apiConfig.url}${path}`)
+      .agent(this.agent)
+      .retry(2, (err, res) => {
+        if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+        return undefined // retry handler only for logging retries, not to influence retry logic
+      })
+      .query(query)
+      .auth(signedWith, { type: 'bearer' })
+      .set(headers)
+      .responseType(responseType)
+      .timeout(this.apiConfig.timeout)
+      .then(response => {
+        return raw ? response : response.body
+      })
+      .catch(error => {
+        const sanitisedError = sanitiseError(error)
+        logger.warn({ ...sanitisedError, query }, `Error calling ${this.name}, path: '${path}', verb: 'GET'`)
+        throw sanitisedError
+      })
   }
 
   async post(
@@ -91,26 +91,26 @@ export default class HmppsRestClient {
     const signedWith = signedWithMethod?.token || (await this.tokenStore.getSystemToken(signedWithMethod?.username))
 
     logger.info(`Post using admin client credentials: calling ${this.name}: ${path}`)
-    try {
-      const result = await superagent
-        .post(`${this.apiConfig.url}${path}`)
-        .send(data)
-        .agent(this.agent)
-        .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
-        .auth(signedWith, { type: 'bearer' })
-        .set(headers)
-        .responseType(responseType)
-        .timeout(this.apiConfig.timeout)
-
-      return raw ? result : result.body
-    } catch (error) {
-      const sanitisedError = sanitiseError(error)
-      logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'POST'`)
-      throw sanitisedError
-    }
+    return superagent
+      .post(`${this.apiConfig.url}${path}`)
+      .send(data)
+      .agent(this.agent)
+      .retry(2, (err, res) => {
+        if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+        return undefined // retry handler only for logging retries, not to influence retry logic
+      })
+      .auth(signedWith, { type: 'bearer' })
+      .set(headers)
+      .responseType(responseType)
+      .timeout(this.apiConfig.timeout)
+      .then(response => {
+        return raw ? response : response.body
+      })
+      .catch(error => {
+        const sanitisedError = sanitiseError(error)
+        logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'POST'`)
+        throw sanitisedError
+      })
   }
 
   async put(
@@ -120,54 +120,52 @@ export default class HmppsRestClient {
     const signedWith = signedWithMethod?.token || (await this.tokenStore.getSystemToken(signedWithMethod?.username))
 
     logger.info(`Put using admin client credentials: calling ${this.name}: ${path}`)
-    try {
-      const result = await superagent
-        .put(`${this.apiConfig.url}${path}`)
-        .send(data)
-        .agent(this.agent)
-        .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
-        .auth(signedWith, { type: 'bearer' })
-        .set(headers)
-        .responseType(responseType)
-        .timeout(this.apiConfig.timeout)
-
-      return raw ? result : result.body
-    } catch (error) {
-      const sanitisedError = sanitiseError(error)
-      logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'PUT'`)
-      throw sanitisedError
-    }
+    return superagent
+      .put(`${this.apiConfig.url}${path}`)
+      .send(data)
+      .agent(this.agent)
+      .retry(2, (err, res) => {
+        if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+        return undefined // retry handler only for logging retries, not to influence retry logic
+      })
+      .auth(signedWith, { type: 'bearer' })
+      .set(headers)
+      .responseType(responseType)
+      .timeout(this.apiConfig.timeout)
+      .then(response => {
+        return raw ? response : response.body
+      })
+      .catch(error => {
+        const sanitisedError = sanitiseError(error)
+        logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'PUT'`)
+        throw sanitisedError
+      })
   }
 
   async stream({ path = null, headers = {} }: StreamRequest, signedWithMethod?: SignedWithMethod): Promise<unknown> {
     const signedWith = signedWithMethod?.token || (await this.tokenStore.getSystemToken(signedWithMethod?.username))
 
     logger.info(`Get using admin client credentials: calling ${this.name}: ${path}`)
-    return new Promise((resolve, reject) => {
-      superagent
-        .get(`${this.apiConfig.url}${path}`)
-        .agent(this.agent)
-        .auth(signedWith, { type: 'bearer' })
-        .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
-        .timeout(this.apiConfig.timeout)
-        .set(headers)
-        .end((error, response) => {
-          if (error) {
-            logger.info(`Error caught for get stream ${path}`)
-            reject(error)
-          } else if (response) {
-            const streamedResponse = Readable.from(response.body)
-            streamedResponse.push(response.body)
-            streamedResponse.push(null)
-            resolve(streamedResponse)
-          }
-        })
-    })
+    return superagent
+      .get(`${this.apiConfig.url}${path}`)
+      .agent(this.agent)
+      .auth(signedWith, { type: 'bearer' })
+      .retry(2, (err, res) => {
+        if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
+        return undefined // retry handler only for logging retries, not to influence retry logic
+      })
+      .timeout(this.apiConfig.timeout)
+      .set(headers)
+      .then(response => {
+        const streamedResponse = Readable.from(response.body)
+        streamedResponse.push(response.body)
+        streamedResponse.push(null)
+        return streamedResponse
+      })
+      .catch(error => {
+        const sanitisedError = sanitiseError(error)
+        logger.warn({ ...sanitisedError }, `Error calling ${this.name}, path: '${path}', verb: 'GET (streamed)'`)
+        throw sanitisedError
+      })
   }
 }

--- a/server/middleware/fetchLicenceMiddleware.test.ts
+++ b/server/middleware/fetchLicenceMiddleware.test.ts
@@ -75,6 +75,13 @@ describe('fetchLicenceMiddleware', () => {
     expect(next).toBeCalledTimes(1)
   })
 
+  it('should handle error from licence service', async () => {
+    licenceService.getLicence.mockRejectedValue('Error')
+
+    await middleware(req, res, next)
+    expect(next).toBeCalledWith('Error')
+  })
+
   it('should allow access for a prison user based on caseload', async () => {
     await middleware(req, res, next)
     expect(res.locals.licence).toEqual(licence)

--- a/server/middleware/fetchLicenceMiddleware.ts
+++ b/server/middleware/fetchLicenceMiddleware.ts
@@ -6,36 +6,41 @@ import logger from '../../logger'
 export default function fetchLicence(licenceService: LicenceService): RequestHandler {
   return async (req, res, next) => {
     if (req.params.licenceId) {
-      const { user } = res.locals
-      const licence = await licenceService.getLicence(req.params.licenceId, user)
+      try {
+        const { user } = res.locals
+        const licence = await licenceService.getLicence(req.params.licenceId, user)
 
-      // Does this prison user have a caseload which allows access this licence?
-      if (licence && user?.nomisStaffId) {
-        if (!user.prisonCaseload.includes(licence.prisonCode)) {
-          logger.info(
-            `Prison caseload ${user?.prisonCasload} denied access to licence ID ${licence.id} ${licence.prisonCode}`
-          )
+        // Does this prison user have a caseload which allows access this licence?
+        if (licence && user?.nomisStaffId) {
+          if (!user.prisonCaseload.includes(licence.prisonCode)) {
+            logger.info(
+              `Prison caseload ${user?.prisonCasload} denied access to licence ID ${licence.id} ${licence.prisonCode}`
+            )
+            return res.redirect('/access-denied')
+          }
+        }
+
+        // Does this probation user belong to an LDU which manages the person on licence?
+        if (licence && user?.deliusStaffIdentifier) {
+          if (!user.probationLduCodes?.includes(licence.probationLduCode)) {
+            logger.info(
+              `Probation LDUs ${user?.probationLduCodes} denies access to licence ID ${licence.id} ${licence.probationLduCode}`
+            )
+            return res.redirect('/access-denied')
+          }
+        }
+
+        // Is the URL requested allowed for a licence in this status?
+        if (licence && !getUrlAccessByStatus(req.path, licence.id, licence.statusCode, user.username)) {
           return res.redirect('/access-denied')
         }
-      }
 
-      // Does this probation user belong to an LDU which manages the person on licence?
-      if (licence && user?.deliusStaffIdentifier) {
-        if (!user.probationLduCodes?.includes(licence.probationLduCode)) {
-          logger.info(
-            `Probation LDUs ${user?.probationLduCodes} denies access to licence ID ${licence.id} ${licence.probationLduCode}`
-          )
-          return res.redirect('/access-denied')
+        if (licence) {
+          res.locals.licence = licence
         }
-      }
-
-      // Is the URL requested allowed for a licence in this status?
-      if (licence && !getUrlAccessByStatus(req.path, licence.id, licence.statusCode, user.username)) {
-        return res.redirect('/access-denied')
-      }
-
-      if (licence) {
-        res.locals.licence = licence
+      } catch (error) {
+        logger.error(error, `Failed to get licence details for licence Id: ${req.params.licenceId}`)
+        return next(error)
       }
     }
     return next()


### PR DESCRIPTION
* Used Promise-then-catch notation in http client
* Wrapped `fetchLicenceMiddleware` in try-catch to handle rejected promise as is done in `populateCurrentUser` middleware
* Added test coverage for the STREAM util in httpClient