### PR TITLE
CVSL-574: Updated govuk-frontend to 4.1.0 (fixes)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6110,9 +6110,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.0.1.tgz",
-      "integrity": "sha512-X+B88mqYHoxAz0ID87Uxo3oHqdKBRnNHd3Cz8+u8nvQUAsrEzROFLK+t7sAu7e+fKqCCrJyIgx6Cmr6dIGnohQ=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.1.0.tgz",
+      "integrity": "sha512-xBUUarxinGWSccmXPmwa7ovg3xabEQ0+Dcv7pdq9X3F69892OFMqP2g8jvlDUrVsDVdasXLk4Jq4w8dPiaEVqQ=="
     },
     "graceful-fs": {
       "version": "4.2.4",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "express": "^4.17.3",
     "express-request-id": "^1.4.1",
     "express-session": "^1.17.2",
-    "govuk-frontend": "^4.0.1",
+    "govuk-frontend": "^4.1.0",
     "helmet": "^5.0.2",
     "http-errors": "^2.0.0",
     "jquery": "^3.6.0",


### PR DESCRIPTION
Failing overnight job `check-outdated` on govuk-frontend.
The new version release notes contain mostly fixes, and the one or two changes appear not to affect the service.