### PR TITLE
CVSL-473: Updating typescript to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12218,9 +12218,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
+      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
     },
     "uid-safe": {

--- a/package.json
+++ b/package.json
@@ -183,6 +183,6 @@
     "redis-mock": "^0.56.3",
     "sass": "^1.42.1",
     "ts-jest": "^27.0.5",
-    "typescript": "^4.6.2"
+    "typescript": "^4.6.3"
   }
 }


### PR DESCRIPTION
Update typescript 4.6.2 -> 4.6.3 to resolve `check_outdated` error overnight.