### PR TITLE
CVSL-545: Correct the audit event time format when raised from the UI service.

### DIFF
--- a/server/services/licenceService.test.ts
+++ b/server/services/licenceService.test.ts
@@ -813,16 +813,16 @@ describe('Licence Service', () => {
   })
 
   describe('Audit events', () => {
-    const eventTime = moment('13/01/2022 11:00:00', 'DD/MM/YYYY hh:mm:ss').toDate()
-    const eventStart = moment('12/01/2022 10:45:00', 'DD/MM/YYYY hh:mm:ss').toDate()
-    const eventEnd = moment('13/01/2022 10:45:00', 'DD/MM/YYYY hh:mm:ss').toDate()
+    const eventTime = moment('13/01/2022 11:00:00', 'DD/MM/YYYY HH:mm:ss').toDate()
+    const eventStart = moment('12/01/2022 10:45:00', 'DD/MM/YYYY HH:mm:ss').toDate()
+    const eventEnd = moment('13/01/2022 10:45:00', 'DD/MM/YYYY HH:mm:ss').toDate()
 
     it('will record a new audit event', async () => {
       await licenceService.recordAuditEvent('Summary', 'Detail', 1, eventTime, user)
       expect(licenceApiClient.recordAuditEvent).toHaveBeenCalledWith(
         {
           username: user.username,
-          eventTime: moment(eventTime).format('DD/MM/YYYY hh:mm:ss'),
+          eventTime: moment(eventTime).format('DD/MM/YYYY HH:mm:ss'),
           eventType: 'USER_EVENT',
           licenceId: 1,
           fullName: `${user.firstName} ${user.lastName}`,
@@ -839,8 +839,8 @@ describe('Licence Service', () => {
         {
           username: 'username',
           licenceId: null,
-          startTime: moment(eventStart).format('DD/MM/YYYY hh:mm:ss'),
-          endTime: moment(eventEnd).format('DD/MM/YYYY hh:mm:ss'),
+          startTime: moment(eventStart).format('DD/MM/YYYY HH:mm:ss'),
+          endTime: moment(eventEnd).format('DD/MM/YYYY HH:mm:ss'),
         },
         user
       )
@@ -852,8 +852,8 @@ describe('Licence Service', () => {
         {
           username: null,
           licenceId: 1,
-          startTime: moment(eventStart).format('DD/MM/YYYY hh:mm:ss'),
-          endTime: moment(eventEnd).format('DD/MM/YYYY hh:mm:ss'),
+          startTime: moment(eventStart).format('DD/MM/YYYY HH:mm:ss'),
+          endTime: moment(eventEnd).format('DD/MM/YYYY HH:mm:ss'),
         },
         user
       )

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -388,8 +388,8 @@ export default class LicenceService {
   ): Promise<void> {
     const requestBody = {
       username: user.username,
-      eventTime: moment(eventTime).format('DD/MM/YYYY hh:mm:ss'),
-      eventType: user ? 'USER_EVENT' : 'SYSTEM_EVENT',
+      eventTime: moment(eventTime).format('DD/MM/YYYY HH:mm:ss'),
+      eventType: user && user?.username !== 'SYSTEM' ? 'USER_EVENT' : 'SYSTEM_EVENT',
       licenceId,
       fullName: `${user.firstName} ${user.lastName}`,
       summary,

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -389,7 +389,7 @@ export default class LicenceService {
     const requestBody = {
       username: user.username,
       eventTime: moment(eventTime).format('DD/MM/YYYY HH:mm:ss'),
-      eventType: user && user?.username !== 'SYSTEM' ? 'USER_EVENT' : 'SYSTEM_EVENT',
+      eventType: user ? 'USER_EVENT' : 'SYSTEM_EVENT',
       licenceId,
       fullName: `${user.firstName} ${user.lastName}`,
       summary,


### PR DESCRIPTION
This bug affects audit events raised by the UI service only.
The moment time parsing was incorrectly using the 12-hour clock form `hh:mm:ss`.
It should (and now does) use the 24-hour clock format `HH:mm:ss` + tests updated.