### PR TITLE
CVSL-287: Update dependencies to fix overnight scans. 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6317,9 +6317,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-3.14.0.tgz",
-      "integrity": "sha512-y7FTuihCSA8Hty+e9h0uPhCoNanCAN+CLioNFlPmlbeHXpbi09VMyxTcH+XfnMPY4Cp++7096v0rLwwdapTXnA=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.0.tgz",
+      "integrity": "sha512-liaJildULUNSSvEgDm36SQTivqBHiZLdrm+O7bBxnW4Q1g64asi+mJIMzW8QeOqlG4Yn8s0gSklsIyaFOuCisQ=="
     },
     "graceful-fs": {
       "version": "4.2.4",
@@ -11960,9 +11960,9 @@
       }
     },
     "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "uid-safe": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "express": "^4.17.1",
     "express-request-id": "^1.4.1",
     "express-session": "^1.17.2",
-    "govuk-frontend": "^3.14.0",
+    "govuk-frontend": "^4.0.0",
     "helmet": "^4.6.0",
     "http-errors": "^1.8.0",
     "jquery": "^3.6.0",
@@ -176,6 +176,6 @@
     "redis-mock": "^0.56.3",
     "sass": "^1.42.1",
     "ts-jest": "^27.0.5",
-    "typescript": "^4.5.2"
+    "typescript": "^4.5.4"
   }
 }

--- a/server/views/pages/create/checkAnswers.test.ts
+++ b/server/views/pages/create/checkAnswers.test.ts
@@ -244,7 +244,7 @@ describe('Create a Licence Views - Check Answers', () => {
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
 
-    expect($('.govuk-summary-list__actions').length).toBe(14)
+    expect($('.govuk-summary-list__actions').length).toBe(12)
     expect($('[data-qa="send-licence-conditions"]').length).toBe(1)
   })
 


### PR DESCRIPTION
A further ticket has been created to check through the govuk-frontend release notes which may need some small changes in our code, but for now the journeys look good and tests are passing.