### PR TITLE
CVSL-417: Varied conditions comparison

### DIFF
--- a/assets/sass/application-ie8.sass
+++ b/assets/sass/application-ie8.sass
@@ -15,4 +15,5 @@ $path: "/assets/images/"
 @import './components/link-button'
 @import './components/status-tags'
 @import './components/utils'
+@import './components/summary-card'
 @import './local'

--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -15,4 +15,5 @@ $path: "/assets/images/"
 @import './components/link-button'
 @import './components/status-tags'
 @import './components/utils'
+@import './components/summary-card'
 @import './local'

--- a/assets/sass/components/_summary-card.scss
+++ b/assets/sass/components/_summary-card.scss
@@ -1,0 +1,99 @@
+.summary-card {
+  border: 1px solid $govuk-border-colour;
+
+  /* Card header */
+  .summary-card__header {
+    border-bottom: 1px solid $govuk-border-colour;
+    align-items: center;
+    background-color: govuk-colour("light-grey");
+    padding: govuk-spacing(3);
+
+    @include govuk-media-query($from: desktop) {
+      display: flex;
+      justify-content: space-between;
+      align-items: start;
+    }
+  }
+
+  .summary-card__title {
+    @include govuk-font($size: 19, $weight: bold);
+    margin: 0;
+  }
+
+  .summary-card__meta {
+    @include govuk-font($size: 16);
+    display: block;
+    margin: 0;
+  }
+
+  .summary-card__actions {
+    @include govuk-font($size: 19);
+  }
+
+  .summary-card__actions-list {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
+  .summary-card__actions-list-item {
+    display: block;
+    white-space: nowrap;
+
+    @include govuk-media-query($from: desktop) {
+      display: inline-block;
+      margin-left: govuk-spacing(2);
+      text-align: right;
+    }
+  }
+
+  .summary-card__actions-list-item:first-child {
+    margin-left: 0;
+  }
+
+  /* Card body */
+  .summary-card__body {
+    @include govuk-font($size: 19);
+    padding: 0;
+  }
+
+  .govuk-table,
+  .govuk-summary-list,
+  .govuk-table {
+    margin-bottom: 0;
+  }
+
+  .govuk-summary-list__row:last-child,
+  .govuk-summary-list__row:last-child > *,
+  .govuk-table__row:last-child .govuk-table__cell {
+    border-bottom: 0;
+  }
+
+  .govuk-summary-list__key {
+    padding-left: 15px;
+  }
+
+  .govuk-summary-list__actions {
+    padding-right: 15px;
+  }
+
+  .govuk-summary-list__row--no-actions {
+    @include govuk-media-query($from: tablet) {
+      &:after {
+        content: "";
+        display: table-cell;
+        width: 10%;
+      }
+    }
+  }
+}
+
+@media print {
+  .summary-card__header {
+    break-inside: avoid;
+  }
+
+  .summary-card__actions {
+    display: none;
+  }
+}

--- a/server/@types/licenceApiClientTypes.ts
+++ b/server/@types/licenceApiClientTypes.ts
@@ -6,6 +6,7 @@ export type AppointmentPersonRequest = components['schemas']['AppointmentPersonR
 export type AppointmentTimeRequest = components['schemas']['AppointmentTimeRequest']
 export type AuditEvent = components['schemas']['AuditEvent']
 export type AuditRequest = components['schemas']['AuditRequest']
+export type BespokeCondition = components['schemas']['BespokeCondition']
 export type BespokeConditionsRequest = components['schemas']['BespokeConditionRequest']
 export type AdditionalConditionsRequest = components['schemas']['AdditionalConditionsRequest']
 export type UpdateAdditionalConditionDataRequest = components['schemas']['UpdateAdditionalConditionDataRequest']

--- a/server/enumeration/conditionType.ts
+++ b/server/enumeration/conditionType.ts
@@ -1,0 +1,7 @@
+enum ConditionType {
+  AP = 'AP',
+  PSS = 'PSS',
+  BESPOKE = 'Bespoke',
+}
+
+export default ConditionType

--- a/server/routes/approvingVariations/handlers/varyRefer.ts
+++ b/server/routes/approvingVariations/handlers/varyRefer.ts
@@ -6,9 +6,12 @@ export default class VaryReferRoutes {
   constructor(private readonly licenceService: LicenceService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
-    const { licence } = res.locals
+    const { licence, user } = res.locals
     if (licence?.statusCode === LicenceStatus.VARIATION_SUBMITTED) {
-      res.render('pages/vary-approve/request-changes')
+      const conditionComparison = await this.licenceService.compareVariationToOriginal(licence, user)
+      res.render('pages/vary-approve/request-changes', {
+        conditionComparison,
+      })
     } else {
       res.redirect(`/licence/vary-approve/list`)
     }

--- a/server/routes/varyingLicences/handlers/reasonForVariation.test.ts
+++ b/server/routes/varyingLicences/handlers/reasonForVariation.test.ts
@@ -2,6 +2,8 @@ import { Request, Response } from 'express'
 
 import LicenceService from '../../../services/licenceService'
 import ReasonForVariationRoutes from './reasonForVariation'
+import { VariedConditions } from '../../../utils/licenceComparator'
+import LicenceStatus from '../../../enumeration/licenceStatus'
 
 const licenceService = new LicenceService(null, null, null) as jest.Mocked<LicenceService>
 jest.mock('../../../services/licenceService')
@@ -27,14 +29,31 @@ describe('Route Handlers - Vary Licence - Reason for variation', () => {
         user: {
           username: 'joebloggs',
         },
+        licence: {
+          id: 1,
+          statusCode: LicenceStatus.VARIATION_IN_PROGRESS,
+        },
       },
     } as unknown as Response
   })
 
   describe('GET', () => {
     it('should render view', async () => {
+      licenceService.compareVariationToOriginal.mockResolvedValue({
+        licenceConditionsAdded: [],
+      } as VariedConditions)
+
       await handler.GET(req, res)
-      expect(res.render).toHaveBeenCalledWith('pages/vary/reasonForVariation')
+
+      expect(licenceService.compareVariationToOriginal).toHaveBeenCalledWith(
+        { id: 1, statusCode: LicenceStatus.VARIATION_IN_PROGRESS },
+        { username: 'joebloggs' }
+      )
+      expect(res.render).toHaveBeenCalledWith('pages/vary/reasonForVariation', {
+        conditionComparison: {
+          licenceConditionsAdded: [],
+        },
+      })
     })
   })
 

--- a/server/routes/varyingLicences/handlers/reasonForVariation.ts
+++ b/server/routes/varyingLicences/handlers/reasonForVariation.ts
@@ -5,7 +5,13 @@ export default class ReasonForVariationRoutes {
   constructor(private readonly licenceService: LicenceService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
-    res.render('pages/vary/reasonForVariation')
+    const { licence, user } = res.locals
+
+    const conditionComparison = await this.licenceService.compareVariationToOriginal(licence, user)
+
+    res.render('pages/vary/reasonForVariation', {
+      conditionComparison,
+    })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {

--- a/server/routes/varyingLicences/handlers/variationSummary.test.ts
+++ b/server/routes/varyingLicences/handlers/variationSummary.test.ts
@@ -2,6 +2,8 @@ import { Request, Response } from 'express'
 
 import LicenceService from '../../../services/licenceService'
 import VariationSummaryRoutes from './variationSummary'
+import LicenceStatus from '../../../enumeration/licenceStatus'
+import { VariedConditions } from '../../../utils/licenceComparator'
 
 const licenceService = new LicenceService(null, null, null) as jest.Mocked<LicenceService>
 jest.mock('../../../services/licenceService')
@@ -26,14 +28,31 @@ describe('Route Handlers - Vary Licence - Variation summary', () => {
         user: {
           username: 'joebloggs',
         },
+        licence: {
+          id: 1,
+          statusCode: LicenceStatus.VARIATION_IN_PROGRESS,
+        },
       },
     } as unknown as Response
   })
 
   describe('GET', () => {
     it('should render view', async () => {
+      licenceService.compareVariationToOriginal.mockResolvedValue({
+        licenceConditionsAdded: [],
+      } as VariedConditions)
+
       await handler.GET(req, res)
-      expect(res.render).toHaveBeenCalledWith('pages/vary/variationSummary')
+
+      expect(licenceService.compareVariationToOriginal).toHaveBeenCalledWith(
+        { id: 1, statusCode: LicenceStatus.VARIATION_IN_PROGRESS },
+        { username: 'joebloggs' }
+      )
+      expect(res.render).toHaveBeenCalledWith('pages/vary/variationSummary', {
+        conditionComparison: {
+          licenceConditionsAdded: [],
+        },
+      })
     })
   })
 

--- a/server/routes/varyingLicences/handlers/variationSummary.ts
+++ b/server/routes/varyingLicences/handlers/variationSummary.ts
@@ -5,6 +5,14 @@ export default class VariationSummaryRoutes {
   constructor(private readonly licenceService: LicenceService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
+    // const { licence, user } = res.locals
+    //
+    // const conditionComparison = await this.licenceService.compareVariationToOriginal(licence, user)
+    //
+    // res.render('pages/vary/variationSummary', {
+    //   conditionComparison,
+    // })
+
     res.render('pages/vary/variationSummary')
   }
 

--- a/server/routes/varyingLicences/handlers/variationSummary.ts
+++ b/server/routes/varyingLicences/handlers/variationSummary.ts
@@ -5,15 +5,13 @@ export default class VariationSummaryRoutes {
   constructor(private readonly licenceService: LicenceService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
-    // const { licence, user } = res.locals
-    //
-    // const conditionComparison = await this.licenceService.compareVariationToOriginal(licence, user)
-    //
-    // res.render('pages/vary/variationSummary', {
-    //   conditionComparison,
-    // })
+    const { licence, user } = res.locals
 
-    res.render('pages/vary/variationSummary')
+    const conditionComparison = await this.licenceService.compareVariationToOriginal(licence, user)
+
+    res.render('pages/vary/variationSummary', {
+      conditionComparison,
+    })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {

--- a/server/services/licenceService.test.ts
+++ b/server/services/licenceService.test.ts
@@ -7,6 +7,7 @@ import PrisonerService from './prisonerService'
 import CommunityService from './communityService'
 import * as conditionsProvider from '../utils/conditionsProvider'
 import * as utils from '../utils/utils'
+import * as licenceComparator from '../utils/licenceComparator'
 import { PrisonApiPrisoner, PrisonInformation } from '../@types/prisonApiClientTypes'
 import { OffenderDetail } from '../@types/probationSearchApiClientTypes'
 import SimpleDateTime from '../routes/creatingLicences/types/simpleDateTime'
@@ -17,12 +18,14 @@ import SimpleDate from '../routes/creatingLicences/types/date'
 import BespokeConditions from '../routes/creatingLicences/types/bespokeConditions'
 import LicenceStatus from '../enumeration/licenceStatus'
 import {
+  Licence,
   LicenceSummary,
   UpdateComRequest,
   UpdatePrisonInformationRequest,
   UpdateSentenceDatesRequest,
 } from '../@types/licenceApiClientTypes'
 import { CommunityApiOffenderManager } from '../@types/communityClientTypes'
+import { VariedConditions } from '../utils/licenceComparator'
 
 jest.mock('../data/licenceApiClient')
 jest.mock('./communityService')
@@ -717,6 +720,22 @@ describe('Licence Service', () => {
   it('should refer a licence variation', async () => {
     await licenceService.referVariation('1', { reasonForReferral: 'Reason' }, user)
     expect(licenceApiClient.referVariation).toBeCalledWith('1', { reasonForReferral: 'Reason' }, user)
+  })
+
+  it('should compare variation with its original licence', async () => {
+    const licenceCompatatorSpy = jest.spyOn(licenceComparator, 'default').mockReturnValue({} as VariedConditions)
+    licenceApiClient.getLicenceById.mockResolvedValue({
+      id: 1,
+    } as Licence)
+
+    await licenceService.compareVariationToOriginal({ id: 2, variationOf: 1 } as Licence, user)
+
+    expect(licenceCompatatorSpy).toBeCalledWith(
+      {
+        id: 1,
+      },
+      { id: 2, variationOf: 1 }
+    )
   })
 
   describe('Exclusion zone file', () => {

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -46,6 +46,7 @@ import Stringable from '../routes/creatingLicences/types/abstract/stringable'
 import LicenceType from '../enumeration/licenceType'
 import { PrisonApiPrisoner } from '../@types/prisonApiClientTypes'
 import { User } from '../@types/CvlUserDetails'
+import compareLicenceConditions, { VariedConditions } from '../utils/licenceComparator'
 
 export default class LicenceService {
   constructor(
@@ -418,6 +419,11 @@ export default class LicenceService {
 
   async referVariation(licenceId: string, referVariationRequest: ReferVariationRequest, user: User): Promise<void> {
     return this.licenceApiClient.referVariation(licenceId, referVariationRequest, user)
+  }
+
+  async compareVariationToOriginal(variation: Licence, user: User): Promise<VariedConditions> {
+    const originalLicence = await this.getLicence(variation.variationOf.toString(), user)
+    return compareLicenceConditions(originalLicence, variation)
   }
 
   private getLicenceType = (nomisRecord: PrisonApiPrisoner): LicenceType => {

--- a/server/utils/licenceComparator.test.ts
+++ b/server/utils/licenceComparator.test.ts
@@ -1,0 +1,281 @@
+import _ from 'lodash'
+import compareLicenceConditions from './licenceComparator'
+import * as conditionsProvider from './conditionsProvider'
+import { Licence } from '../@types/licenceApiClientTypes'
+
+jest.spyOn(conditionsProvider, 'expandAdditionalConditions').mockImplementation(conditions => conditions)
+
+const licenceTemplate = {
+  additionalLicenceConditions: [],
+  additionalPssConditions: [],
+  bespokeConditions: [],
+} as Licence
+
+describe('Licence Comparator', () => {
+  describe('Licence conditions', () => {
+    it('should return list of removed licence conditions', () => {
+      const originalLicence = {
+        ...licenceTemplate,
+        additionalLicenceConditions: [
+          {
+            code: '1',
+            category: 'category1',
+            text: 'testCondition1',
+          },
+          {
+            code: '2',
+            category: 'category2',
+            text: 'testCondition2',
+          },
+        ],
+        bespokeConditions: [{ text: 'bespoke1' }, { text: 'bespoke2' }],
+      } as Licence
+
+      const variedLicence = {
+        ...licenceTemplate,
+        additionalLicenceConditions: [],
+      } as Licence
+
+      expect(compareLicenceConditions(originalLicence, variedLicence)).toEqual({
+        licenceConditionsAdded: [],
+        licenceConditionsAmended: [],
+        licenceConditionsRemoved: [
+          {
+            category: 'category1',
+            condition: 'testCondition1',
+          },
+          {
+            category: 'category2',
+            condition: 'testCondition2',
+          },
+          {
+            category: 'Bespoke condition',
+            condition: 'bespoke1',
+          },
+          {
+            category: 'Bespoke condition',
+            condition: 'bespoke2',
+          },
+        ],
+        pssConditionsAdded: [],
+        pssConditionsAmended: [],
+        pssConditionsRemoved: [],
+      })
+    })
+
+    it('should return list of added licence conditions', () => {
+      const originalLicence = {
+        ...licenceTemplate,
+        additionalLicenceConditions: [],
+      } as Licence
+
+      const variedLicence = {
+        ...licenceTemplate,
+        additionalLicenceConditions: [
+          {
+            code: '1',
+            category: 'category1',
+            text: 'testCondition1',
+          },
+          {
+            code: '2',
+            category: 'category2',
+            text: 'testCondition2',
+          },
+        ],
+        bespokeConditions: [{ text: 'bespoke1' }, { text: 'bespoke2' }],
+      } as Licence
+
+      expect(compareLicenceConditions(originalLicence, variedLicence)).toEqual({
+        licenceConditionsAdded: [
+          {
+            category: 'category1',
+            condition: 'testCondition1',
+          },
+          {
+            category: 'category2',
+            condition: 'testCondition2',
+          },
+          {
+            category: 'Bespoke condition',
+            condition: 'bespoke1',
+          },
+          {
+            category: 'Bespoke condition',
+            condition: 'bespoke2',
+          },
+        ],
+        licenceConditionsAmended: [],
+        licenceConditionsRemoved: [],
+        pssConditionsAdded: [],
+        pssConditionsAmended: [],
+        pssConditionsRemoved: [],
+      })
+    })
+
+    it('should return list of amended licence conditions', () => {
+      const originalLicence = {
+        ...licenceTemplate,
+        additionalLicenceConditions: [
+          {
+            code: '1',
+            category: 'category1',
+            text: 'testCondition1',
+          },
+        ],
+      } as Licence
+
+      const variedLicence = {
+        ...licenceTemplate,
+        additionalLicenceConditions: [
+          {
+            code: '1',
+            category: 'category1',
+            text: 'amendedTestCondition1',
+          },
+        ],
+      } as Licence
+
+      expect(compareLicenceConditions(originalLicence, variedLicence)).toEqual({
+        licenceConditionsAdded: [],
+        licenceConditionsAmended: [
+          {
+            category: 'category1',
+            condition: 'amendedTestCondition1',
+          },
+        ],
+        licenceConditionsRemoved: [],
+        pssConditionsAdded: [],
+        pssConditionsAmended: [],
+        pssConditionsRemoved: [],
+      })
+    })
+  })
+
+  describe('PSS conditions', () => {
+    it('should return list of removed pss conditions', () => {
+      const originalLicence = {
+        ...licenceTemplate,
+        additionalPssConditions: [
+          {
+            code: '1',
+            category: 'category1',
+            text: 'testCondition1',
+          },
+        ],
+      } as Licence
+
+      const variedLicence = {
+        ...licenceTemplate,
+        additionalPssConditions: [],
+      } as Licence
+
+      expect(compareLicenceConditions(originalLicence, variedLicence)).toEqual({
+        licenceConditionsAdded: [],
+        licenceConditionsAmended: [],
+        licenceConditionsRemoved: [],
+        pssConditionsAdded: [],
+        pssConditionsAmended: [],
+        pssConditionsRemoved: [
+          {
+            category: 'category1',
+            condition: 'testCondition1',
+          },
+        ],
+      })
+    })
+
+    it('should return list of added pss conditions', () => {
+      const originalLicence = {
+        ...licenceTemplate,
+        additionalPssConditions: [],
+      } as Licence
+
+      const variedLicence = {
+        ...licenceTemplate,
+        additionalPssConditions: [
+          {
+            code: '1',
+            category: 'category1',
+            text: 'testCondition1',
+          },
+        ],
+      } as Licence
+
+      expect(compareLicenceConditions(originalLicence, variedLicence)).toEqual({
+        licenceConditionsAdded: [],
+        licenceConditionsAmended: [],
+        licenceConditionsRemoved: [],
+        pssConditionsAdded: [
+          {
+            category: 'category1',
+            condition: 'testCondition1',
+          },
+        ],
+        pssConditionsAmended: [],
+        pssConditionsRemoved: [],
+      })
+    })
+
+    it('should return list of amended pss conditions', () => {
+      const originalLicence = {
+        ...licenceTemplate,
+        additionalPssConditions: [
+          {
+            code: '1',
+            category: 'category1',
+            text: 'testCondition1',
+          },
+        ],
+      } as Licence
+
+      const variedLicence = {
+        ...licenceTemplate,
+        additionalPssConditions: [
+          {
+            code: '1',
+            category: 'category1',
+            text: 'amendedTestCondition1',
+          },
+        ],
+      } as Licence
+
+      expect(compareLicenceConditions(originalLicence, variedLicence)).toEqual({
+        licenceConditionsAdded: [],
+        licenceConditionsAmended: [],
+        licenceConditionsRemoved: [],
+        pssConditionsAdded: [],
+        pssConditionsAmended: [
+          {
+            category: 'category1',
+            condition: 'amendedTestCondition1',
+          },
+        ],
+        pssConditionsRemoved: [],
+      })
+    })
+  })
+
+  it('should return no changes if the licence has not changed', () => {
+    const originalLicence = {
+      ...licenceTemplate,
+      additionalLicenceConditions: [
+        {
+          code: '1',
+          category: 'category1',
+          text: 'testCondition1',
+        },
+      ],
+      bespokeConditions: [{ text: 'bespoke1' }],
+    } as Licence
+
+    expect(compareLicenceConditions(originalLicence, _.cloneDeep(originalLicence))).toEqual({
+      licenceConditionsAdded: [],
+      licenceConditionsAmended: [],
+      licenceConditionsRemoved: [],
+      pssConditionsAdded: [],
+      pssConditionsAmended: [],
+      pssConditionsRemoved: [],
+    })
+  })
+})

--- a/server/utils/licenceComparator.ts
+++ b/server/utils/licenceComparator.ts
@@ -1,0 +1,182 @@
+import _ from 'lodash'
+import { AdditionalCondition, BespokeCondition, Licence } from '../@types/licenceApiClientTypes'
+import ConditionType from '../enumeration/conditionType'
+import { expandAdditionalConditions } from './conditionsProvider'
+
+type Condition = {
+  category: string
+  condition: string
+}
+
+export type VariedConditions = {
+  licenceConditionsAdded: Condition[]
+  licenceConditionsRemoved: Condition[]
+  licenceConditionsAmended: Condition[]
+  pssConditionsAdded: Condition[]
+  pssConditionsRemoved: Condition[]
+  pssConditionsAmended: Condition[]
+}
+
+const compareLicenceConditions = (originalLicence: Licence, variation: Licence): VariedConditions => {
+  const variedAdditionalLicenceConditions = compareAdditionalConditionSet(
+    originalLicence.additionalLicenceConditions,
+    variation.additionalLicenceConditions,
+    ConditionType.AP
+  )
+  const variedBespokeConditions = compareBespokeConditionSet(
+    originalLicence.bespokeConditions,
+    variation.bespokeConditions
+  )
+
+  const variedAdditionalPssConditions = compareAdditionalConditionSet(
+    originalLicence.additionalPssConditions,
+    variation.additionalPssConditions,
+    ConditionType.PSS
+  )
+
+  const combinedLicenceConditions = _.mergeWith(
+    variedAdditionalLicenceConditions,
+    variedBespokeConditions,
+    (objValue, srcValue) => objValue.concat(srcValue)
+  )
+
+  return _.merge(combinedLicenceConditions, variedAdditionalPssConditions)
+}
+
+const compareAdditionalConditionSet = (
+  originalConditionSet: AdditionalCondition[],
+  variedConditionSet: AdditionalCondition[],
+  conditionType: ConditionType
+): VariedConditions => {
+  const variedConditionsBuilder = new VariedConditionsBuilder(conditionType)
+  const sortedOriginalConditionSet = sortConditionSet(expandAdditionalConditions(originalConditionSet))
+  const sortedVariedConditionSet = sortConditionSet(expandAdditionalConditions(variedConditionSet))
+
+  let originalCondition = sortedOriginalConditionSet.shift()
+  let variedCondition = sortedVariedConditionSet.shift()
+
+  while (originalCondition !== undefined || variedCondition !== undefined) {
+    if (originalCondition?.code < variedCondition?.code || variedCondition === undefined) {
+      variedConditionsBuilder.recordConditionRemoved({
+        category: originalCondition.category,
+        condition: originalCondition.text,
+      })
+      originalCondition = sortedOriginalConditionSet.shift()
+    } else if (originalCondition?.code > variedCondition?.code || originalCondition === undefined) {
+      variedConditionsBuilder.recordConditionAdded({
+        category: variedCondition.category,
+        condition: variedCondition.text,
+      })
+      variedCondition = sortedVariedConditionSet.shift()
+    } else {
+      if (originalCondition.text !== variedCondition.text) {
+        variedConditionsBuilder.recordConditionAmended({
+          category: variedCondition.category,
+          condition: variedCondition.text,
+        })
+      }
+
+      originalCondition = sortedOriginalConditionSet.shift()
+      variedCondition = sortedVariedConditionSet.shift()
+    }
+  }
+
+  return variedConditionsBuilder.buildVariedConditions()
+}
+
+const compareBespokeConditionSet = (
+  originalConditionSet: BespokeCondition[],
+  variedConditionSet: BespokeCondition[]
+): VariedConditions => {
+  const variedConditionsBuilder = new VariedConditionsBuilder(ConditionType.BESPOKE)
+  const sortedOriginalConditionSet = sortBespokeConditionSet(originalConditionSet)
+  const sortedVariedConditionSet = sortBespokeConditionSet(variedConditionSet)
+
+  let originalCondition = sortedOriginalConditionSet.shift()
+  let variedCondition = sortedVariedConditionSet.shift()
+
+  while (originalCondition || variedCondition) {
+    if (originalCondition?.text < variedCondition?.text || variedCondition === undefined) {
+      variedConditionsBuilder.recordConditionRemoved({
+        category: 'Bespoke condition',
+        condition: originalCondition.text,
+      })
+      originalCondition = sortedOriginalConditionSet.shift()
+    } else if (originalCondition?.text > variedCondition?.text || originalCondition === undefined) {
+      variedConditionsBuilder.recordConditionAdded({
+        category: 'Bespoke condition',
+        condition: variedCondition.text,
+      })
+      variedCondition = sortedVariedConditionSet.shift()
+    } else {
+      if (originalCondition.text !== variedCondition.text) {
+        variedConditionsBuilder.recordConditionAmended({
+          category: 'Bespoke condition',
+          condition: variedCondition.text,
+        })
+      }
+
+      originalCondition = sortedOriginalConditionSet.shift()
+      variedCondition = sortedVariedConditionSet.shift()
+    }
+  }
+
+  return variedConditionsBuilder.buildVariedConditions()
+}
+
+const sortConditionSet = (conditionSet: AdditionalCondition[]) => {
+  return conditionSet.sort((a, b) => {
+    if (a.code > b.code) {
+      return 1
+    }
+    return -1
+  })
+}
+
+const sortBespokeConditionSet = (conditionSet: BespokeCondition[]) => {
+  return conditionSet.sort((a, b) => {
+    if (a.text > b.text) {
+      return 1
+    }
+    return -1
+  })
+}
+
+class VariedConditionsBuilder {
+  constructor(private readonly conditionType: ConditionType) {}
+
+  private conditonsAdded: Condition[] = []
+
+  private conditonsRemoved: Condition[] = []
+
+  private conditonsAmended: Condition[] = []
+
+  recordConditionAdded = (condition: Condition) => {
+    this.conditonsAdded.push(condition)
+  }
+
+  recordConditionRemoved = (condition: Condition) => {
+    this.conditonsRemoved.push(condition)
+  }
+
+  recordConditionAmended = (condition: Condition) => {
+    this.conditonsAmended.push(condition)
+  }
+
+  buildVariedConditions = (): VariedConditions => {
+    if (this.conditionType === 'AP' || this.conditionType === 'Bespoke') {
+      return {
+        licenceConditionsAdded: this.conditonsAdded,
+        licenceConditionsRemoved: this.conditonsRemoved,
+        licenceConditionsAmended: this.conditonsAmended,
+      } as VariedConditions
+    }
+    return {
+      pssConditionsAdded: this.conditonsAdded,
+      pssConditionsRemoved: this.conditonsRemoved,
+      pssConditionsAmended: this.conditonsAmended,
+    } as VariedConditions
+  }
+}
+
+export default compareLicenceConditions

--- a/server/views/customComponents/summaryCard/macro.njk
+++ b/server/views/customComponents/summaryCard/macro.njk
@@ -1,0 +1,46 @@
+{% macro summaryCard(params) %}
+    {%- include "./template.njk" -%}
+{% endmacro %}
+
+{% macro summaryListWithExtraDetail(params) %}
+    {%- macro _extraDetail(params) %}
+        <div {%- if params.classes %} class="{{ params.classes }}" {% endif %} {%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+        {{ params.html | safe if params.html else params.text }}
+        {%- if action.visuallyHiddenText -%}
+            <span class="govuk-visually-hidden"> {{ params.visuallyHiddenText }}</span>
+        {% endif -%}
+        </div>
+    {% endmacro -%}
+
+    {# Determine if we need 2 or 3 columns #}
+    {% set anyRowHasExtraDetail = false %}
+    {% for row in params.rows %}
+        {% set anyRowHasExtraDetail = true if row.extraDetail.items | length else anyRowHasExtraDetail %}
+    {% endfor -%}
+
+    <dl class="govuk-summary-list {%- if params.classes %} {{ params.classes }}{% endif %}"{% for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+    {% for row in params.rows %}
+        {% if row %}
+            <div class="govuk-summary-list__row {%- if anyRowHasExtraDetail and not row.extraDetail.items %} govuk-summary-list__row--no-actions{% endif %} {%- if row.classes %} {{ row.classes }}{% endif %}">
+                <dt class="govuk-summary-list__key {%- if row.key.classes %} {{ row.key.classes }}{% endif %}">
+                    {{ row.key.html | safe if row.key.html else row.key.text }}
+                </dt>
+                <dd class="govuk-summary-list__value {%- if row.value.classes %} {{ row.value.classes }}{% endif %}">
+                    {{ row.value.html | indent(8) | trim | safe if row.value.html else row.value.text }}
+                </dd>
+                {% if row.extraDetail.items.length %}
+                    <dd class="govuk-summary-list__actions {%- if row.extraDetail.classes %} {{ row.extraDetail.classes }}{% endif %}">
+                        {% if row.extraDetail.items.length == 1 %}
+                            {{ _extraDetail(row.extraDetail.items[0]) | indent(12) | trim }}
+                        {% else %}
+                            {% for extraDetail in row.extraDetail.items %}
+                                {{ _extraDetail(extraDetail) | indent(18) | trim }}
+                            {% endfor %}
+                        {% endif %}
+                    </dd>
+                {% endif %}
+            </div>
+        {% endif %}
+    {% endfor %}
+    </dl>
+{% endmacro %}

--- a/server/views/customComponents/summaryCard/template.njk
+++ b/server/views/customComponents/summaryCard/template.njk
@@ -1,0 +1,47 @@
+{% from "customComponents/summaryCard/macro.njk" import summaryListWithExtraDetail %}
+
+{%- macro _actionLink(action) %}
+    <a class="govuk-link {%- if action.classes %} {{ action.classes }}{% endif %}" href="{{ action.href }}" {%- for attribute, value in action.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+    {{ action.html | safe if action.html else action.text }}
+    {%- if action.visuallyHiddenText -%}
+        <span class="govuk-visually-hidden"> {{ action.visuallyHiddenText }}</span>
+    {% endif -%}
+    </a>
+{% endmacro -%}
+
+<section class="summary-card
+  {%- if params.classes %} {{ params.classes }}{% endif %}"
+{%- for attribute, value in params.attributes %} {{attribute}}="{{value}}"{% endfor %}>
+    {% if params.titleHtml or params.titleText or params.actions %}
+        <header class="summary-card__header">
+            {% set headingLevel = params.headingLevel if params.headingLevel else 2 %}
+            <h{{ headingLevel }} class="summary-card__title">
+                {{ params.titleHtml | safe if params.titleHtml else params.titleText }}
+            </h{{ headingLevel }}>
+            {% if params.actions.items.length %}
+                <div class="summary-card__actions">
+                    {% if params.actions.items.length == 1 %}
+                        {{ _actionLink(params.actions.items[0]) | indent(12) | trim }}
+                    {% else %}
+                        <ul class="summary-card__actions-list">
+                            {% for action in params.actions.items %}
+                                {% if action %}
+                                    <li class="summary-card__actions-list-item">
+                                        {{ _actionLink(action) | indent(18) | trim }}
+                                    </li>
+                                {% endif %}
+                            {% endfor %}
+                        </ul>
+                    {% endif %}
+                </div>
+            {% endif %}
+        </header>
+    {% endif %}
+    {% if params.rows or params.text %}
+        <div class="summary-card__body">
+            {{ summaryListWithExtraDetail({
+              rows: params.rows
+            }) if params.rows else params.text }}
+        </div>
+    {% endif %}
+</section>

--- a/server/views/pages/vary-approve/request-changes.njk
+++ b/server/views/pages/vary-approve/request-changes.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "partials/variedConditions.njk" import variedConditions %}
 
 {% set pageTitle = applicationName + " - reasons for referral" %}
 {% set pageId = "reason-for-referral-page" %}
@@ -24,7 +25,7 @@
 
                 {{ govukDetails({
                     summaryText: "View the varied licence conditions",
-                    html: ""
+                    html: variedConditions(conditionComparison)
                 }) }}
 
                 {{ govukTextarea({

--- a/server/views/pages/vary/reasonForVariation.njk
+++ b/server/views/pages/vary/reasonForVariation.njk
@@ -3,6 +3,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "partials/variedConditions.njk" import variedConditions %}
 
 {% set pageTitle = applicationName + " - Vary a licence - Reason for variation" %}
 {% set pageId = "reason-for-variation-page" %}
@@ -23,7 +24,7 @@
 
                 {{ govukDetails({
                     summaryText: "View the varied licence conditions",
-                    html: ""
+                    html: variedConditions(conditionComparison)
                 }) }}
 
                 {{ govukTextarea({

--- a/server/views/pages/vary/variationSummary.njk
+++ b/server/views/pages/vary/variationSummary.njk
@@ -2,6 +2,8 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "partials/variationDetails.njk" import variationDetails %}
+{% from "partials/variedConditions.njk" import variedConditions %}
 
 {% set pageTitle = applicationName + " - Vary a licence - Variation summary" %}
 {% set pageId = "variation-summary-page" %}
@@ -17,6 +19,10 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
+
+                {{ variationDetails(licence) }}
+                {{ variedConditions(conditionComparison) }}
+
                 <div class="govuk-button-group">
                     {{ govukButton({
                         text: "Send for approval",

--- a/server/views/partials/variationDetails.njk
+++ b/server/views/partials/variationDetails.njk
@@ -1,0 +1,48 @@
+{% from "customComponents/summaryCard/macro.njk" import summaryCard %}
+
+{% macro variationDetails(licence) %}
+    {{ summaryCard({
+        classes: "govuk-!-margin-bottom-6",
+        titleText: "Variation details",
+        rows: [
+            {
+                key: {
+                    text: "Reasons for the variation"
+                },
+                value: {
+                    html: licence.reasonForVariation
+                }
+            },
+            {
+                key: {
+                    text: "SPO Communications"
+                },
+                value: {
+                    text: "Have you communicated and agreed this change with your SPO?"
+                },
+                extraDetail: {
+                    items: [
+                        {
+                            text: licence.spoDiscussion
+                        }
+                    ]
+                }
+            },
+            {
+                key: {
+                    text: "VLO Communications"
+                },
+                value: {
+                    text: "	Have you consulted with the victim liaison officer (VLO) for this case?"
+                },
+                extraDetail: {
+                    items: [
+                        {
+                            text: licence.vloDiscussion
+                        }
+                    ]
+                }
+            }
+        ]
+    }) }}
+{% endmacro %}

--- a/server/views/partials/variedConditions.njk
+++ b/server/views/partials/variedConditions.njk
@@ -1,0 +1,38 @@
+{% from "customComponents/summaryCard/macro.njk" import summaryCard %}
+
+{% macro variedConditions(conditionComparison) %}
+    {% macro buildConditionsSummaryCard(title, conditions) %}
+        {% set rows = [] %}
+        {% for condition in conditions %}
+            {% set rows = (rows.push({
+                key: {  text: condition.category },
+                value: { text: condition.condition }
+            }), rows) %}
+        {% endfor %}
+
+        {{ summaryCard({
+            classes: "govuk-!-margin-bottom-6",
+            titleText: title,
+            rows: rows
+        }) }}
+    {% endmacro %}
+
+    {% if conditionComparison.licenceConditionsAdded.length > 0 %}
+        {{ buildConditionsSummaryCard('Licence conditions added', conditionComparison.licenceConditionsAdded) }}
+    {% endif %}
+    {% if conditionComparison.licenceConditionsRemoved.length > 0 %}
+        {{ buildConditionsSummaryCard('Licence conditions removed', conditionComparison.licenceConditionsRemoved) }}
+    {% endif %}
+    {% if conditionComparison.licenceConditionsAmended.length > 0 %}
+        {{ buildConditionsSummaryCard('Licence conditions amended', conditionComparison.licenceConditionsAmended) }}
+    {% endif %}
+    {% if conditionComparison.pssConditionsAdded.length > 0 %}
+        {{ buildConditionsSummaryCard('Post sentence requirements added', conditionComparison.pssConditionsAdded) }}
+    {% endif %}
+    {% if conditionComparison.pssConditionsRemoved.length > 0 %}
+        {{ buildConditionsSummaryCard('Post sentence requirements removed', conditionComparison.pssConditionsRemoved) }}
+    {% endif %}
+    {% if conditionComparison.pssConditionsAmended.length > 0 %}
+        {{ buildConditionsSummaryCard('Post sentence requirements amended', conditionComparison.pssConditionsAmended) }}
+    {% endif %}
+{% endmacro %}


### PR DESCRIPTION
- Implemented the following algorithm to compare two lists
- Added a custom CSS component, which would ideally be added to the MoJ design library. 

```
sort left-list and right-list
adds = {}
deletes = {}
get first right-item from right-list
get first left-item from left-list
while (either list has items)
  if left-item < right-item or right-list is empty
    add left-item to deletes
    get new left-item from left-list
  else if left-item > right-item or left-list is empty
    add right-item to adds
    get new right-item from right-list
  else
    get new right-item from right-list
    get new left-item from left-list
```


![screencapture-localhost-3000-licence-vary-id-4-reason-for-variation-2022-03-01-19_02_44](https://user-images.githubusercontent.com/30229564/156232217-e201f361-89bf-438b-889c-fa50f21c690a.png)
