### PR TITLE
CVSL-582 text changes for Add reasons page

### DIFF
--- a/server/routes/creatingLicences/types/reasonForReferral.ts
+++ b/server/routes/creatingLicences/types/reasonForReferral.ts
@@ -3,7 +3,7 @@ import { IsNotEmpty } from 'class-validator'
 
 class ReasonForReferral {
   @Expose()
-  @IsNotEmpty({ message: 'Please provide a short explanation why amendments should be made to this variation' })
+  @IsNotEmpty({ message: 'You must add a reason for wanting to decline the variation request' })
   reasonForReferral: string
 }
 

--- a/server/views/pages/vary-approve/request-changes.njk
+++ b/server/views/pages/vary-approve/request-changes.njk
@@ -13,7 +13,7 @@
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">Add reasons for requesting amendments to the licence variation</h1>
+            <h1 class="govuk-heading-l">Add reasons for declining the licence variation request</h1>
         </div>
     </div>
 
@@ -27,7 +27,7 @@
                 <div class="govuk-hint">Add a short explanation for why it's necessary for amendments to be made to the licence variation.</div>
 
                 {{ govukDetails({
-                    summaryText: "View the varied licence conditions",
+                    summaryText: "View licence variation details",
                     html: variedConditions(conditionComparison)
                 }) }}
 
@@ -48,7 +48,7 @@
 
                 <div class="govuk-button-group">
                     {{ govukButton({
-                        text: "Submit and request amendments",
+                        text: "Continue",
                         attributes: { 'data-qa': 'request-amendments' }
                     }) }}
                 </div>


### PR DESCRIPTION
ACs
Change H1 to Add reasons for declining the licence variation request 
Change accordion text to "View licence variation details" 
Change green button text to Continue 

Change error summary text to
There is a problem
You must add a reason for wanting to decline the variation request 

Change inline error message text
You must add a reason for wanting to decline the variation request 
