### PR TITLE
CVSL-498: Fix POM being incorrectly identified as the COM

### DIFF
--- a/integration_tests/integration/eventHandlers.spec.ts
+++ b/integration_tests/integration/eventHandlers.spec.ts
@@ -60,6 +60,7 @@ context('Event handlers', () => {
 
   describe('Probation events', () => {
     it('should listen to the offender manager changed event and call endpoint to update responsible COM', () => {
+      cy.task('stubGetProbationer')
       cy.task('stubGetAnOffendersManagers')
       cy.task('stubGetStaffDetailsByStaffId')
       cy.task('stubUpdateResponsibleCom')

--- a/integration_tests/mockApis/community.ts
+++ b/integration_tests/mockApis/community.ts
@@ -257,6 +257,7 @@ export default {
           {
             isResponsibleOfficer: true,
             staffId: 2000,
+            staffCode: 'X12345',
             probationArea: {
               code: 'N01',
               description: 'Area N01',

--- a/integration_tests/mockApis/probationSearch.ts
+++ b/integration_tests/mockApis/probationSearch.ts
@@ -22,6 +22,7 @@ export default {
               {
                 active: true,
                 staff: {
+                  code: 'X12345',
                   forenames: 'Joe',
                   surname: 'Bloggs',
                 },

--- a/localstack/01-setup-queues.sh
+++ b/localstack/01-setup-queues.sh
@@ -7,14 +7,14 @@ export AWS_DEFAULT_REGION=eu-west-2
 
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_prison_events_queue_dl
-aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/create_and_vary_a_licence_prison_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_prison_events_queue_dl\"}"}'
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/000000000000/create_and_vary_a_licence_prison_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_prison_events_queue_dl\"}"}'
 
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_probation_events_queue_dl
-aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/create_and_vary_a_licence_probation_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_probation_events_queue_dl\"}"}'
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/000000000000/create_and_vary_a_licence_probation_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_probation_events_queue_dl\"}"}'
 
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue
 aws --endpoint-url=http://localhost:4566 sqs create-queue --queue-name create_and_vary_a_licence_domain_events_queue_dl
-aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/queue/create_and_vary_a_licence_domain_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_domain_events_queue_dl\"}"}'
+aws --endpoint-url=http://localhost:4566 sqs set-queue-attributes --queue-url "http://localhost:4566/000000000000/create_and_vary_a_licence_domain_events_queue" --attributes '{"RedrivePolicy":"{\"maxReceiveCount\":\"3\", \"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:create_and_vary_a_licence_domain_events_queue_dl\"}"}'
 
 echo Queue setup complete

--- a/server/config.ts
+++ b/server/config.ts
@@ -50,7 +50,7 @@ export default {
       secretAccessKey: get('SQS_PRISON_EVENTS_SECRET_ACCESS_KEY', 'bar', requiredInProduction),
       queueUrl: get(
         'SQS_PRISON_EVENTS_QUEUE_URL',
-        'http://localhost:4566/queue/create_and_vary_a_licence_prison_events_queue',
+        'http://localhost:4566/000000000000/create_and_vary_a_licence_prison_events_queue',
         requiredInProduction
       ),
     },
@@ -59,7 +59,7 @@ export default {
       secretAccessKey: get('SQS_PROBATION_EVENTS_SECRET_ACCESS_KEY', 'bar', requiredInProduction),
       queueUrl: get(
         'SQS_PROBATION_EVENTS_QUEUE_URL',
-        'http://localhost:4566/queue/create_and_vary_a_licence_probation_events_queue',
+        'http://localhost:4566/000000000000/create_and_vary_a_licence_probation_events_queue',
         requiredInProduction
       ),
     },
@@ -68,7 +68,7 @@ export default {
       secretAccessKey: get('SQS_DOMAIN_EVENTS_SECRET_ACCESS_KEY', 'bar', requiredInProduction),
       queueUrl: get(
         'SQS_DOMAIN_EVENTS_QUEUE_URL',
-        'http://localhost:4566/queue/create_and_vary_a_licence_domain_events_queue',
+        'http://localhost:4566/000000000000/create_and_vary_a_licence_domain_events_queue',
         requiredInProduction
       ),
     },

--- a/server/listeners/eventHandlers/probationEvents/offenderManagerChangedEventHandler.test.ts
+++ b/server/listeners/eventHandlers/probationEvents/offenderManagerChangedEventHandler.test.ts
@@ -2,6 +2,7 @@ import LicenceService from '../../../services/licenceService'
 import { ProbationEventMessage } from '../../../@types/events'
 import OffenderManagerChangedEventHandler from './offenderManagerChangedEventHandler'
 import CommunityService from '../../../services/communityService'
+import { OffenderDetail } from '../../../@types/probationSearchApiClientTypes'
 
 const communityService = new CommunityService(null, null) as jest.Mocked<CommunityService>
 const licenceService = new LicenceService(null, null, null) as jest.Mocked<LicenceService>
@@ -18,6 +19,7 @@ describe('Offender manager changed event handler', () => {
 
   it('should handle case where the offender has no managers allocated', async () => {
     communityService.getAnOffendersManagers.mockResolvedValue([])
+    communityService.getProbationer.mockResolvedValue({ offenderManagers: [] } as OffenderDetail)
 
     const event = {
       crn: 'X1234',
@@ -31,14 +33,24 @@ describe('Offender manager changed event handler', () => {
   })
 
   it('should update the responsible COM to the current RO in delius', async () => {
+    communityService.getProbationer.mockResolvedValue({
+      offenderManagers: [
+        {
+          active: true,
+          staff: {
+            code: 'X12345',
+          },
+        },
+      ],
+    } as OffenderDetail)
     communityService.getAnOffendersManagers.mockResolvedValue([
       {
+        staffCode: 'X12344',
         staffId: 2000,
-        isResponsibleOfficer: false,
       },
       {
+        staffCode: 'X12345',
         staffId: 3000,
-        isResponsibleOfficer: true,
       },
     ])
     communityService.getStaffDetailByStaffIdentifier.mockResolvedValue({
@@ -63,14 +75,24 @@ describe('Offender manager changed event handler', () => {
   })
 
   it('should not update the responsible COM if the COM does not have a username', async () => {
+    communityService.getProbationer.mockResolvedValue({
+      offenderManagers: [
+        {
+          active: true,
+          staff: {
+            code: 'X12345',
+          },
+        },
+      ],
+    } as OffenderDetail)
     communityService.getAnOffendersManagers.mockResolvedValue([
       {
+        staffCode: 'X12344',
         staffId: 2000,
-        isResponsibleOfficer: false,
       },
       {
+        staffCode: 'X12345',
         staffId: 3000,
-        isResponsibleOfficer: true,
       },
     ])
     communityService.getStaffDetailByStaffIdentifier.mockResolvedValue({

--- a/server/listeners/eventHandlers/probationEvents/offenderManagerChangedEventHandler.ts
+++ b/server/listeners/eventHandlers/probationEvents/offenderManagerChangedEventHandler.ts
@@ -7,8 +7,12 @@ export default class OffenderManagerChangedEventHandler {
 
   handle = async (event: ProbationEventMessage): Promise<void> => {
     const { crn } = event
+    const deliusRecord = await this.communityService.getProbationer({ crn })
     const offenderManagers = await this.communityService.getAnOffendersManagers(crn)
-    const newCom = offenderManagers.find(om => om.isResponsibleOfficer)
+
+    const responsibleOfficer = deliusRecord.offenderManagers.find(om => om.active)
+    const newCom = offenderManagers.find(om => om.staffCode === responsibleOfficer.staff.code)
+
     if (newCom) {
       const comDetails = await this.communityService.getStaffDetailByStaffIdentifier(newCom.staffId)
 

--- a/server/services/licenceService.test.ts
+++ b/server/services/licenceService.test.ts
@@ -63,12 +63,15 @@ describe('Licence Service', () => {
   describe('Create Licence', () => {
     beforeEach(() => {
       prisonerService.getPrisonerDetail.mockResolvedValue({} as PrisonApiPrisoner)
-      communityService.getProbationer.mockResolvedValue({ offenderManagers: [] } as OffenderDetail)
+      communityService.getProbationer.mockResolvedValue({
+        offenderManagers: [{ active: true, staff: { code: 'X12345' } }],
+      } as OffenderDetail)
       prisonerService.getPrisonInformation.mockResolvedValue({ phones: [] } as PrisonInformation)
       communityService.getAnOffendersManagers.mockResolvedValue([
         {
           isResponsibleOfficer: true,
           staffId: 2000,
+          staffCode: 'X12345',
           probationArea: {
             code: 'Area',
             description: 'AreaDesc',

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -76,7 +76,8 @@ export default class LicenceService {
       this.communityService.getAnOffendersManagers(deliusRecord.otherIds?.crn),
     ])
 
-    const responsibleOfficer = offenderManagers.find(om => om.isResponsibleOfficer)
+    const responsibleOfficer = deliusRecord.offenderManagers.find(om => om.active)
+    const responsibleOfficerDetails = offenderManagers.find(om => om.staffCode === responsibleOfficer.staff.code)
 
     const licenceType = this.getLicenceType(nomisRecord)
 
@@ -111,14 +112,14 @@ export default class LicenceService {
       ]
         .filter(n => n)
         .join(' '),
-      probationAreaCode: responsibleOfficer.probationArea?.code,
-      probationAreaDescription: responsibleOfficer.probationArea?.description,
-      probationPduCode: responsibleOfficer.team?.borough?.code,
-      probationPduDescription: responsibleOfficer.team?.borough?.description,
-      probationLauCode: responsibleOfficer.team?.district?.code,
-      probationLauDescription: responsibleOfficer.team?.district?.description,
-      probationTeamCode: responsibleOfficer.team?.code,
-      probationTeamDescription: responsibleOfficer.team?.description,
+      probationAreaCode: responsibleOfficerDetails.probationArea?.code,
+      probationAreaDescription: responsibleOfficerDetails.probationArea?.description,
+      probationPduCode: responsibleOfficerDetails.team?.borough?.code,
+      probationPduDescription: responsibleOfficerDetails.team?.borough?.description,
+      probationLauCode: responsibleOfficerDetails.team?.district?.code,
+      probationLauDescription: responsibleOfficerDetails.team?.district?.description,
+      probationTeamCode: responsibleOfficerDetails.team?.code,
+      probationTeamDescription: responsibleOfficerDetails.team?.description,
       crn: deliusRecord.otherIds?.crn,
       pnc: deliusRecord.otherIds?.pncNumber,
       cro: deliusRecord.otherIds?.croNumber,
@@ -128,13 +129,13 @@ export default class LicenceService {
       standardPssConditions: [LicenceType.PSS, LicenceType.AP_PSS].includes(licenceType)
         ? getStandardConditions(LicenceType.PSS)
         : [],
-      responsibleComStaffId: responsibleOfficer.staffId,
+      responsibleComStaffId: responsibleOfficerDetails.staffId,
     } as CreateLicenceRequest
 
     // TODO: This section can be removed after having been live in production for some time. This is only needed initially because some
     //  COM records will not be saved in our database initially. Over time, the OFFENDER_MANAGER_CHANGED event, and logins will have populated
     //  staff details into the database, and this call will have become redundant
-    const comDetails = await this.communityService.getStaffDetailByStaffIdentifier(responsibleOfficer.staffId)
+    const comDetails = await this.communityService.getStaffDetailByStaffIdentifier(responsibleOfficerDetails.staffId)
     await this.updateComDetails({
       staffIdentifier: comDetails?.staffIdentifier,
       staffUsername: comDetails?.username,


### PR DESCRIPTION
- Identify the COM based on a cross-reference from probation-offender-search, rather than trusting the isResponsibleOfficer flag from community API