### PR TITLE
Ensure dates are present on the offender support page.

### DIFF
--- a/server/routes/support/handlers/offenderDetail.test.ts
+++ b/server/routes/support/handlers/offenderDetail.test.ts
@@ -222,4 +222,101 @@ describe('Route Handlers - Offender detail', () => {
       },
     })
   })
+  it('Should render all offender information with NULL sentence dates', async () => {
+    req.params = {
+      nomsId: 'ABC123',
+    }
+
+    const expectedPrisonerDetail = {
+      firstName: 'David',
+      lastName: 'Pepper',
+      conditionalReleaseDate: null,
+      confirmedReleaseDate: '2022-06-01',
+      postRecallReleaseDate: null,
+      topupSupervisionExpiryDate: null,
+      homeDetentionCurfewEligibilityDate: null,
+      sentenceExpiryDate: null,
+      licenceExpiryDate: null,
+      paroleEligibilityDate: null,
+      indeterminateSentence: false,
+      dateOfBirth: '1995-03-05',
+    } as Prisoner
+    prisonerService.searchPrisonersByNomisIds.mockResolvedValue([expectedPrisonerDetail])
+
+    communityService.searchProbationers.mockResolvedValue([
+      {
+        otherIds: {
+          crn: 'X1234',
+        },
+        offenderManagers: [
+          {
+            active: true,
+            staff: {
+              code: 'X123',
+              forenames: 'Mr',
+              surname: 'T',
+            },
+            team: {
+              description: 'The A Team',
+              localDeliveryUnit: {
+                description: 'LDU A',
+              },
+              district: {
+                description: 'LAU A',
+              },
+              borough: {
+                description: 'PDU A',
+              },
+            },
+            probationArea: {
+              description: 'Wales',
+            },
+          },
+        ],
+      } as unknown as OffenderDetail,
+    ])
+
+    prisonerService.getHdcStatuses.mockResolvedValue([
+      {
+        bookingId: '1',
+        approvalStatus: 'APPROVED',
+        checksPassed: true,
+      } as HdcStatus,
+    ])
+
+    communityService.getStaffDetailByStaffCode.mockResolvedValue({
+      email: 'mr.g@probation.gov.uk',
+      telephoneNumber: '078929482994',
+    })
+
+    await handler.GET(req, res)
+    expect(res.render).toHaveBeenCalledWith('pages/support/offenderDetail', {
+      prisonerDetail: {
+        ...expectedPrisonerDetail,
+        conditionalReleaseDate: 'Not found',
+        confirmedReleaseDate: '01 Jun 2022',
+        crn: 'X1234',
+        determinate: 'Yes',
+        dob: '05 Mar 1995',
+        hdcStatus: 'APPROVED',
+        hdced: 'Not found',
+        licenceExpiryDate: 'Not found',
+        name: 'David Pepper',
+        paroleEligibilityDate: 'Not found',
+        postRecallReleaseDate: 'Not found',
+        sentenceExpiryDate: 'Not found',
+        tused: 'Not found',
+      },
+      probationPractitioner: {
+        email: 'mr.g@probation.gov.uk',
+        lau: 'LAU A',
+        ldu: 'LDU A',
+        name: 'Mr T',
+        pdu: 'PDU A',
+        region: 'Wales',
+        team: 'The A Team',
+        telephone: '078929482994',
+      },
+    })
+  })
 })

