### PR TITLE
ignore teams check when accessing a licence with the ACO role.

### DIFF
--- a/server/middleware/fetchLicenceMiddleware.test.ts
+++ b/server/middleware/fetchLicenceMiddleware.test.ts
@@ -30,6 +30,7 @@ const probationRes = {
       deliusStaffIdentifier: 123,
       probationAreaCode: 'N55',
       probationTeamCodes: ['N55A'],
+      userRoles: ['ROLE_LICENCE_RO'],
     },
     licence: undefined,
   },
@@ -116,5 +117,16 @@ describe('fetchLicenceMiddleware', () => {
     expect(licenceService.getLicence).toBeCalledTimes(1)
     expect(res.redirect).toBeCalledWith('/access-denied')
     expect(next).not.toBeCalled()
+  })
+
+  it('should allow access for PDUH regardless of teams', async () => {
+    res = probationRes
+    res.locals.licence = undefined
+    res.locals.user.probationTeamCodes = ['WRONG', 'WRONG-AGAIN']
+    res.locals.user.userRoles = ['ROLE_LICENCE_ACO'] // PDU role
+    await middleware(req, res, next)
+    expect(res.locals.licence).toEqual(licence)
+    expect(licenceService.getLicence).toBeCalledTimes(1)
+    expect(next).toBeCalledTimes(1)
   })
 })

--- a/server/middleware/fetchLicenceMiddleware.ts
+++ b/server/middleware/fetchLicenceMiddleware.ts
@@ -10,33 +10,40 @@ export default function fetchLicence(licenceService: LicenceService): RequestHan
         const { user } = res.locals
         const licence = await licenceService.getLicence(req.params.licenceId, user)
 
-        // Does this prison user have a caseload which allows access this licence?
-        if (licence && user?.nomisStaffId) {
-          if (!user.prisonCaseload.includes(licence.prisonCode)) {
-            logger.info(
-              `Prison caseload ${user?.prisonCasload} denied access to licence ID ${licence.id} ${licence.prisonCode}`
-            )
-            return res.redirect('/access-denied')
+        if (licence) {
+          // Does this prison user have a caseload which allows access this licence?
+          if (user?.nomisStaffId) {
+            if (!user.prisonCaseload.includes(licence.prisonCode)) {
+              logger.info(
+                `Prison caseload ${user?.prisonCasload} denied access to licence ID ${licence.id} ${licence.prisonCode}`
+              )
+              return res.redirect('/access-denied')
+            }
           }
-        }
 
-        // Does this probation user belong to the team which manages the person on licence?
-        if (licence && user?.deliusStaffIdentifier) {
-          if (!user.probationTeamCodes?.includes(licence.probationTeamCode)) {
+          /*
+           * Does this probation user belong to the team which manages the person on licence?
+           * Ignore check if user has the ACO role. This role permits approving licences belonging to
+           * team's outside their own
+           */
+          if (
+            user?.deliusStaffIdentifier &&
+            !user?.userRoles?.includes('ROLE_LICENCE_ACO') &&
+            !user.probationTeamCodes?.includes(licence.probationTeamCode)
+          ) {
             logger.info(
               `Probation teams ${user?.probationTeamCodes} denies access to licence ID ${licence.id} ${licence.probationTeamCode}`
             )
+
             return res.redirect('/access-denied')
           }
-        }
 
-        // Is the URL requested allowed for a licence in this status?
-        if (licence && !getUrlAccessByStatus(req.path, licence.id, licence.statusCode, user.username)) {
-          logger.info(`URL access denied to licence ID ${licence.statusCode} ${licence.id} ${req.path}`)
-          return res.redirect('/access-denied')
-        }
+          // Is the URL requested allowed for a licence in this status?
+          if (!getUrlAccessByStatus(req.path, licence.id, licence.statusCode, user.username)) {
+            logger.info(`URL access denied to licence ID ${licence.statusCode} ${licence.id} ${req.path}`)
+            return res.redirect('/access-denied')
+          }
 
-        if (licence) {
           res.locals.licence = licence
         }
       } catch (error) {


### PR DESCRIPTION
ignore teams check when accessing a licence with the ACO role. PDU head can view cases across all teams.