### PR TITLE
CVSL-630 change tab label as PDUH's don't have cases

### DIFF
--- a/server/views/pages/vary-approve/cases.njk
+++ b/server/views/pages/vary-approve/cases.njk
@@ -73,7 +73,7 @@
         <ul class="moj-sub-navigation__list">
             <li class="moj-sub-navigation__item">
                 <a id="myCases" class="moj-sub-navigation__link" {% if not regionCases %}aria-current="page"{% endif %}
-                   href="?view=me">My cases</a>
+                   href="?view=me">Cases in this PDU</a>
             </li>
             <li class="moj-sub-navigation__item">
                 <a id="allRegions" class="moj-sub-navigation__link" {% if regionCases %}aria-current="page"{% endif %}


### PR DESCRIPTION
ticket: PDUH currently see the tabs 'my cases' and 'all cases in this region'. PDUHs don't work on cases so 'my cases' needs to be replaced with 'Cases in this PDU'


<img width="500" alt="Screenshot 2022-09-26 at 16 36 02" src="https://user-images.githubusercontent.com/50441412/192319619-9e9472ee-f80c-4010-b168-a228235b642d.png">
