### PR TITLE
CVSL-657 - Adds temporary notice of updating policy framework version

### DIFF
--- a/server/views/pages/create/additionalLicenceConditions.njk
+++ b/server/views/pages/create/additionalLicenceConditions.njk
@@ -8,6 +8,21 @@
 {% set backLinkHref = "/licence/create/id/" + licence.id + "/additional-licence-conditions-question" %}
 
 {% block content %}
+    <div class="moj-banner" role="region" aria-label="information" style="margin-top: 5px;">
+      <svg class="moj-banner__icon" fill="currentColor" role="presentation" focusable="false" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 25 25" height="25" width="25">
+        <path d="M13.7,18.5h-2.4v-2.4h2.4V18.5z M12.5,13.7c-0.7,0-1.2-0.5-1.2-1.2V7.7c0-0.7,0.5-1.2,1.2-1.2s1.2,0.5,1.2,1.2v4.8
+      C13.7,13.2,13.2,13.7,12.5,13.7z M12.5,0.5c-6.6,0-12,5.4-12,12s5.4,12,12,12s12-5.4,12-12S19.1,0.5,12.5,0.5z"></path>
+      </svg>
+
+      <div class="moj-banner__message">
+        Create and vary a licence is being updated to use the additional conditions from the latest Licence Conditions Policy Framework.<br>
+        In the meantime, you can continue to use the conditions below from the previous version of the framework.<br>
+        <a class="govuk-link govuk-link--no-visited-state" href="https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/1096084/licence-conditions-policy-framework.pdf" target="_blank">
+          Find out more in the Licence Conditions Policy Framework on GOV.UK (opens in a new tab).
+        </a>
+      </div>
+    </div>
+
     <div class="govuk-grid-row govuk-!-margin-bottom-6">
         <div class="govuk-grid-column-three-quarters">
             <h1 class="govuk-heading-l govuk-!-margin-bottom-0">Select additional licence conditions</h1>


### PR DESCRIPTION
Adds a notice explaining that the policy framework is currently being updated, to prevent unnecessary support queries.
This should be removed once the in-flight versioning work has been completed.

<img width="1006" alt="image" src="https://user-images.githubusercontent.com/102144566/191531451-14bc8c40-8f0c-466b-9943-e9bd43b2b56c.png">
