### PR TITLE
CVSL-531: Avoid updating licence status for dates-changed events

### DIFF
--- a/integration_tests/integration/eventHandlers.spec.ts
+++ b/integration_tests/integration/eventHandlers.spec.ts
@@ -78,10 +78,9 @@ context('Event handlers', () => {
   })
 
   describe('Prison events', () => {
-    it('should listen to the SENTENCE_DATES-CHANGED event and call endpoint to update sentence dates and update licence status', () => {
+    it('should listen to the SENTENCE_DATES-CHANGED event and call endpoint to update sentence dates', () => {
       cy.task('stubGetLicencesForOffender', { nomisId: 'G9786GC', status: 'APPROVED' })
       cy.task('stubGetPrisonerDetail')
-      cy.task('stubUpdateLicenceStatus')
       cy.task('stubUpdateSentenceDates')
 
       cy.task(
@@ -97,15 +96,13 @@ context('Event handlers', () => {
          }`
       )
 
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 })
       cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/sentence-dates', times: 1 })
     })
 
-    it('should listen to the CONFIRMED_RELEASE_DATE-CHANGED event and call endpoint to update sentence dates and update licence status', () => {
+    it('should listen to the CONFIRMED_RELEASE_DATE-CHANGED event and call endpoint to update sentence dates', () => {
       cy.task('searchPrisonersByBookingIds')
       cy.task('stubGetLicencesForOffender', { nomisId: 'G9786GC', status: 'APPROVED' })
       cy.task('stubGetPrisonerDetail')
-      cy.task('stubUpdateLicenceStatus')
       cy.task('stubUpdateSentenceDates')
 
       cy.task(
@@ -121,7 +118,6 @@ context('Event handlers', () => {
          }`
       )
 
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/status', times: 1 })
       cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/licence/id/1/sentence-dates', times: 1 })
     })
   })

--- a/server/listeners/eventHandlers/prisonEvents/datesChangedEventHandler.test.ts
+++ b/server/listeners/eventHandlers/prisonEvents/datesChangedEventHandler.test.ts
@@ -1,6 +1,5 @@
 import LicenceService from '../../../services/licenceService'
 import { LicenceSummary } from '../../../@types/licenceApiClientTypes'
-import LicenceStatus from '../../../enumeration/licenceStatus'
 import PrisonerService from '../../../services/prisonerService'
 import { PrisonApiPrisoner, PrisonEventMessage } from '../../../@types/prisonApiClientTypes'
 import SentenceDatesChangedEventHandler from './datesChangedEventHandler'
@@ -57,6 +56,7 @@ describe('Sentence dates changed event handler', () => {
     const event = {
       offenderIdDisplay: 'ABC123',
     } as PrisonEventMessage
+
     licenceService.getLicencesByNomisIdsAndStatus.mockResolvedValue([])
 
     await handler.handle(event)
@@ -68,26 +68,11 @@ describe('Sentence dates changed event handler', () => {
     expect(licenceService.updateSentenceDates).not.toHaveBeenCalled()
   })
 
-  it('should update the licence to IN_PROGRESS', async () => {
-    const event = {
-      offenderIdDisplay: 'ABC123',
-    } as PrisonEventMessage
-    licenceService.getLicencesByNomisIdsAndStatus.mockResolvedValue([
-      {
-        licenceId: 1,
-        licenceStatus: 'APPROVED',
-      } as LicenceSummary,
-    ])
-
-    await handler.handle(event)
-
-    expect(licenceService.updateStatus).toHaveBeenCalledWith('1', LicenceStatus.IN_PROGRESS)
-  })
-
   it('should update the sentence dates on the licence', async () => {
     const event = {
       offenderIdDisplay: 'ABC123',
     } as PrisonEventMessage
+
     licenceService.getLicencesByNomisIdsAndStatus.mockResolvedValue([
       {
         licenceId: 1,
@@ -121,6 +106,7 @@ describe('Sentence dates changed event handler', () => {
     const event = {
       offenderIdDisplay: 'ABC123',
     } as PrisonEventMessage
+
     licenceService.getLicencesByNomisIdsAndStatus.mockResolvedValue([
       {
         licenceId: 1,
@@ -154,6 +140,7 @@ describe('Sentence dates changed event handler', () => {
     const event = {
       offenderIdDisplay: 'ABC123',
     } as PrisonEventMessage
+
     licenceService.getLicencesByNomisIdsAndStatus.mockResolvedValue([
       {
         licenceId: 1,

--- a/server/listeners/eventHandlers/prisonEvents/datesChangedEventHandler.ts
+++ b/server/listeners/eventHandlers/prisonEvents/datesChangedEventHandler.ts
@@ -24,8 +24,6 @@ export default class DatesChangedEventHandler {
 
     if (licence) {
       const prisoner = await this.prisonerService.getPrisonerDetail(nomisId)
-
-      await this.licenceService.updateStatus(licence.licenceId.toString(), LicenceStatus.IN_PROGRESS)
       await this.licenceService.updateSentenceDates(licence.licenceId.toString(), {
         conditionalReleaseDate:
           convertDateFormat(prisoner.sentenceDetail?.conditionalReleaseOverrideDate) ||


### PR DESCRIPTION
This is part 1 of a 2-port change. Part 2 is in the API coming soon.

This change avoids updating the licence status whenever we get a dates-changed event.
It will be replaced by a notification to the COM (via the API) if any of the date changes are `material` to the licence.
This avoids the situation where licences are changed from APPROVED to IN_PROGRESS just prior to release, as it looks like the OMU staff update the release date near, or on, the day of release.
