### PR TITLE
CVSL-317: Add integration tests for AWS event consumer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,8 @@ jobs:
           name: Create localstack queues
           command: |
             export AWS_DEFAULT_REGION=eu-west-2
+            export AWS_ACCESS_KEY_ID=foo
+            export AWS_SECRET_ACCESS_KEY=bar
 
             aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue
             aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue_dl

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,19 +133,19 @@ jobs:
           command: sudo apt-get install libxss1
       - hmpps/wait_till_ready # Wait for localstack to start before creating resources
       - run:
-        name: Create localstack queues
-        command: |
-          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue
-          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue_dl
-          aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_prison_events_queue_dl\"}"}'
+          name: Create localstack queues
+          command: |
+            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue
+            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue_dl
+            aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_prison_events_queue_dl\"}"}'
 
-          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue
-          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue_dl
-          aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_probation_events_queue_dl\"}"}'
+            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue
+            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue_dl
+            aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_probation_events_queue_dl\"}"}'
 
-          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue
-          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue_dl
-          aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_domain_events_queue_dl\"}"}'
+            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue
+            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue_dl
+            aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_domain_events_queue_dl\"}"}'
       - run:
           name: Get wiremock
           command: curl -o wiremock.jar https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.27.1/wiremock-standalone-2.27.1.jar

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,8 @@ jobs:
       - run:
           name: Create localstack queues
           command: |
+            export AWS_DEFAULT_REGION=eu-west-2
+
             aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue
             aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue_dl
             aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_prison_events_queue_dl\"}"}'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,30 @@ parameters:
     type: string
     default: 14.17-browsers
 
+executors:
+  integration-tests:
+    docker:
+      - image: 'cimg/node:<<parameters.node_tag>>'
+      - image: 'circleci/redis:<<parameters.redis_tag>>'
+      - image: 'localstack/localstack:0.11.2'
+        environment:
+          SERVICES: sqs
+          DATA_DIR: /tmp/localstack/data
+          TMP_DIR: /private
+          DEFAULT_REGION: eu-west-2
+    working_directory: ~/app
+    resource_class: <<parameters.resource_class>>
+    parameters:
+      resource_class:
+        default: medium
+        type: string
+      node_tag:
+        default: "14.16-browsers"
+        type: string
+      redis_tag:
+        default: "buster"
+        type: string
+
 jobs:
   build:
     executor:
@@ -98,17 +122,30 @@ jobs:
           path: test-results/unit-test-reports.html
 
   integration_test:
-    executor:
-      name: hmpps/node_redis
-      node_tag: << pipeline.parameters.node-version >>
-      redis_tag: buster
+    executor: integration-tests
     steps:
+      - hmpps/install_aws_cli
       - checkout
       - attach_workspace:
           at: ~/app
       - run:
           name: Install missing OS dependency
           command: sudo apt-get install libxss1
+      - hmpps/wait_till_ready # Wait for localstack to start before creating resources
+      - run:
+        name: Create localstack queues
+        command: |
+          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue
+          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue_dl
+          aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_prison_events_queue_dl\"}"}'
+
+          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue
+          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue_dl
+          aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_probation_events_queue_dl\"}"}'
+
+          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue
+          aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue_dl
+          aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_domain_events_queue_dl\"}"}'
       - run:
           name: Get wiremock
           command: curl -o wiremock.jar https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.27.1/wiremock-standalone-2.27.1.jar

--- a/integration_tests/integration/eventHandlers.spec.ts
+++ b/integration_tests/integration/eventHandlers.spec.ts
@@ -4,10 +4,9 @@ context('Event handlers', () => {
     cy.task('stubSystemToken')
   })
 
