### PR TITLE
CVSL-308: Team caseload view

### DIFF
--- a/integration_tests/mockApis/community.ts
+++ b/integration_tests/mockApis/community.ts
@@ -47,7 +47,12 @@ export default {
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/secure/staff/staffIdentifier/2000/managedOffenders`,
+        urlPathPattern: `/secure/staff/staffIdentifier/2000/managedOffenders`,
+        queryParameters: {
+          current: {
+            matches: 'true',
+          },
+        },
       },
       response: {
         status: 200,

--- a/server/@types/communityApiImport/index.d.ts
+++ b/server/@types/communityApiImport/index.d.ts
@@ -1019,6 +1019,14 @@ export interface definitions {
     staffCode: string
     staffIdentifier: number
   }
+  TeamManagedCase: {
+    nomsNumber: string
+    crnNumber: string
+    allocated: boolean
+    staffIdentifier: number
+    staffForename: string
+    staffSurname: string
+  }
   /** MAPPA Details */
   MappaDetails: {
     /** MAPPA Category (0 = unknown) */

--- a/server/@types/communityClientTypes.ts
+++ b/server/@types/communityClientTypes.ts
@@ -1,7 +1,4 @@
 import { definitions } from './communityApiImport'
 
-// export type CommunityApiOffenderDetail = definitions['OffenderDetail']
 export type CommunityApiManagedOffender = definitions['ManagedOffender']
 export type CommunityApiStaffDetails = definitions['StaffDetails']
-export type CommunityApiTeam = definitions['Team']
-export type CommunityApiHuman = definitions['Human']

--- a/server/@types/communityClientTypes.ts
+++ b/server/@types/communityClientTypes.ts
@@ -2,3 +2,7 @@ import { definitions } from './communityApiImport'
 
 export type CommunityApiManagedOffender = definitions['ManagedOffender']
 export type CommunityApiStaffDetails = definitions['StaffDetails']
+
+// TODO: Return the correct type imported from Community-API when the teams/managaedOffenders endpoint is in.
+//  At the moment, delius-wiremock returns a subset of CommunityApiManagedOffender
+export type CommunityApiTeamManagedCase = definitions['TeamManagedCase']

--- a/server/@types/managedCase.ts
+++ b/server/@types/managedCase.ts
@@ -1,9 +1,9 @@
-import { CommunityApiManagedOffender } from './communityClientTypes'
+import { CommunityApiManagedOffender, CommunityApiTeamManagedCase } from './communityClientTypes'
 import { Prisoner } from './prisonerSearchApiClientTypes'
 import LicenceStatus from '../enumeration/licenceStatus'
 import LicenceType from '../enumeration/licenceType'
 
-export type ManagedCase = CommunityApiManagedOffender & Prisoner
+export type ManagedCase = CommunityApiManagedOffender & Prisoner & CommunityApiTeamManagedCase
 export interface CaseTypeAndStatus extends ManagedCase {
   licenceStatus: LicenceStatus
   licenceType: LicenceType

--- a/server/data/communityApiClient.test.ts
+++ b/server/data/communityApiClient.test.ts
@@ -1,6 +1,10 @@
 import HmppsRestClient from './hmppsRestClient'
 import CommunityApiClient from './communityApiClient'
-import { CommunityApiManagedOffender, CommunityApiStaffDetails } from '../@types/communityClientTypes'
+import {
+  CommunityApiManagedOffender,
+  CommunityApiStaffDetails,
+  CommunityApiTeamManagedCase,
+} from '../@types/communityClientTypes'
 import { User } from '../@types/CvlUserDetails'
 
 jest.mock('./tokenStore', () => {
@@ -22,21 +26,36 @@ describe('Community Api client tests', () => {
     jest.resetAllMocks()
   })
 
-  it('Get staff detail by username', async () => {
+  it('Get staff detail', async () => {
     get.mockResolvedValue({ staffIdentifier: 2000 } as CommunityApiStaffDetails)
 
-    const result = await communityApiClient.getStaffDetailByUsername({ username: 'joebloggs' } as User)
+    const result = await communityApiClient.getStaffDetail({ username: 'joebloggs' } as User)
 
     expect(get).toHaveBeenCalledWith({ path: '/secure/staff/username/joebloggs' })
     expect(result).toEqual({ staffIdentifier: 2000 })
   })
 
-  it('Get staff detail by username', async () => {
+  it('Get staff caseload', async () => {
     get.mockResolvedValue({ nomsNumber: 'ABC1234' } as CommunityApiManagedOffender)
 
     const result = await communityApiClient.getStaffCaseload(2000)
 
-    expect(get).toHaveBeenCalledWith({ path: '/secure/staff/staffIdentifier/2000/managedOffenders' })
+    expect(get).toHaveBeenCalledWith({
+      path: '/secure/staff/staffIdentifier/2000/managedOffenders',
+      query: { current: true },
+    })
+    expect(result).toEqual({ nomsNumber: 'ABC1234' })
+  })
+
+  it('Get team caseload', async () => {
+    get.mockResolvedValue({ nomsNumber: 'ABC1234' } as CommunityApiTeamManagedCase)
+
+    const result = await communityApiClient.getTeamCaseload(['teamA', 'teamB'])
+
+    expect(get).toHaveBeenCalledWith({
+      path: '/secure/teams/managedOffenders',
+      query: { current: true, teamCode: ['teamA', 'teamB'] },
+    })
     expect(result).toEqual({ nomsNumber: 'ABC1234' })
   })
 })

--- a/server/data/communityApiClient.ts
+++ b/server/data/communityApiClient.ts
@@ -23,8 +23,7 @@ export default class CommunityApiClient extends RestClient {
 
   async getTeamCaseload(teamCodes: string[]): Promise<CommunityApiManagedOffender[]> {
     return (await this.get({
-      // path: `/secure/teams/managedOffenders`,
-      path: `/secure/staff/staffIdentifier/2000/managedOffenders`,
+      path: `/secure/teams/managedOffenders`,
       query: { teamCode: teamCodes, current: true },
     })) as Promise<CommunityApiManagedOffender[]>
   }

--- a/server/data/communityApiClient.ts
+++ b/server/data/communityApiClient.ts
@@ -17,6 +17,15 @@ export default class CommunityApiClient extends RestClient {
   async getStaffCaseload(staffId: number): Promise<CommunityApiManagedOffender[]> {
     return (await this.get({
       path: `/secure/staff/staffIdentifier/${staffId}/managedOffenders`,
+      query: { current: true },
+    })) as Promise<CommunityApiManagedOffender[]>
+  }
+
+  async getTeamCaseload(teamCodes: string[]): Promise<CommunityApiManagedOffender[]> {
+    return (await this.get({
+      // path: `/secure/teams/managedOffenders`,
+      path: `/secure/staff/staffIdentifier/2000/managedOffenders`,
+      query: { teamCode: teamCodes, current: true },
     })) as Promise<CommunityApiManagedOffender[]>
   }
 }

--- a/server/data/communityApiClient.ts
+++ b/server/data/communityApiClient.ts
@@ -12,7 +12,7 @@ export default class CommunityApiClient extends RestClient {
     super('Community API', config.apis.communityApi as ApiConfig)
   }
 
-  async getStaffDetailByUsername(user: User): Promise<CommunityApiStaffDetails> {
+  async getStaffDetail(user: User): Promise<CommunityApiStaffDetails> {
     return (await this.get({
       path: `/secure/staff/username/${user.username}`,
     })) as Promise<CommunityApiStaffDetails>

--- a/server/data/communityApiClient.ts
+++ b/server/data/communityApiClient.ts
@@ -1,6 +1,10 @@
 import config, { ApiConfig } from '../config'
 import RestClient from './hmppsRestClient'
-import { CommunityApiStaffDetails, CommunityApiManagedOffender } from '../@types/communityClientTypes'
+import {
+  CommunityApiStaffDetails,
+  CommunityApiManagedOffender,
+  CommunityApiTeamManagedCase,
+} from '../@types/communityClientTypes'
 import { User } from '../@types/CvlUserDetails'
 
 export default class CommunityApiClient extends RestClient {
@@ -21,10 +25,10 @@ export default class CommunityApiClient extends RestClient {
     })) as Promise<CommunityApiManagedOffender[]>
   }
 
-  async getTeamCaseload(teamCodes: string[]): Promise<CommunityApiManagedOffender[]> {
+  async getTeamCaseload(teamCodes: string[]): Promise<CommunityApiTeamManagedCase[]> {
     return (await this.get({
       path: `/secure/teams/managedOffenders`,
       query: { teamCode: teamCodes, current: true },
-    })) as Promise<CommunityApiManagedOffender[]>
+    })) as Promise<CommunityApiTeamManagedCase[]>
   }
 }

--- a/server/routes/creatingLicences/handlers/caseload.test.ts
+++ b/server/routes/creatingLicences/handlers/caseload.test.ts
@@ -32,11 +32,29 @@ describe('Route Handlers - Create Licence - Caseload', () => {
         licenceType: LicenceType.AP,
       },
     ] as unknown as CaseTypeAndStatus[])
+
+    caseloadService.getTeamCaseload.mockResolvedValue([
+      {
+        crnNumber: 'X381306',
+        firstName: 'Joe',
+        lastName: 'Rogan',
+        conditionalReleaseDate: '2022-10-12',
+        prisonerNumber: '123',
+        licenceStatus: LicenceStatus.IN_PROGRESS,
+        licenceType: LicenceType.AP,
+      },
+    ] as unknown as CaseTypeAndStatus[])
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
   })
 
   describe('GET', () => {
     beforeEach(() => {
-      req = {} as Request
+      req = {
+        query: {},
+      } as Request
 
       res = {
         render: jest.fn(),
@@ -49,7 +67,7 @@ describe('Route Handlers - Create Licence - Caseload', () => {
       } as unknown as Response
     })
 
-    it('should render view', async () => {
+    it('should render view with My Cases tab selected', async () => {
       await handler.GET(req, res)
       expect(res.render).toHaveBeenCalledWith('pages/create/caseload', {
         caseload: [
@@ -63,8 +81,32 @@ describe('Route Handlers - Create Licence - Caseload', () => {
           },
         ],
         statusConfig,
+        teamView: false,
       })
       expect(caseloadService.getStaffCaseload).toHaveBeenCalledWith(res.locals.user)
+      expect(caseloadService.getTeamCaseload).not.toHaveBeenCalled()
+    })
+
+    it('should render view with Team Cases tab selected', async () => {
+      req.query = { view: 'team' }
+
+      await handler.GET(req, res)
+      expect(res.render).toHaveBeenCalledWith('pages/create/caseload', {
+        caseload: [
+          {
+            name: 'Joe Rogan',
+            crnNumber: 'X381306',
+            conditionalReleaseDate: '12th October 2022',
+            prisonerNumber: '123',
+            licenceStatus: LicenceStatus.IN_PROGRESS,
+            licenceType: LicenceType.AP,
+          },
+        ],
+        statusConfig,
+        teamView: true,
+      })
+      expect(caseloadService.getTeamCaseload).toHaveBeenCalledWith(res.locals.user)
+      expect(caseloadService.getStaffCaseload).not.toHaveBeenCalled()
     })
   })
 

--- a/server/routes/creatingLicences/handlers/caseload.ts
+++ b/server/routes/creatingLicences/handlers/caseload.ts
@@ -10,8 +10,14 @@ export default class CaseloadRoutes {
   constructor(private readonly licenceService: LicenceService, private readonly caseloadService: CaseloadService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
+    const teamView = req.query.view === 'team'
+
     const { user } = res.locals
-    const caseload = await this.caseloadService.getStaffCaseload(user)
+
+    const caseload = teamView
+      ? await this.caseloadService.getTeamCaseload(user)
+      : await this.caseloadService.getStaffCaseload(user)
+
     const caseloadViewModel = caseload.map(offender => {
       return {
         name: convertToTitleCase([offender.firstName, offender.lastName].join(' ')),
@@ -22,7 +28,7 @@ export default class CaseloadRoutes {
         licenceType: offender.licenceType,
       }
     })
-    res.render('pages/create/caseload', { caseload: caseloadViewModel, statusConfig })
+    res.render('pages/create/caseload', { caseload: caseloadViewModel, statusConfig, teamView })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {

--- a/server/services/caseloadService.ts
+++ b/server/services/caseloadService.ts
@@ -2,7 +2,7 @@ import moment from 'moment'
 import CommunityService from './communityService'
 import PrisonerService from './prisonerService'
 import LicenceService from './licenceService'
-import { CaseTypeAndStatus, ManagedCase } from '../@types/managedCase'
+import { CaseTypeAndStatus } from '../@types/managedCase'
 import LicenceStatus from '../enumeration/licenceStatus'
 import LicenceType from '../enumeration/licenceType'
 import { User } from '../@types/CvlUserDetails'
@@ -17,58 +17,60 @@ export default class CaseloadService {
 
   async getStaffCaseload(user: User): Promise<CaseTypeAndStatus[]> {
     const { deliusStaffIdentifier } = user
+
+    const managedOffenders = await this.communityService.getManagedOffenders(deliusStaffIdentifier)
+
+    const caseloadNomisIds = managedOffenders
+      .filter(offender => offender.nomsNumber)
+      .map(offender => offender.nomsNumber)
+
+    const offendersLicences = await this.mapOffendersToLicences(caseloadNomisIds, user)
+
+    // Combine nomis + licence record with matching delius record by nomisId
+    return offendersLicences.map(offender => {
+      return { ...offender, ...managedOffenders.find(o => o.nomsNumber === offender.prisonerNumber) }
+    })
+  }
+
+  async getTeamCaseload(user: User): Promise<CaseTypeAndStatus[]> {
+    const { probationTeams } = user
+
+    const managedOffenders = await this.communityService.getManagedOffendersByTeam(probationTeams)
+
+    const caseloadNomisIds = managedOffenders
+      .filter(offender => offender.nomsNumber)
+      .map(offender => offender.nomsNumber)
+
+    const offendersLicences = await this.mapOffendersToLicences(caseloadNomisIds, user)
+
+    // Combine nomis + licence record with matching delius record by nomisId
+    return offendersLicences.map(offender => {
+      return { ...offender, ...managedOffenders.find(o => o.nomsNumber === offender.prisonerNumber) }
+    })
+  }
+
+  async getVaryCaseload(user: User): Promise<LicenceSummary[]> {
+    const { deliusStaffIdentifier } = user
     const managedOffenders = await this.communityService.getManagedOffenders(deliusStaffIdentifier)
     const caseloadNomisIds = managedOffenders
       .filter(offender => offender.currentOm)
       .filter(offender => offender.nomsNumber)
       .map(offender => offender.nomsNumber)
 
-    const existingLicences = await this.licenceService.getLicencesByNomisIdsAndStatus(
-      caseloadNomisIds,
-      [
-        LicenceStatus.ACTIVE,
-        LicenceStatus.RECALLED,
-        LicenceStatus.IN_PROGRESS,
-        LicenceStatus.SUBMITTED,
-        LicenceStatus.APPROVED,
-        LicenceStatus.REJECTED,
-      ],
-      user
-    )
+    return this.licenceService.getLicencesByNomisIdsAndStatus(caseloadNomisIds, [LicenceStatus.ACTIVE], user)
+  }
 
-    // Get the full offender records from prisoner search
-    const offenders = await this.prisonerService.searchPrisonersByNomisIds(caseloadNomisIds, user)
+  private mapOffendersToLicences = async (caseloadNomisIds: string[], user: User): Promise<CaseTypeAndStatus[]> => {
+    const [offenders, existingLicences] = await Promise.all([
+      this.getOffendersEligibleForLicenceByNomisId(caseloadNomisIds, user),
+      this.getExistingLicences(caseloadNomisIds, user),
+    ])
 
-    // Get the HDC status for all bookings in the prisoner list
-    const hdcStatuses = await this.prisonerService.getHdcStatuses(offenders, user)
+    // TODO: If the length(offenders) !== length(managedOffenders), it means a managed offender in delius was not found in nomis and a NO_RECORD should be raised
 
-    // Filter the cases by the case list rules
     return offenders
       .map(offender => {
-        const matchingDeliusCase = managedOffenders.find(
-          deliusCase => deliusCase.nomsNumber === offender.prisonerNumber
-        )
-        // TODO: If the nomisId in Delius does not match a prison record - filter for now, will revisit to add a NO_RECORD
-        if (!matchingDeliusCase) {
-          return null
-        }
-        return { ...matchingDeliusCase, ...offender } as ManagedCase
-      })
-      .filter(managedCase => managedCase)
-      .filter(managedCase => !managedCase.paroleEligibilityDate)
-      .filter(managedCase => managedCase.legalStatus !== 'DEAD')
-      .filter(managedCase => managedCase.status && managedCase.status.startsWith('ACTIVE'))
-      .filter(managedCase => !managedCase.indeterminateSentence && managedCase.conditionalReleaseDate)
-      .filter(
-        managedCase =>
-          !managedCase.releaseDate || moment().isSameOrBefore(moment(managedCase.releaseDate, 'YYYY-MM-DD'))
-      )
-      .filter(managedCase => {
-        const hdcStatus = hdcStatuses.find(hdc => hdc.bookingId === managedCase.bookingId)
-        return !hdcStatus?.eligibleForHdc
-      })
-      .map(managedCase => {
-        const existingLicence = existingLicences.find(licence => licence.nomisId === managedCase.nomsNumber)
+        const existingLicence = existingLicences.find(licence => licence.nomisId === offender.prisonerNumber)
         if (existingLicence) {
           if (
             existingLicence.licenceStatus === LicenceStatus.ACTIVE ||
@@ -81,7 +83,7 @@ export default class CaseloadService {
 
           // Return a case in the list for the existing licence
           return {
-            ...managedCase,
+            ...offender,
             licenceStatus: existingLicence.licenceStatus,
             licenceType: existingLicence.licenceType,
           } as CaseTypeAndStatus
@@ -89,31 +91,56 @@ export default class CaseloadService {
 
         // Work out the licence type from the prisoner search record
         const licenceType = this.getLicenceType(
-          managedCase.topupSupervisionExpiryDate,
-          managedCase.licenceExpiryDate,
-          managedCase.sentenceExpiryDate
+          offender.topupSupervisionExpiryDate,
+          offender.licenceExpiryDate,
+          offender.sentenceExpiryDate
         )
 
         // Create a case in the list in status NOT_STARTED
-        return { ...managedCase, licenceStatus: LicenceStatus.NOT_STARTED, licenceType } as CaseTypeAndStatus
+        return { ...offender, licenceStatus: LicenceStatus.NOT_STARTED, licenceType } as CaseTypeAndStatus
       })
       .filter(managedCase => managedCase)
+  }
+
+  private getExistingLicences = async (nomisIds: string[], user: User) => {
+    return this.licenceService.getLicencesByNomisIdsAndStatus(
+      nomisIds,
+      [
+        LicenceStatus.ACTIVE,
+        LicenceStatus.RECALLED,
+        LicenceStatus.IN_PROGRESS,
+        LicenceStatus.SUBMITTED,
+        LicenceStatus.APPROVED,
+        LicenceStatus.REJECTED,
+      ],
+      user
+    )
+  }
+
+  private getOffendersEligibleForLicenceByNomisId = async (nomisIds: string[], user: User) => {
+    let offenders = await this.prisonerService.searchPrisonersByNomisIds(nomisIds, user)
+    offenders = offenders
+      .filter(managedCase => !managedCase.paroleEligibilityDate)
+      .filter(managedCase => managedCase.legalStatus !== 'DEAD')
+      .filter(managedCase => managedCase.status && managedCase.status.startsWith('ACTIVE'))
+      .filter(managedCase => !managedCase.indeterminateSentence && managedCase.conditionalReleaseDate)
+      .filter(
+        managedCase =>
+          !managedCase.releaseDate || moment().isSameOrBefore(moment(managedCase.releaseDate, 'YYYY-MM-DD'))
+      )
+
+    const hdcStatuses = await this.prisonerService.getHdcStatuses(offenders, user)
+
+    return offenders
+      .filter(offender => {
+        const hdcStatus = hdcStatuses.find(hdc => hdc.bookingId === offender.bookingId)
+        return !hdcStatus?.eligibleForHdc
+      })
       .sort((a, b) => {
         const crd1 = moment(a.conditionalReleaseDate, 'YYYY-MM-DD').unix()
         const crd2 = moment(b.conditionalReleaseDate, 'YYYY-MM-DD').unix()
         return crd1 - crd2
       })
-  }
-
-  async getVaryCaseload(user: User): Promise<LicenceSummary[]> {
-    const { deliusStaffIdentifier } = user
-    const managedOffenders = await this.communityService.getManagedOffenders(deliusStaffIdentifier)
-    const caseloadNomisIds = managedOffenders
-      .filter(offender => offender.currentOm)
-      .filter(offender => offender.nomsNumber)
-      .map(offender => offender.nomsNumber)
-
-    return this.licenceService.getLicencesByNomisIdsAndStatus(caseloadNomisIds, [LicenceStatus.ACTIVE], user)
   }
 
   private getLicenceType = (tused: string, led: string, sed: string): LicenceType => {

--- a/server/services/caseloadService.ts
+++ b/server/services/caseloadService.ts
@@ -53,7 +53,6 @@ export default class CaseloadService {
     const { deliusStaffIdentifier } = user
     const managedOffenders = await this.communityService.getManagedOffenders(deliusStaffIdentifier)
     const caseloadNomisIds = managedOffenders
-      .filter(offender => offender.currentOm)
       .filter(offender => offender.nomsNumber)
       .map(offender => offender.nomsNumber)
 

--- a/server/services/communityService.test.ts
+++ b/server/services/communityService.test.ts
@@ -2,7 +2,7 @@ import CommunityService from './communityService'
 import CommunityApiClient from '../data/communityApiClient'
 import ProbationSearchApiClient from '../data/probationSearchApiClient'
 import { User } from '../@types/CvlUserDetails'
-import { CommunityApiManagedOffender } from '../@types/communityClientTypes'
+import { CommunityApiManagedOffender, CommunityApiTeamManagedCase } from '../@types/communityClientTypes'
 import { OffenderDetail } from '../@types/probationSearchApiClientTypes'
 
 jest.mock('../data/communityApiClient')
@@ -21,12 +21,12 @@ describe('Community Service', () => {
       email: 'joebloggs@probation.gov.uk',
     }
 
-    communityApiClient.getStaffDetailByUsername.mockResolvedValue(expectedResponse)
+    communityApiClient.getStaffDetail.mockResolvedValue(expectedResponse)
 
     const actualResult = await communityService.getStaffDetail(user)
 
     expect(actualResult).toEqual(expectedResponse)
-    expect(communityApiClient.getStaffDetailByUsername).toHaveBeenCalledWith(user)
+    expect(communityApiClient.getStaffDetail).toHaveBeenCalledWith(user)
   })
 
   it('Get Managed Offenders', async () => {
@@ -43,6 +43,22 @@ describe('Community Service', () => {
 
     expect(actualResult).toEqual(expectedResponse)
     expect(communityApiClient.getStaffCaseload).toHaveBeenCalledWith(2000)
+  })
+
+  it('Get Managed Offenders By Team', async () => {
+    const expectedResponse = [
+      {
+        staffIdentifier: 2000,
+        nomsNumber: 'ABC123',
+      },
+    ] as CommunityApiTeamManagedCase[]
+
+    communityApiClient.getTeamCaseload.mockResolvedValue(expectedResponse)
+
+    const actualResult = await communityService.getManagedOffendersByTeam(['teamA'])
+
+    expect(actualResult).toEqual(expectedResponse)
+    expect(communityApiClient.getTeamCaseload).toHaveBeenCalledWith(['teamA'])
   })
 
   it('Search probationers', async () => {

--- a/server/services/communityService.ts
+++ b/server/services/communityService.ts
@@ -18,6 +18,10 @@ export default class CommunityService {
     return this.communityApiClient.getStaffCaseload(staffIdentifier)
   }
 
+  async getManagedOffendersByTeam(teamCodes: string[]): Promise<CommunityApiManagedOffender[]> {
+    return this.communityApiClient.getTeamCaseload(teamCodes)
+  }
+
   async searchProbationers(searchCriteria: SearchDto): Promise<OffenderDetail[]> {
     return this.probationSearchApiClient.searchProbationer(searchCriteria)
   }

--- a/server/services/communityService.ts
+++ b/server/services/communityService.ts
@@ -15,7 +15,7 @@ export default class CommunityService {
   ) {}
 
   async getStaffDetail(user: User): Promise<CommunityApiStaffDetails> {
-    return this.communityApiClient.getStaffDetailByUsername(user)
+    return this.communityApiClient.getStaffDetail(user)
   }
 
   async getManagedOffenders(staffIdentifier: number): Promise<CommunityApiManagedOffender[]> {

--- a/server/services/communityService.ts
+++ b/server/services/communityService.ts
@@ -1,7 +1,11 @@
 import CommunityApiClient from '../data/communityApiClient'
 import ProbationSearchApiClient from '../data/probationSearchApiClient'
 import { OffenderDetail, SearchDto } from '../@types/probationSearchApiClientTypes'
-import { CommunityApiManagedOffender, CommunityApiStaffDetails } from '../@types/communityClientTypes'
+import {
+  CommunityApiManagedOffender,
+  CommunityApiStaffDetails,
+  CommunityApiTeamManagedCase,
+} from '../@types/communityClientTypes'
 import { User } from '../@types/CvlUserDetails'
 
 export default class CommunityService {
@@ -18,7 +22,7 @@ export default class CommunityService {
     return this.communityApiClient.getStaffCaseload(staffIdentifier)
   }
 
-  async getManagedOffendersByTeam(teamCodes: string[]): Promise<CommunityApiManagedOffender[]> {
+  async getManagedOffendersByTeam(teamCodes: string[]): Promise<CommunityApiTeamManagedCase[]> {
     return this.communityApiClient.getTeamCaseload(teamCodes)
   }
 

--- a/server/views/pages/create/caseload.njk
+++ b/server/views/pages/create/caseload.njk
@@ -2,6 +2,7 @@
 
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 {% from "partials/statusBadge.njk" import statusBadge %}
 {% from "partials/licenceDescription.njk" import licenceDescription %}
 
@@ -49,9 +50,22 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-xl">Select a person to start creating their licence</h1>
+            <h1 class="govuk-heading-xl">Select a person to create licences and supervision orders</h1>
         </div>
     </div>
+
+    {{ mojSubNavigation({
+        label: 'Sub navigation',
+        items: [{
+            text: 'My cases',
+            href: '?view=me',
+            active: not teamView
+        }, {
+            text: 'Team cases',
+            href: '?view=team',
+            active: teamView
+        }]
+    }) }}
 
     <form method="POST">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">


### PR DESCRIPTION
- Refactored `caseloadService` to reuse the caseload filtering rules
- Cacheing can be introduced later if we feel we need it
- Increased test coverage of `caseloadService`
- Added new tab to caseload page
- Integrated with new `teams/managedCases` endpoint
- Removed the `currentOm` filter and replaced with the `?current=true` query parameter