### PR TITLE
CVSL-556: Set the varied licence to INACTIVE when the variation is activated.

### DIFF
--- a/server/routes/varyingLicences/handlers/timeline.test.ts
+++ b/server/routes/varyingLicences/handlers/timeline.test.ts
@@ -188,14 +188,20 @@ describe('Route Handlers - Timeline', () => {
         ...commonRes,
         locals: {
           licence: {
-            id: 1,
+            id: 2,
             statusCode: LicenceStatus.VARIATION_APPROVED,
+            variationOf: 1,
           },
           user: commonUser,
         },
       } as unknown as Response
+
       await handler.POST(req, res)
-      expect(licenceService.updateStatus).toHaveBeenCalledWith(1, LicenceStatus.ACTIVE, { username: 'joebloggs' })
+
+      expect(licenceService.updateStatus).toHaveBeenNthCalledWith(1, 2, LicenceStatus.ACTIVE, { username: 'joebloggs' })
+      expect(licenceService.updateStatus).toHaveBeenNthCalledWith(2, 1, LicenceStatus.INACTIVE, {
+        username: 'joebloggs',
+      })
       expect(res.redirect).toHaveBeenCalledWith('/licence/vary/id/1/timeline')
     })
   })

--- a/server/routes/varyingLicences/handlers/timeline.ts
+++ b/server/routes/varyingLicences/handlers/timeline.ts
@@ -33,9 +33,10 @@ export default class TimelineRoutes {
     const { licenceId } = req.params
     const { user, licence } = res.locals
 
-    // The only POST to this form is the trigger to set approved variations to ACTIVE
+    // The POST is the trigger to set the approved variation to ACTIVE and varied licence to INACTIVE
     if (licence.statusCode === LicenceStatus.VARIATION_APPROVED) {
       await this.licenceService.updateStatus(licence.id, LicenceStatus.ACTIVE, user)
+      await this.licenceService.updateStatus(licence.variationOf, LicenceStatus.INACTIVE, user)
     }
 
     return res.redirect(`/licence/vary/id/${licenceId}/timeline`)


### PR DESCRIPTION
This moves the trigger to set the varied licence to the same point at which the variation is set to ACTIVE.
It was formerly doing this when the variation was APPROVED.