--- a/server/routes/support/handlers/offenderDetail.ts
+++ b/server/routes/support/handlers/offenderDetail.ts
@@ -19,19 +19,44 @@ export default class OffenderDetailRoutes {
       : undefined
     const hdcStatus = _.head(await this.prisonerService.getHdcStatuses([prisonerDetail], user))
 
+    const conditionalReleaseDate = prisonerDetail.conditionalReleaseDate
+      ? moment(prisonerDetail.conditionalReleaseDate).format('DD MMM YYYY')
+      : 'Not found'
+    const confirmedReleaseDate = prisonerDetail.confirmedReleaseDate
+      ? moment(prisonerDetail.confirmedReleaseDate).format('DD MMM YYYY')
+      : 'Not found'
+    const postRecallReleaseDate = prisonerDetail.postRecallReleaseDate
+      ? moment(prisonerDetail.postRecallReleaseDate).format('DD MMM YYYY')
+      : 'Not found'
+    const tused = prisonerDetail.topupSupervisionExpiryDate
+      ? moment(prisonerDetail.topupSupervisionExpiryDate).format('DD MMM YYYY')
+      : 'Not found'
+    const hdced = prisonerDetail.homeDetentionCurfewEligibilityDate
+      ? moment(prisonerDetail.homeDetentionCurfewEligibilityDate).format('DD MMM YYYY')
+      : 'Not found'
+    const sentenceExpiryDate = prisonerDetail.sentenceExpiryDate
+      ? moment(prisonerDetail.sentenceExpiryDate).format('DD MMM YYYY')
+      : 'Not found'
+    const licenceExpiryDate = prisonerDetail.licenceExpiryDate
+      ? moment(prisonerDetail.licenceExpiryDate).format('DD MMM YYYY')
+      : 'Not found'
+    const paroleEligibilityDate = prisonerDetail.paroleEligibilityDate
+      ? moment(prisonerDetail.paroleEligibilityDate).format('DD MMM YYYY')
+      : 'Not found'
+
     res.render('pages/support/offenderDetail', {
       prisonerDetail: {
         ...prisonerDetail,
         name: convertToTitleCase(`${prisonerDetail.firstName} ${prisonerDetail.lastName}`),
         crn: deliusRecord?.otherIds.crn,
-        conditionalReleaseDate: moment(prisonerDetail.conditionalReleaseDate).format('DD MMM YYYY'),
-        confirmedReleaseDate: moment(prisonerDetail.confirmedReleaseDate).format('DD MMM YYYY'),
-        postRecallReleaseDate: moment(prisonerDetail.postRecallReleaseDate).format('DD MMM YYYY'),
-        tused: moment(prisonerDetail.topupSupervisionExpiryDate).format('DD MMM YYYY'),
-        hdced: moment(prisonerDetail.homeDetentionCurfewEligibilityDate).format('DD MMM YYYY'),
-        sentenceExpiryDate: moment(prisonerDetail.sentenceExpiryDate).format('DD MMM YYYY'),
-        licenceExpiryDate: moment(prisonerDetail.licenceExpiryDate).format('DD MMM YYYY'),
-        paroleEligibilityDate: moment(prisonerDetail.paroleEligibilityDate).format('DD MMM YYYY'),
+        conditionalReleaseDate,
+        confirmedReleaseDate,
+        postRecallReleaseDate,
+        tused,
+        hdced,
+        sentenceExpiryDate,
+        licenceExpiryDate,
+        paroleEligibilityDate,
         determinate: prisonerDetail.indeterminateSentence ? 'No' : 'Yes',
         dob: moment(prisonerDetail.dateOfBirth).format('DD MMM YYYY'),
         hdcStatus: hdcStatus ? hdcStatus?.approvalStatus : 'Not found',

--- a/server/services/caseloadService.test.ts
+++ b/server/services/caseloadService.test.ts
@@ -414,13 +414,13 @@ describe('Caseload Service', () => {
     prisonerService.searchPrisonersByNomisIds.mockResolvedValue([
       {
         prisonerNumber: 'AB1234E',
-        conditionalReleaseDate: tenDaysFromNow,
+        conditionalReleaseDate: '2022-07-10',
         status: 'ACTIVE IN',
         prisonId: 'MHI',
       } as Prisoner,
       {
         prisonerNumber: 'AB1234F',
-        conditionalReleaseDate: tenDaysFromNow,
+        conditionalReleaseDate: '2022-07-10',
         status: 'ACTIVE IN',
         prisonId: 'CFI',
       } as Prisoner,
@@ -444,7 +444,7 @@ describe('Caseload Service', () => {
         },
         nomisRecord: {
           prisonerNumber: 'AB1234F',
-          conditionalReleaseDate: tenDaysFromNow,
+          conditionalReleaseDate: '2022-07-10',
         },
         licences: [
           {


### PR DESCRIPTION
Ensure dates are present on the offender support page. Show "Not found" if date is not present.