### PR TITLE
CVSL-441: Upgrade docker containers for ARM support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ executors:
     docker:
       - image: 'cimg/node:<<parameters.node_tag>>'
       - image: 'circleci/redis:<<parameters.redis_tag>>'
-      - image: 'localstack/localstack:0.11.2'
+      - image: 'localstack/localstack:0.13.2'
         environment:
           SERVICES: sqs
           DATA_DIR: /tmp/localstack/data
@@ -141,17 +141,17 @@ jobs:
             export AWS_ACCESS_KEY_ID=foo
             export AWS_SECRET_ACCESS_KEY=bar
 
-            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue
-            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue_dl
-            aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_prison_events_queue_dl\"}"}'
+            aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue
+            aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue_dl
+            aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/create_and_vary_a_licence_prison_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_prison_events_queue_dl\"}"}'
 
-            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue
-            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue_dl
-            aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_probation_events_queue_dl\"}"}'
+            aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue
+            aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue_dl
+            aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/create_and_vary_a_licence_probation_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_probation_events_queue_dl\"}"}'
 
-            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue
-            aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue_dl
-            aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_domain_events_queue_dl\"}"}'
+            aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue
+            aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue_dl
+            aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/create_and_vary_a_licence_domain_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_domain_events_queue_dl\"}"}'
       - run:
           name: Get wiremock
           command: curl -o wiremock.jar https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.27.1/wiremock-standalone-2.27.1.jar

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -2,7 +2,7 @@ version: '3.1'
 services:
 
   redis:
-    image: 'bitnami/redis:5.0'
+    image: 'redis:5.0'
     networks:
       - hmpps
     container_name: redis 
@@ -24,7 +24,7 @@ services:
       test: [ 'CMD', 'curl', '-f', 'http://localhost:5000/actuator/health' ]
 
   gotenberg:
-    image: thecodingmachine/gotenberg:6.4.3
+    image: thecodingmachine/gotenberg:7.5.0
     networks:
       - hmpps
     container_name: gotenberg

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -2,7 +2,7 @@ version: '3.1'
 services:
 
   redis:
-    image: 'bitnami/redis:5.0'
+    image: 'redis:5.0'
     networks:
       - hmpps_int
     container_name: redis
@@ -12,7 +12,7 @@ services:
       - '6379:6379'
 
   wiremock:
-    image: rodolpheche/wiremock
+    image: wiremock/wiremock
     networks:
     - hmpps_int
     container_name: wiremock
@@ -21,7 +21,7 @@ services:
       - "9091:8080"
 
   gotenberg:
-    image: thecodingmachine/gotenberg:6.4.3
+    image: thecodingmachine/gotenberg:7.5.0
     networks:
       - hmpps_int
     container_name: gotenberg
@@ -38,7 +38,7 @@ services:
       test: [ 'CMD', 'curl', '-f', 'http://localhost:3000/ping' ]
 
   localstack:
-    image: localstack/localstack:0.11.2
+    image: localstack/localstack:0.13.2
     networks:
       - hmpps_int
     container_name: localstack

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.1'
 services:
 
   redis:
-    image: 'bitnami/redis:5.0'
+    image: 'redis:5.0'
     networks:
       - hmpps
     container_name: redis 
@@ -41,7 +41,7 @@ services:
       - NOTIFY_ENABLED=false
 
   gotenberg:
-    image: thecodingmachine/gotenberg:6.4.3
+    image: thecodingmachine/gotenberg:7.5.0
     networks:
       - hmpps
     container_name: gotenberg
@@ -64,7 +64,7 @@ services:
       test: [ 'CMD', 'curl', '-f', 'http://localhost:5000/actuator/health' ]
 
   localstack:
-    image: localstack/localstack:0.11.2
+    image: localstack/localstack:0.13.2
     networks:
       - hmpps
     container_name: localstack

--- a/helm_deploy/create-and-vary-a-licence/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence/values.yaml
@@ -96,7 +96,7 @@ gotenberg:
 
   image:
     repository: thecodingmachine/gotenberg
-    tag: 6.3.0
+    tag: 7.5.0
     port: 3000
 
   ingress:

