### PR TITLE
CVSL-305: Add basic user details into the dataLayer on page loads when user is present in res.locals.

### DIFF
--- a/server/views/layout.njk
+++ b/server/views/layout.njk
@@ -10,6 +10,22 @@
     <!-- Tag manager dataLayer -->
     <script nonce="{{ cspNonce }}">window.dataLayer = window.dataLayer || [];</script>
 
+    <!-- Add user details to the dataLayer if present on this page load -->
+    {% if user %}
+      <script nonce="{{ cspNonce }}">window.dataLayer.push({
+          'user': {
+            'authSource': user?.authSource,
+            'roles': user?.userRoles,
+            'username': user?.username,
+            'displayName': user?.displayName,
+            'prisons': user?.prisonCaseload,
+            'probationAreaCode': user?.probationArea,
+            'probationAreaDesc': user?.probationAreaDescription,
+            'probationTeams': user?.probationTeams,
+          },
+        })</script>
+    {% endif %}
+
     <!-- Google Tag Manager -->
     <script nonce="{{ cspNonce }}">(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
                 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
This is to expose some details about the user to Google Analytics.
Kam can configure GTM to look for these values and provide some analytics about who is using the service.