-  describe('RELEASED event', () => {
-    it('should call endpoint to update licence status to ACTIVE', () => {
-      cy.task('stubGetExistingLicenceForOffenderWithResult')
-      cy.task('stubGetLicencesForOffender', { nomisId: 'ABC1234', status: 'APPROVED' })
+  describe('Domain events', () => {
+    it('should listen to the released event and call endpoint to update licence status to ACTIVE', () => {
+      cy.task('stubGetLicencesForOffender', { nomisId: 'A7774DY', status: 'APPROVED' })
       cy.task('stubUpdateLicenceStatus')
 
       cy.task(
@@ -16,6 +15,10 @@ context('Event handlers', () => {
             "Message" :  "{\\"eventType\\":\\"prison-offender-events.prisoner.released\\",\\"additionalInformation\\":{\\"nomsNumber\\":\\"A7774DY\\",\\"reason\\":\\"RELEASED\\",\\"details\\":\\"Movement reason code CR\\",\\"currentLocation\\":\\"OUTSIDE_PRISON\\",\\"prisonId\\":\\"MDI\\",\\"currentPrisonStatus\\":\\"NOT_UNDER_PRISON_CARE\\"},\\"version\\":1,\\"occurredAt\\":\\"2022-01-12T14:56:51.662128Z\\",\\"publishedAt\\":\\"2022-01-12T14:58:25.021008001Z\\",\\"description\\":\\"A prisoner has been released from prison\\"}"
          }`
       )
+
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 }).then(result => {
+        if (!result) throw new Error(`Endpoint called an unexpected number of times`)
+      })
     })
   })
 })

--- a/integration_tests/integration/eventHandlers.spec.ts
+++ b/integration_tests/integration/eventHandlers.spec.ts
@@ -1,6 +1,7 @@
 context('Event handlers', () => {
   beforeEach(() => {
     cy.task('reset')
+    cy.task('purgeQueues')
     cy.task('stubSystemToken')
   })
 
@@ -16,8 +17,8 @@ context('Event handlers', () => {
          }`
       )
 
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 }).then(result => {
-        if (!result) throw new Error(`Endpoint called an unexpected number of times`)
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 }).then(success => {
+        if (!success) throw new Error(`Endpoint called an unexpected number of times`)
       })
     })
   })

--- a/integration_tests/integration/eventHandlers.spec.ts
+++ b/integration_tests/integration/eventHandlers.spec.ts
@@ -1,0 +1,21 @@
+context('Event handlers', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSystemToken')
+  })
+
+  describe('RELEASED event', () => {
+    it('should call endpoint to update licence status to ACTIVE', () => {
+      cy.task('stubGetExistingLicenceForOffenderWithResult')
+      cy.task('stubGetLicencesForOffender', { nomisId: 'ABC1234', status: 'APPROVED' })
+      cy.task('stubUpdateLicenceStatus')
+
+      cy.task(
+        'sendDomainEvent',
+        `{
+            "Message" :  "{\\"eventType\\":\\"prison-offender-events.prisoner.released\\",\\"additionalInformation\\":{\\"nomsNumber\\":\\"A7774DY\\",\\"reason\\":\\"RELEASED\\",\\"details\\":\\"Movement reason code CR\\",\\"currentLocation\\":\\"OUTSIDE_PRISON\\",\\"prisonId\\":\\"MDI\\",\\"currentPrisonStatus\\":\\"NOT_UNDER_PRISON_CARE\\"},\\"version\\":1,\\"occurredAt\\":\\"2022-01-12T14:56:51.662128Z\\",\\"publishedAt\\":\\"2022-01-12T14:58:25.021008001Z\\",\\"description\\":\\"A prisoner has been released from prison\\"}"
+         }`
+      )
+    })
+  })
+})

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -168,6 +168,7 @@ export default {
       token(['ROLE_LICENCE_RO'], 'delius'),
       tokenVerification.stubVerifyToken(),
     ]),
+  systemToken: () => token(null, 'auth'),
   stubPrisonSignIn: (): Promise<[Response, Response, Response, Response, Response]> =>
     Promise.all([
       favicon(),

--- a/integration_tests/mockApis/licence.ts
+++ b/integration_tests/mockApis/licence.ts
@@ -290,6 +290,34 @@ export default {
     })
   },
 
