### PR TITLE
CVSL-582 vary confirmation page text change

### DIFF
--- a/server/views/pages/vary/confirmation.njk
+++ b/server/views/pages/vary/confirmation.njk
@@ -22,7 +22,7 @@
                 They will contact you if they need more information.
             </p>
             <p class="govuk-body">
-                When the variation is approved, you will be able to print and issue the licence.
+                You will get an email when the variation is approved and you will be able to print and issue the licence.            
             </p>
 
             <h2 class="govuk-heading-m">Give us your feedback</h2>


### PR DESCRIPTION
Now refers to an email.
No change to logic
<img width="600" alt="Screenshot 2022-07-25 at 14 12 31" src="https://user-images.githubusercontent.com/50441412/180785558-04913358-1bf1-4f8e-a490-946132f92548.png">

