### PR TITLE
CVSL-243: Fix actualReleaseDate field when confirmedReleaseDate is null on the confirmCreatePage

### DIFF
--- a/server/routes/creatingLicences/handlers/confirmCreate.test.ts
+++ b/server/routes/creatingLicences/handlers/confirmCreate.test.ts
@@ -52,20 +52,22 @@ describe('Route Handlers - Create Licence - Confirm Create', () => {
   })
 
   describe('GET', () => {
-    prisonerService.getPrisonerDetail.mockResolvedValue({
-      sentenceDetail: {
-        confirmedReleaseDate: '2022-11-20',
-        conditionalReleaseDate: '2022-11-21',
-      },
-      dateOfBirth: '1960-11-10',
-      firstName: 'Patrick',
-      lastName: 'Holmes',
-    } as PrisonApiPrisoner)
-    communityService.getProbationer.mockResolvedValue({
-      otherIds: {
-        crn: 'X1234',
-      },
-    } as OffenderDetail)
+    beforeEach(() => {
+      prisonerService.getPrisonerDetail.mockResolvedValue({
+        sentenceDetail: {
+          confirmedReleaseDate: '2022-11-20',
+          conditionalReleaseDate: '2022-11-21',
+        },
+        dateOfBirth: '1960-11-10',
+        firstName: 'Patrick',
+        lastName: 'Holmes',
+      } as PrisonApiPrisoner)
+      communityService.getProbationer.mockResolvedValue({
+        otherIds: {
+          crn: 'X1234',
+        },
+      } as OffenderDetail)
+    })
 
     it('should render view', async () => {
       await handler.GET(req, res)
@@ -73,6 +75,30 @@ describe('Route Handlers - Create Licence - Confirm Create', () => {
         licence: {
           conditionalReleaseDate: '21/11/2022',
           actualReleaseDate: '20/11/2022',
+          crn: 'X1234',
+          dateOfBirth: '10/11/1960',
+          forename: 'Patrick',
+          surname: 'Holmes',
+        },
+        releaseIsOnBankHolidayOrWeekend: true,
+      })
+    })
+
+    it('actualReleaseDate should be undefined if confirmedReleaseDate does not exist', async () => {
+      prisonerService.getPrisonerDetail.mockResolvedValue({
+        sentenceDetail: {
+          conditionalReleaseDate: '2022-11-20',
+        },
+        dateOfBirth: '1960-11-10',
+        firstName: 'Patrick',
+        lastName: 'Holmes',
+      } as PrisonApiPrisoner)
+
+      await handler.GET(req, res)
+      expect(res.render).toHaveBeenCalledWith('pages/create/confirmCreate', {
+        licence: {
+          conditionalReleaseDate: '20/11/2022',
+          actualReleaseDate: undefined,
           crn: 'X1234',
           dateOfBirth: '10/11/1960',
           forename: 'Patrick',

--- a/server/routes/creatingLicences/handlers/confirmCreate.ts
+++ b/server/routes/creatingLicences/handlers/confirmCreate.ts
@@ -28,7 +28,9 @@ export default class ConfirmCreateRoutes {
     return res.render('pages/create/confirmCreate', {
       licence: {
         crn: deliusRecord?.otherIds?.crn,
-        actualReleaseDate: moment(nomisRecord.sentenceDetail.confirmedReleaseDate).format('DD/MM/YYYY'),
+        actualReleaseDate: nomisRecord.sentenceDetail.confirmedReleaseDate
+          ? moment(nomisRecord.sentenceDetail.confirmedReleaseDate).format('DD/MM/YYYY')
+          : undefined,
         conditionalReleaseDate: moment(nomisRecord.sentenceDetail.conditionalReleaseDate).format('DD/MM/YYYY'),
         dateOfBirth: moment(nomisRecord.dateOfBirth).format('DD/MM/YYYY'),
         forename: convertToTitleCase(nomisRecord.firstName),


### PR DESCRIPTION
- When confirmedReleaseDate was null, the original code was setting actualReleaseDate == todays date