+  stubGetLicencesForOffender: (options: { nomisId: string; status: string }): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPathPattern: `/licence/match`,
+        queryParameters: {
+          nomsId: {
+            matches: options.nomisId,
+          },
+          status: {
+            matches: '.*',
+          },
+        },
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: [
+          {
+            licenceId: 1,
+            nomisId: options.nomisId,
+            licenceStatus: options.status,
+          },
+        ],
+      },
+    })
+  },
+
   stubPutAppointmentPerson: (): SuperAgentRequest => {
     return stubFor({
       request: {

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -1,4 +1,4 @@
-import { resetStubs } from '../wiremock'
+import { resetStubs, verifyEndpointCalled } from '../wiremock'
 
 import auth from '../mockApis/auth'
 import tokenVerification from '../mockApis/tokenVerification'
@@ -12,6 +12,7 @@ import events from '../support/events'
 export default (on: (string, Record) => void): void => {
   on('task', {
     reset: resetStubs,
+    verifyEndpointCalled,
 
     getSignInUrl: auth.getSignInUrl,
     stubPrisonSignIn: auth.stubPrisonSignIn,

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -59,5 +59,6 @@ export default (on: (string, Record) => void): void => {
     sendDomainEvent: events.sendDomainEvent,
     sendPrisonEvent: events.sendPrisonEvent,
     sendProbationEvent: events.sendProbationEvent,
+    purgeQueues: events.purgeQueues,
   })
 }

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -7,6 +7,7 @@ import community from '../mockApis/community'
 import prisonerSearch from '../mockApis/prisonerSearch'
 import prison from '../mockApis/prison'
 import probationSearch from '../mockApis/probationSearch'
+import events from '../support/events'
 
 export default (on: (string, Record) => void): void => {
   on('task', {
@@ -17,12 +18,14 @@ export default (on: (string, Record) => void): void => {
     stubProbationSignIn: auth.stubProbationSignIn,
     stubAuthUser: auth.stubUser,
     stubAuthPing: auth.stubPing,
+    stubSystemToken: auth.systemToken,
 
     stubTokenVerificationPing: tokenVerification.stubPing,
 
     stubGetLicence: licence.stubGetLicence,
     stubPostLicence: licence.stubPostLicence,
     stubGetExistingLicenceForOffenderWithResult: licence.stubGetExistingLicenceForOffenderWithResult,
+    stubGetLicencesForOffender: licence.stubGetLicencesForOffender,
     stubPutAppointmentPerson: licence.stubPutAppointmentPerson,
     stubPutAppointmentTime: licence.stubPutAppointmentTime,
     stubPutAppointmentAddress: licence.stubPutAppointmentAddress,
@@ -51,5 +54,9 @@ export default (on: (string, Record) => void): void => {
     stubGetHdcStatus: prison.stubGetHdcStatus,
 
     stubGetProbationer: probationSearch.stubGetProbationer,
+
+    sendDomainEvent: events.sendDomainEvent,
+    sendPrisonEvent: events.sendPrisonEvent,
+    sendProbationEvent: events.sendProbationEvent,
   })
 }

--- a/integration_tests/support/events.ts
+++ b/integration_tests/support/events.ts
@@ -1,7 +1,11 @@
 import AWS from 'aws-sdk'
 import { SendMessageRequest } from 'aws-sdk/clients/sqs'
 
-const sqs = new AWS.SQS({ region: 'eu-west-2' })
+const sqs = new AWS.SQS({
+  region: 'eu-west-2',
+  accessKeyId: 'foo',
+  secretAccessKey: 'bar',
+})
 
 const sendMessage = (message: SendMessageRequest): void => {
   sqs.sendMessage(message, (err, data) => {

--- a/integration_tests/support/events.ts
+++ b/integration_tests/support/events.ts
@@ -3,7 +3,7 @@ import { SendMessageRequest } from 'aws-sdk/clients/sqs'
 
 const sqs = new AWS.SQS({ region: 'eu-west-2' })
 
-const sendMessage = (message: SendMessageRequest): unknown => {
+const sendMessage = (message: SendMessageRequest): void => {
   sqs.sendMessage(message, (err, data) => {
     if (err) {
       // eslint-disable-next-line no-console
@@ -13,28 +13,58 @@ const sendMessage = (message: SendMessageRequest): unknown => {
       console.log('Successfully added message', data.MessageId)
     }
   })
+}
+
+const purgeQueues = (): unknown => {
+  sqs.purgeQueue({ QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue' }, err => {
+    if (err) {
+      // eslint-disable-next-line no-console
+      console.log('Error', err)
+    }
+  })
+  sqs.purgeQueue({ QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue' }, err => {
+    if (err) {
+      // eslint-disable-next-line no-console
+      console.log('Error', err)
+    }
+  })
+  sqs.purgeQueue({ QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue' }, err => {
+    if (err) {
+      // eslint-disable-next-line no-console
+      console.log('Error', err)
+    }
+  })
   return null
 }
 
-const sendDomainEvent = (body: string): unknown => {
-  return sendMessage({
+const sendDomainEvent = async (body: string): Promise<unknown> => {
+  sendMessage({
     QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue',
     MessageBody: body,
   })
+  // Wait for the event listener to clear the queue
+  await new Promise(resolve => setTimeout(resolve, 10000))
+  return null
 }
 
-const sendPrisonEvent = (body: string): unknown => {
-  return sendMessage({
+const sendPrisonEvent = async (body: string): Promise<unknown> => {
+  sendMessage({
     QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue',
     MessageBody: body,
   })
+  // Wait for the event listener to clear the queue
+  await new Promise(resolve => setTimeout(resolve, 10000))
+  return null
 }
 
-const sendProbationEvent = (body: string): unknown => {
-  return sendMessage({
+const sendProbationEvent = async (body: string): Promise<unknown> => {
+  sendMessage({
     QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue',
     MessageBody: body,
   })
+  // Wait for the event listener to clear the queue
+  await new Promise(resolve => setTimeout(resolve, 10000))
+  return null
 }
 
-export default { sendDomainEvent, sendPrisonEvent, sendProbationEvent }
+export default { sendDomainEvent, sendPrisonEvent, sendProbationEvent, purgeQueues }

--- a/integration_tests/support/events.ts
+++ b/integration_tests/support/events.ts
@@ -1,0 +1,40 @@
+import AWS from 'aws-sdk'
+import { SendMessageRequest } from 'aws-sdk/clients/sqs'
+
+const sqs = new AWS.SQS({ region: 'eu-west-2' })
+
+const sendMessage = (message: SendMessageRequest): unknown => {
+  sqs.sendMessage(message, (err, data) => {
+    if (err) {
+      // eslint-disable-next-line no-console
+      console.log('Error', err)
+    } else {
+      // eslint-disable-next-line no-console
+      console.log('Successfully added message', data.MessageId)
+    }
+  })
+  return null
+}
+
+const sendDomainEvent = (body: string): unknown => {
+  return sendMessage({
+    QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue',
+    MessageBody: body,
+  })
+}
+
+const sendPrisonEvent = (body: string): unknown => {
+  return sendMessage({
+    QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue',
+    MessageBody: body,
+  })
+}
+
+const sendProbationEvent = (body: string): unknown => {
+  return sendMessage({
+    QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue',
+    MessageBody: body,
+  })
+}
+
+export default { sendDomainEvent, sendPrisonEvent, sendProbationEvent }

--- a/integration_tests/wiremock.ts
+++ b/integration_tests/wiremock.ts
@@ -11,8 +11,6 @@ const resetStubs = (): Promise<Array<Response>> =>
   Promise.all([superagent.delete(`${url}/mappings`), superagent.delete(`${url}/requests`)])
 
 const verifyEndpointCalled = async (options: { verb: string; path: string; times: number }): Promise<boolean> => {
-  // wait for wiremock to update the request counts
-  await new Promise(resolve => setTimeout(resolve, 5000))
   return superagent
     .post('http://localhost:9091/__admin/requests/count')
     .send({

--- a/integration_tests/wiremock.ts
+++ b/integration_tests/wiremock.ts
@@ -10,4 +10,17 @@ const getRequests = (): SuperAgentRequest => superagent.get(`${url}/requests`)
 const resetStubs = (): Promise<Array<Response>> =>
   Promise.all([superagent.delete(`${url}/mappings`), superagent.delete(`${url}/requests`)])
 
-export { stubFor, getRequests, resetStubs }
+const verifyEndpointCalled = async (options: { verb: string; path: string; times: number }): Promise<boolean> => {
+  // wait for wiremock to update the request counts
+  await new Promise(resolve => setTimeout(resolve, 5000))
+  return superagent
+    .post('http://localhost:9091/__admin/requests/count')
+    .send({
+      method: options.verb,
+      url: options.path,
+    })
+    .then(response => response.body)
+    .then(response => response.count === options.times)
+}
+
+export { stubFor, getRequests, resetStubs, verifyEndpointCalled }

--- a/server/config.ts
+++ b/server/config.ts
@@ -46,8 +46,8 @@ export default {
   },
   sqs: {
     prisonEvents: {
-      accessKeyId: get('SQS_PRISON_EVENTS_ACCESS_KEY_ID', '', requiredInProduction),
-      secretAccessKey: get('SQS_PRISON_EVENTS_SECRET_ACCESS_KEY', '', requiredInProduction),
+      accessKeyId: get('SQS_PRISON_EVENTS_ACCESS_KEY_ID', 'foo', requiredInProduction),
+      secretAccessKey: get('SQS_PRISON_EVENTS_SECRET_ACCESS_KEY', 'bar', requiredInProduction),
       queueUrl: get(
         'SQS_PRISON_EVENTS_QUEUE_URL',
         'http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue',
@@ -55,8 +55,8 @@ export default {
       ),
     },
     probationEvents: {
-      accessKeyId: get('SQS_PROBATION_EVENTS_ACCESS_KEY_ID', '', requiredInProduction),
-      secretAccessKey: get('SQS_PROBATION_EVENTS_SECRET_ACCESS_KEY', '', requiredInProduction),
+      accessKeyId: get('SQS_PROBATION_EVENTS_ACCESS_KEY_ID', 'foo', requiredInProduction),
+      secretAccessKey: get('SQS_PROBATION_EVENTS_SECRET_ACCESS_KEY', 'bar', requiredInProduction),
       queueUrl: get(
         'SQS_PROBATION_EVENTS_QUEUE_URL',
         'http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue',
@@ -64,8 +64,8 @@ export default {
       ),
     },
     domainEvents: {
-      accessKeyId: get('SQS_DOMAIN_EVENTS_ACCESS_KEY_ID', '', requiredInProduction),
-      secretAccessKey: get('SQS_DOMAIN_EVENTS_SECRET_ACCESS_KEY', '', requiredInProduction),
+      accessKeyId: get('SQS_DOMAIN_EVENTS_ACCESS_KEY_ID', 'foo', requiredInProduction),
+      secretAccessKey: get('SQS_DOMAIN_EVENTS_SECRET_ACCESS_KEY', 'bar', requiredInProduction),
       queueUrl: get(
         'SQS_DOMAIN_EVENTS_QUEUE_URL',
         'http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue',

--- a/server/listeners/eventHandlers/domainEvents/index.ts
+++ b/server/listeners/eventHandlers/domainEvents/index.ts
@@ -14,7 +14,7 @@ export default function buildEventHandler({ licenceService }: Services) {
 
       switch (domainEvent.eventType) {
         case 'prison-offender-events.prisoner.released':
-          releaseEventHandler.handle(domainEvent)
+          releaseEventHandler.handle(domainEvent).catch(error => logger.error(error))
       }
     })
   }


### PR DESCRIPTION
- Created custom CircleCi executor including localstack (pathfinder and manage intelligence have done this, should add it to the orb for future and other projects?)
- Created queues in localstack for integration test
- Added new integration test helper to push events onto the stack
- Added new helper to check wiremock `count` endpoint to assert the correct endpoint is called after consuming an event
- Handled rejected promise from the event handler