### PR TITLE
CVSL-485: Assign the COM role on offender allocation

### DIFF
--- a/integration_tests/integration/eventHandlers.spec.ts
+++ b/integration_tests/integration/eventHandlers.spec.ts
@@ -63,6 +63,8 @@ context('Event handlers', () => {
       cy.task('stubGetProbationer')
       cy.task('stubGetAnOffendersManagers')
       cy.task('stubGetStaffDetailsByStaffId')
+      cy.task('stubGetUserDetailsByUsername')
+      cy.task('stubAssignRole')
       cy.task('stubUpdateResponsibleCom')
 
       cy.task(
@@ -78,6 +80,11 @@ context('Event handlers', () => {
          }`
       )
 
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/secure/users/jsmith/roles/LHDCBT002', times: 1 }).then(
+        success => {
+          if (!success) throw new Error(`Endpoint called an unexpected number of times`)
+        }
+      )
       cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/offender/crn/X1234/responsible-com', times: 1 }).then(
         success => {
           if (!success) throw new Error(`Endpoint called an unexpected number of times`)

--- a/integration_tests/integration/eventHandlers.spec.ts
+++ b/integration_tests/integration/eventHandlers.spec.ts
@@ -23,9 +23,7 @@ context('Event handlers', () => {
          }`
       )
 
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 }).then(success => {
-        if (!success) throw new Error(`Endpoint called an unexpected number of times`)
-      })
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 })
     })
 
     it('should listen to the transferred event and call endpoint to update prison information and update licence status', () => {
@@ -47,14 +45,8 @@ context('Event handlers', () => {
          }`
       )
 
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 }).then(success => {
-        if (!success) throw new Error(`Endpoint called an unexpected number of times`)
-      })
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/prison-information', times: 1 }).then(
-        success => {
-          if (!success) throw new Error(`Endpoint called an unexpected number of times`)
-        }
-      )
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 })
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/prison-information', times: 1 })
     })
   })
 
@@ -80,16 +72,8 @@ context('Event handlers', () => {
          }`
       )
 
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/secure/users/JSMITH/roles/LHDCBT002', times: 1 }).then(
-        success => {
-          if (!success) throw new Error(`Endpoint called an unexpected number of times`)
-        }
-      )
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/offender/crn/X1234/responsible-com', times: 1 }).then(
-        success => {
-          if (!success) throw new Error(`Endpoint called an unexpected number of times`)
-        }
-      )
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/secure/users/JSMITH/roles/LHDCBT002', times: 1 })
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/offender/crn/X1234/responsible-com', times: 1 })
     })
   })
 
@@ -113,12 +97,8 @@ context('Event handlers', () => {
          }`
       )
 
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 }).then(success => {
-        if (!success) throw new Error(`Endpoint called an unexpected number of times`)
-      })
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/sentence-dates', times: 1 }).then(success => {
-        if (!success) throw new Error(`Endpoint called an unexpected number of times`)
-      })
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 })
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/sentence-dates', times: 1 })
     })
 
     it('should listen to the CONFIRMED_RELEASE_DATE-CHANGED event and call endpoint to update sentence dates and update licence status', () => {
@@ -141,12 +121,8 @@ context('Event handlers', () => {
          }`
       )
 
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 }).then(success => {
-        if (!success) throw new Error(`Endpoint called an unexpected number of times`)
-      })
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/sentence-dates', times: 1 }).then(success => {
-        if (!success) throw new Error(`Endpoint called an unexpected number of times`)
-      })
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 })
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/sentence-dates', times: 1 })
     })
   })
 })

--- a/integration_tests/integration/eventHandlers.spec.ts
+++ b/integration_tests/integration/eventHandlers.spec.ts
@@ -80,7 +80,7 @@ context('Event handlers', () => {
          }`
       )
 
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/secure/users/jsmith/roles/LHDCBT002', times: 1 }).then(
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/secure/users/JSMITH/roles/LHDCBT002', times: 1 }).then(
         success => {
           if (!success) throw new Error(`Endpoint called an unexpected number of times`)
         }

--- a/integration_tests/mockApis/community.ts
+++ b/integration_tests/mockApis/community.ts
@@ -55,6 +55,36 @@ export default {
     })
   },
 
+  stubGetUserDetailsByUsername: (): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: `/secure/users/(.)*/details`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          roles: [],
+        },
+      },
+    })
+  },
+
+  stubAssignRole: (): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'PUT',
+        urlPattern: `/secure/users/(.)*/roles/(.)*`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {},
+      },
+    })
+  },
+
   stubGetStaffDetailsByStaffId: (): SuperAgentRequest => {
     return stubFor({
       request: {

--- a/integration_tests/plugins/index.ts
+++ b/integration_tests/plugins/index.ts
@@ -63,6 +63,8 @@ export default (on: (string, Record) => void): void => {
     stubGetStaffDetailsByList: community.stubGetStaffDetailsByList,
     stubGetManagedOffenders: community.stubGetManagedOffenders,
     stubGetAnOffendersManagers: community.stubGetAnOffendersManagers,
+    stubGetUserDetailsByUsername: community.stubGetUserDetailsByUsername,
+    stubAssignRole: community.stubAssignRole,
 
     searchPrisonersByNomisIds: prisonerSearch.searchPrisonersByNomisIds,
     searchPrisonersByBookingIds: prisonerSearch.searchPrisonersByBookingIds,

--- a/integration_tests/wiremock.ts
+++ b/integration_tests/wiremock.ts
@@ -19,6 +19,10 @@ const verifyEndpointCalled = async (options: { verb: string; path: string; times
     })
     .then(response => response.body)
     .then(response => response.count === options.times)
+    .then(success => {
+      if (!success) throw new Error(`Endpoint called an unexpected number of times`)
+      return success
+    })
 }
 
 export { stubFor, getRequests, resetStubs, verifyEndpointCalled }

--- a/server/listeners/eventHandlers/probationEvents/offenderManagerChangedEventHandler.ts
+++ b/server/listeners/eventHandlers/probationEvents/offenderManagerChangedEventHandler.ts
@@ -2,6 +2,8 @@ import { ProbationEventMessage } from '../../../@types/events'
 import CommunityService from '../../../services/communityService'
 import LicenceService from '../../../services/licenceService'
 
+const COM_ROLE_ID = 'LHDCBT002'
+
 export default class OffenderManagerChangedEventHandler {
   constructor(private readonly communityService: CommunityService, private readonly licenceService: LicenceService) {}
 
@@ -18,6 +20,12 @@ export default class OffenderManagerChangedEventHandler {
 
       // If the COM does not have a username, they are assumed to be ineligible for use of this service. (e.g. the "unallocated" staff members)
       if (comDetails?.username) {
+        // Assign the com role to the user if they do not have it already
+        const userDetails = await this.communityService.getUserDetailsByUsername(comDetails.username)
+        if (userDetails.roles.find(role => role.name === COM_ROLE_ID) === undefined) {
+          await this.communityService.assignDeliusRole(comDetails.username.trim().toUpperCase(), COM_ROLE_ID)
+        }
+
         await this.licenceService.updateResponsibleCom(crn, {
           staffIdentifier: comDetails?.staffIdentifier,
           staffUsername: comDetails?.username,


### PR DESCRIPTION
- Tested using delius wiremock
- Also simplified the endpoint verification task during integration tests by reusing the `success` logic in one place