### PR TITLE
refs CVSL-540

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -69,7 +69,7 @@ services:
     container_name: licences-db
     restart: always
     ports:
-      - "5433:5432"
+      - "5432:5432"
     environment:
       - POSTGRES_PASSWORD=create-and-vary-a-licence
       - POSTGRES_USER=create-and-vary-a-licence

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -61,5 +61,18 @@ services:
       - './.localstack:/tmp/localstack'
       - $PWD/localstack:/docker-entrypoint-initaws.d
 
+  # Optional - only when running API locally
+  licences-db:
+    image: postgres
+    networks:
+      - hmpps
+    container_name: licences-db
+    restart: always
+    ports:
+      - "5433:5432"
+    environment:
+      - POSTGRES_PASSWORD=create-and-vary-a-licence
+      - POSTGRES_USER=create-and-vary-a-licence
+      - POSTGRES_DB=create-and-vary-a-licence-db
 networks:
   hmpps:


### PR DESCRIPTION
Add the postgresql container to docker-compose-dev.yaml - so will run this and other required containers when using DEV for auth, prison, community APIs etc.