### PR TITLE
CVSL-304: Create temp upload directory and set permissions during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,9 @@ COPY --from=build --chown=appuser:appgroup \
 COPY --from=build --chown=appuser:appgroup \
         /app/node_modules ./node_modules
 
+# Create a directory to be used for temporary file uploads (ephemeral)
+RUN mkdir uploads && chown appuser:appgroup uploads && chmod 775 uploads
+
 EXPOSE 3000
 ENV NODE_ENV='production'
 USER 2000


### PR DESCRIPTION
This is to fix the failing deployment, which complains it cannot create the /app/uploads directory.