### PR TITLE
CVSl 582 PDU head approval correction

### DIFF
--- a/server/views/pages/vary-approve/approved.njk
+++ b/server/views/pages/vary-approve/approved.njk
@@ -16,7 +16,7 @@
 
             <h2 class="govuk-heading-m">What happens next</h2>
             <p class="govuk-body" id="sent-to">
-                The licence and post sentence supervision order variation for {{ licence.forename }} {{ licence.surname }} has been approved with your digital signature.
+                The variation for {{ licence.forename }} {{ licence.surname }} has been approved with your digital signature.
             </p>
             <p class="govuk-body" id="notified-to">
                 We have sent an email notification to the probation practitioner.

--- a/server/views/pages/vary-approve/approved.njk
+++ b/server/views/pages/vary-approve/approved.njk
@@ -11,20 +11,23 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {{ govukPanel({
-                titleText: "The licence variation for " + licence.forename + " " + licence.surname + " has been approved."
+                titleText: "Licence variation for " + licence.forename + " " + licence.surname + " approved."
             }) }}
 
             <h2 class="govuk-heading-m">What happens next</h2>
             <p class="govuk-body" id="sent-to">
-                The licence variation for {{ licence.forename }} {{ licence.surname }} been approved.
+                The licence and post sentence supervision order variation for {{ licence.forename }} {{ licence.surname }} has been approved with your digital signature.
             </p>
             <p class="govuk-body" id="notified-to">
-                The probation team will be notified of the approval.
+                We have sent an email notification to the probation practitioner.
+            </p>
+            <p class="govuk-body">
+                They will be able to print and issue the licence.
             </p>
 
             <p class="govuk-body">
                 {{ govukButton({
-                    text: "Return to approvals case list",
+                    text: "Return to case list",
                     classes: "govuk-button--primary govuk-!-margin-bottom-0 govuk-body",
                     href: '/licence/vary-approve/list',
                     attributes: { 'data-qa': 'return-to-vary-approve-cases' }

--- a/server/views/pages/vary-approve/variation-referred.njk
+++ b/server/views/pages/vary-approve/variation-referred.njk
@@ -8,33 +8,30 @@
 {% set hideLicenceBanner = true %}
 
 {% block content %}
-    <div class="govuk-grid-row govuk-body">
+    <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {{ govukPanel({
-                titleText: "Licence variation for " + licence.forename + " " + licence.surname + " approved"
+                titleText: "The licence variation for " + licence.forename + " " + licence.surname + " has been referred."
             }) }}
 
             <h2 class="govuk-heading-m">What happens next</h2>
-            <p id="sent-to">
-                The licence and post sentence supervision order variation for {{ licence.forename }} {{ licence.surname }} has been approved with your digital signature.
+            <p class="govuk-body" id="sent-to">
+                We have sent an email to notify the probation practitioner.
             </p>
-            <p>
-                We have sent an email notification to the probation practitioner.
-            </p>
-            <p id="they-can">
-                They will be able to print and issue the licence.
+            <p class="govuk-body" id="they-can">
+                They can amend the variation request and re-submit it for approval.
             </p>
 
-            <p>
+            <p class="govuk-body">
                 {{ govukButton({
-                    text: "Return to case list",
+                    text: "Return to approvals case list",
                     classes: "govuk-button--primary govuk-!-margin-bottom-0 govuk-body",
                     href: '/licence/vary-approve/list',
                     attributes: { 'data-qa': 'return-to-vary-approve-cases' }
                 }) }}
             </p>
 
-            <p>
+            <p class="govuk-body">
                 <a href="{{ exitSurveyLink }}" rel="noreferrer noopener" target="_blank" id="exit-survey" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
             </p>
         </div>


### PR DESCRIPTION
The changes were previously applied to wrong page (variation-referred.njk). 
Changes reversed and applied to correct page (approved.njk)

ACs
Change banner to Licence variation for [first name last name] approved

Change text under What happens next to:
The variation for [first name last name] has been approved with your digital signature.
We have sent an email notification to the probation practitioner.
They will be able to print and issue the licence.

Change green button text to "Return to case list" 

Vary approved page:
<img width="1189" alt="Screenshot 2022-07-29 at 10 32 38" src="https://user-images.githubusercontent.com/50441412/181730607-b3c9aefc-2f11-41c9-ad4e-fb9891eb6bde.png">


