### PR TITLE
Wait for 10 seconds for localstack to be ready before creating resources

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,9 @@ jobs:
       - run:
           name: Install missing OS dependency
           command: sudo apt-get install libxss1
-      - hmpps/wait_till_ready # Wait for localstack to start before creating resources
+      - run:
+          name: Wait for localstack to start before creating resources
+          command: sleep 10
       - run:
           name: Create localstack queues
           command: |


### PR DESCRIPTION
- Pathfinder uses the `hmpps/wait_till_ready` command, but this will wait for ports to start accepting requests. This is not necessarily the same time that localstack is ready to start creating resources.
- Manage intelligence project simply waits 10 seconds.
- If this still experiences problems, we can do a more sophisticated check by logging out the localstack logs and grepping for "READY"