### PR TITLE
CVSL-285: Link button focus. IE SCSS updates.

### DIFF
--- a/assets/js/govukFrontendInit.js
+++ b/assets/js/govukFrontendInit.js
@@ -1,7 +1,7 @@
 window.GOVUKFrontend.initAll()
 
 // Initiate the back links
-$('[class$=js-backlink]').click(e => {
+$('[class$=js-backlink]').on('click', e => {
   e.preventDefault()
   if ($('ul.govuk-error-summary__list').length > 0) {
     window.history.go(-2)

--- a/assets/sass/application-ie8.sass
+++ b/assets/sass/application-ie8.sass
@@ -4,8 +4,15 @@ $path: "/assets/images/"
 @import 'govuk/all-ie8'
 @import 'moj/all'
 
-@import './components/header-bar'
-@import './components/card'
+@import "./constants/colours"
+
 @import './components/add-another'
+@import './components/card'
+@import './components/caseload'
 @import './components/check-answers-header'
+@import './components/file_upload'
+@import './components/header-bar'
+@import './components/link-button'
+@import './components/status-tags'
+@import './components/utils'
 @import './local'

--- a/assets/sass/components/_link-button.scss
+++ b/assets/sass/components/_link-button.scss
@@ -6,3 +6,7 @@
   cursor: pointer;
   text-align: left;
 }
+
+.link-button:focus {
+  @include govuk-focused-text;
+}

--- a/server/views/layout.njk
+++ b/server/views/layout.njk
@@ -75,6 +75,9 @@
   {% include 'partials/licenceDetailsBanner.njk' %}
   {% include 'partials/formError.njk' %}
   <span class="govuk-visually-hidden" id="{{ pageId }}"></span>
+
+  {# IE issue where keyboard navigation does not tab into main content #}
+  <div id="main" tabindex="-1"></div>
 {% endblock %}
 
 {% block bodyEnd %}


### PR DESCRIPTION
Three things here:
* Set the focus property on the link button (names on case list view)
* Updated the SCCS modules included in the IE version of application.css - missing modules.
* Experimental - add an empty main div with a tabindex -1 - attempt to get IE11 to tab into the content for keyboard-only navigation.