### PR TITLE
CVSL-575

### DIFF
--- a/server/services/caseloadService.test.ts
+++ b/server/services/caseloadService.test.ts
@@ -703,13 +703,15 @@ describe('Caseload Service', () => {
         licenceStatus: LicenceStatus.APPROVED,
         comUsername: 'joebloggs',
       },
+      {
+        nomisId: 'AB1234E',
+        licenceId: 2,
+        licenceType: LicenceType.AP,
+        licenceStatus: LicenceStatus.IN_PROGRESS,
+        comUsername: 'joebloggs',
+      },
     ])
     prisonerService.searchPrisonersByReleaseDate.mockResolvedValueOnce([
-      {
-        prisonerNumber: 'AB1234E',
-        conditionalReleaseDate: '2022-06-20',
-        status: 'ACTIVE IN',
-      } as Prisoner,
       {
         prisonerNumber: 'AB1234F',
         conditionalReleaseDate: '2022-06-20',
@@ -719,6 +721,10 @@ describe('Caseload Service', () => {
     communityService.getOffendersByNomsNumbers.mockResolvedValueOnce([
       {
         otherIds: { nomsNumber: 'AB1234D', crn: 'X12347' },
+        offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
+      } as OffenderDetail,
+      {
+        otherIds: { nomsNumber: 'AB1234E', crn: 'X12348' },
         offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
       } as OffenderDetail,
     ])
@@ -735,6 +741,11 @@ describe('Caseload Service', () => {
     prisonerService.searchPrisonersByNomisIds.mockResolvedValue([
       {
         prisonerNumber: 'AB1234D',
+        conditionalReleaseDate: '2022-06-20',
+        status: 'ACTIVE IN',
+      } as Prisoner,
+      {
+        prisonerNumber: 'AB1234E',
         conditionalReleaseDate: '2022-06-20',
         status: 'ACTIVE IN',
       } as Prisoner,

--- a/server/services/caseloadService.ts
+++ b/server/services/caseloadService.ts
@@ -91,7 +91,6 @@ export default class CaseloadService {
             LicenceStatus.NOT_IN_PILOT,
             LicenceStatus.OOS_RECALL,
             LicenceStatus.OOS_BOTUS,
-            LicenceStatus.IN_PROGRESS,
           ].some(status => c.licences.find(l => l.status === status))
         )
       })


### PR DESCRIPTION
Remove IN_PROGRESS licences when checking for licences by date. The standard list of licences for an OMU caseload now contains IN_PROGRESS records, so should not be returned again using the date range.