--- a/integration_tests/support/events.ts
+++ b/integration_tests/support/events.ts
@@ -20,19 +20,19 @@ const sendMessage = (message: SendMessageRequest): void => {
 }
 
 const purgeQueues = (): unknown => {
-  sqs.purgeQueue({ QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue' }, err => {
+  sqs.purgeQueue({ QueueUrl: 'http://localhost:4566/queue/create_and_vary_a_licence_domain_events_queue' }, err => {
     if (err) {
       // eslint-disable-next-line no-console
       console.log('Error', err)
     }
   })
-  sqs.purgeQueue({ QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue' }, err => {
+  sqs.purgeQueue({ QueueUrl: 'http://localhost:4566/queue/create_and_vary_a_licence_prison_events_queue' }, err => {
     if (err) {
       // eslint-disable-next-line no-console
       console.log('Error', err)
     }
   })
-  sqs.purgeQueue({ QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue' }, err => {
+  sqs.purgeQueue({ QueueUrl: 'http://localhost:4566/queue/create_and_vary_a_licence_probation_events_queue' }, err => {
     if (err) {
       // eslint-disable-next-line no-console
       console.log('Error', err)
@@ -43,7 +43,7 @@ const purgeQueues = (): unknown => {
 
 const sendDomainEvent = async (body: string): Promise<unknown> => {
   sendMessage({
-    QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue',
+    QueueUrl: 'http://localhost:4566/queue/create_and_vary_a_licence_domain_events_queue',
     MessageBody: body,
   })
   // Wait for the event listener to clear the queue
@@ -53,7 +53,7 @@ const sendDomainEvent = async (body: string): Promise<unknown> => {
 
 const sendPrisonEvent = async (body: string): Promise<unknown> => {
   sendMessage({
-    QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue',
+    QueueUrl: 'http://localhost:4566/queue/create_and_vary_a_licence_prison_events_queue',
     MessageBody: body,
   })
   // Wait for the event listener to clear the queue
@@ -63,7 +63,7 @@ const sendPrisonEvent = async (body: string): Promise<unknown> => {
 
 const sendProbationEvent = async (body: string): Promise<unknown> => {
   sendMessage({
-    QueueUrl: 'http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue',
+    QueueUrl: 'http://localhost:4566/queue/create_and_vary_a_licence_probation_events_queue',
     MessageBody: body,
   })
   // Wait for the event listener to clear the queue

--- a/localstack/01-setup-queues.sh
+++ b/localstack/01-setup-queues.sh
@@ -5,16 +5,16 @@ export AWS_ACCESS_KEY_ID=foo
 export AWS_SECRET_ACCESS_KEY=bar
 export AWS_DEFAULT_REGION=eu-west-2
 
-aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue
-aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue_dl
-aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_prison_events_queue_dl\"}"}'
+aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue
+aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue_dl
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/create_and_vary_a_licence_prison_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_prison_events_queue_dl\"}"}'
 
-aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue
-aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue_dl
-aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_probation_events_queue_dl\"}"}'
+aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue
+aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue_dl
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/create_and_vary_a_licence_probation_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_probation_events_queue_dl\"}"}'
 
-aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue
-aws --endpoint-url=http://localhost:4576 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue_dl
-aws --endpoint-url=http://localhost:4576 sqs set-queue-attributes --queue-url "http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_domain_events_queue_dl\"}"}'
+aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue
+aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue_dl
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/create_and_vary_a_licence_domain_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_domain_events_queue_dl\"}"}'
 
 echo Queue setup complete

--- a/server/config.ts
+++ b/server/config.ts
@@ -50,7 +50,7 @@ export default {
       secretAccessKey: get('SQS_PRISON_EVENTS_SECRET_ACCESS_KEY', 'bar', requiredInProduction),
       queueUrl: get(
         'SQS_PRISON_EVENTS_QUEUE_URL',
-        'http://localhost:4576/queue/create_and_vary_a_licence_prison_events_queue',
+        'http://localhost:4566/queue/create_and_vary_a_licence_prison_events_queue',
         requiredInProduction
       ),
     },
@@ -59,7 +59,7 @@ export default {
       secretAccessKey: get('SQS_PROBATION_EVENTS_SECRET_ACCESS_KEY', 'bar', requiredInProduction),
       queueUrl: get(
         'SQS_PROBATION_EVENTS_QUEUE_URL',
-        'http://localhost:4576/queue/create_and_vary_a_licence_probation_events_queue',
+        'http://localhost:4566/queue/create_and_vary_a_licence_probation_events_queue',
         requiredInProduction
       ),
     },
@@ -68,7 +68,7 @@ export default {
       secretAccessKey: get('SQS_DOMAIN_EVENTS_SECRET_ACCESS_KEY', 'bar', requiredInProduction),
       queueUrl: get(
         'SQS_DOMAIN_EVENTS_QUEUE_URL',
-        'http://localhost:4576/queue/create_and_vary_a_licence_domain_events_queue',
+        'http://localhost:4566/queue/create_and_vary_a_licence_domain_events_queue',
         requiredInProduction
       ),
     },

--- a/server/data/gotenbergApiClient.test.ts
+++ b/server/data/gotenbergApiClient.test.ts
@@ -19,8 +19,8 @@ describe('Gotenberg client tests', () => {
   const htmlString = '<html><head><title>A title</title></head><body><p>A document</p></body>'
 
   describe('Render HTML as PDF', () => {
-    it('POST /convert/html', async () => {
-      fakeApi.post('/convert/html').reply(200, pdfStream)
+    it('POST /forms/chromium/convert/html', async () => {
+      fakeApi.post('/forms/chromium/convert/html').reply(200, pdfStream)
       const data = await client.renderPdfFromHtml(htmlString)
       expect(data).toEqual(Buffer.from(pdfStream))
       expect(nock.isDone()).toBe(true)

--- a/server/data/gotenbergClient.ts
+++ b/server/data/gotenbergClient.ts
@@ -21,7 +21,7 @@ export default class GotenbergClient {
     const { headerHtml, footerHtml, marginBottom, marginLeft, marginRight, marginTop } = options
     try {
       const request = superagent
-        .post(`${this.gotenbergHost}/convert/html`)
+        .post(`${this.gotenbergHost}/forms/chromium/convert/html`)
         .set('Content-Type', 'multi-part/form-data')
         .buffer(true)
         .attach('files', Buffer.from(html), 'index.html')


### PR DESCRIPTION
- Apple have stopped manufacturing Macbooks with intel x86_64 chips
- New Macbooks have ARM architecture with the new M1 chip
- Some of the docker containers we use locally have not been packaged for ARM architecture, which means that running them locally either fails or is very slow, as the x86_64 architecture needs to be emulated
- Newer versions of these docker images do support ARM, so upgrading to those new versions solves this issue