### PR TITLE
CVSL-550: Updating typescript to latest (overnight job fail)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11116,9 +11116,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "uid-safe": {

--- a/package.json
+++ b/package.json
@@ -181,6 +181,6 @@
     "redis-mock": "^0.56.3",
     "sass": "^1.50.1",
     "ts-jest": "^27.1.4",
-    "typescript": "^4.6.3"
+    "typescript": "^4.6.4"
   }
 }


### PR DESCRIPTION
4.6.3 -> 4.6.4 to prevent overnight check_outdated job from failing build.