### PR TITLE
CVSL-582 text changes to confirmation page 

### DIFF
--- a/server/views/pages/vary-approve/variation-referred.njk
+++ b/server/views/pages/vary-approve/variation-referred.njk
@@ -8,30 +8,33 @@
 {% set hideLicenceBanner = true %}
 
 {% block content %}
-    <div class="govuk-grid-row">
+    <div class="govuk-grid-row govuk-body">
         <div class="govuk-grid-column-two-thirds">
             {{ govukPanel({
-                titleText: "The licence variation for " + licence.forename + " " + licence.surname + " has been referred."
+                titleText: "Licence variation for " + licence.forename + " " + licence.surname + " declined"
             }) }}
 
             <h2 class="govuk-heading-m">What happens next</h2>
-            <p class="govuk-body" id="sent-to">
-                We have sent an email to notify the probation practitioner.
+            <p>
+                The variation for {{ licence.forename }} {{licence.surname}} has been declined.
             </p>
-            <p class="govuk-body" id="they-can">
-                They can amend the variation request and re-submit it for approval.
+            <p>
+                We have sent an email to the probation practitioner to notify them.
+            </p>
+            <p>
+                They can amend and resend the variation or discard it.
             </p>
 
-            <p class="govuk-body">
+            <p>
                 {{ govukButton({
-                    text: "Return to approvals case list",
+                    text: "Return to case list",
                     classes: "govuk-button--primary govuk-!-margin-bottom-0 govuk-body",
                     href: '/licence/vary-approve/list',
                     attributes: { 'data-qa': 'return-to-vary-approve-cases' }
                 }) }}
             </p>
 
-            <p class="govuk-body">
+            <p>
                 <a href="{{ exitSurveyLink }}" rel="noreferrer noopener" target="_blank" id="exit-survey" class="govuk-link">What did you think of this service?</a> (takes 30 seconds)
             </p>
         </div>


### PR DESCRIPTION
following decline of variation by PDU head

AC's:
Change banner to Licence variation for [first name last name] declined 

Change text under What happens next to
The variation for [first name last name] has been declined.
We have sent an email to the probation practitioner to notify them. 
They can amend and resend the variation or discard it.

Change green button text to "Return to case list" 

view: 
<img width="555" alt="Screenshot 2022-07-29 at 11 03 55" src="https://user-images.githubusercontent.com/50441412/181737826-6ba55ba1-d183-49c2-b95f-6ae36374d9e4.png">


