### PR TITLE
CVSL-575: Show IN_PROGRESS licences on the OMU case list

### DIFF
--- a/server/routes/viewingLicences/handlers/viewLicence.test.ts
+++ b/server/routes/viewingLicences/handlers/viewLicence.test.ts
@@ -67,13 +67,13 @@ describe('Route - view and approve a licence', () => {
       expect(licenceService.recordAuditEvent).toHaveBeenCalled()
     })
 
-    it('should not render view when status is IN_PROGRESS', async () => {
+    it('should not render view when status is NOT_STARTED', async () => {
       res = {
         render: jest.fn(),
         redirect: jest.fn(),
         locals: {
           user: { username, deliusStaffIdentifier: 999 },
-          licence: { ...licence, statusCode: LicenceStatus.IN_PROGRESS },
+          licence: { ...licence, statusCode: LicenceStatus.NOT_STARTED },
         },
       } as unknown as Response
 

--- a/server/routes/viewingLicences/handlers/viewLicence.ts
+++ b/server/routes/viewingLicences/handlers/viewLicence.ts
@@ -11,7 +11,8 @@ export default class ViewAndPrintLicenceRoutes {
       licence?.statusCode === LicenceStatus.APPROVED ||
       licence?.statusCode === LicenceStatus.ACTIVE ||
       licence?.statusCode === LicenceStatus.SUBMITTED ||
-      licence?.statusCode === LicenceStatus.REJECTED
+      licence?.statusCode === LicenceStatus.REJECTED ||
+      licence?.statusCode === LicenceStatus.IN_PROGRESS
     ) {
       if (licence?.comStaffId !== user?.deliusStaffIdentifier) {
         // Recorded here as we do not know the reason for fetchLicence in the API

--- a/server/services/licenceService.test.ts
+++ b/server/services/licenceService.test.ts
@@ -627,7 +627,7 @@ describe('Licence Service', () => {
 
     const result = await licenceService.getLicencesForOmu(user)
     expect(licenceApiClient.matchLicences).toBeCalledWith(
-      ['ACTIVE', 'APPROVED', 'SUBMITTED'],
+      ['ACTIVE', 'APPROVED', 'SUBMITTED', 'IN_PROGRESS'],
       ['MDI'],
       null,
       null,

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -324,6 +324,7 @@ export default class LicenceService {
       LicenceStatus.ACTIVE.valueOf(),
       LicenceStatus.APPROVED.valueOf(),
       LicenceStatus.SUBMITTED.valueOf(),
+      LicenceStatus.IN_PROGRESS.valueOf(),
     ]
     const filteredPrisons = filterCentralCaseload(user.prisonCaseload)
     return this.licenceApiClient.matchLicences(


### PR DESCRIPTION
Formerly, we were not showing IN_PROGRESS licences on the OMU list.
This meant that OMU could see NOT_STARTED licences, but once the COM started work on them they would disappear.
They would reappear when the COM submitted them and they were status SUBMITTED.
OMU people had commented that licences "disappear" from their list and it was confusing.
This PR corrects that behaviour so licences stay visible to OMU throughout the process, though are not clickable until SUBMITTED.