### PR TITLE
CVSL-433: Restrict access to Wales probation area and prisons in production

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -25,6 +25,7 @@ generic-service:
     GOTENBERG_API_URL: "http://create-and-vary-a-licence-gotenberg"
     # A reference to the CVL service - for links in HTML to get images/stylesheets (internal within namespace)
     LICENCES_URL: "http://create-and-vary-a-licence"
+    RESTRICT_ROLLOUT: "true"
 
 gotenberg:
   replicaCount: 2

--- a/server/config.ts
+++ b/server/config.ts
@@ -176,7 +176,7 @@ export default {
   },
   rollout: {
     restricted: get('RESTRICT_ROLLOUT', false),
-    probationAreas: ['N55'],
-    prisons: ['MDI', 'LEI'],
+    probationAreas: ['N03'],
+    prisons: ['CFI', 'SWI', 'UKI', 'UPI', 'PRI'],
   },
 }


### PR DESCRIPTION
Switches on RESTRICT_ROLLOUT env variable in production.
Configures the set of prisons and probation areas which are allowed to access.