### PR TITLE
CVSL-619 - email probation practitioner cronjob

### DIFF
--- a/helm_deploy/create-and-vary-a-licence/templates/email-probation-practioner-cronjob.yaml
+++ b/helm_deploy/create-and-vary-a-licence/templates/email-probation-practioner-cronjob.yaml
@@ -1,0 +1,23 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: email-probation-practioner
+spec:
+  schedule: "0 2 * * *" # 2am every day
+  concurrencyPolicy: Replace
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 43200
+  successfulJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: create-and-vary-a-licence
+            image: {{ with index .Values "generic-service" }}{{ .image.repository }}:{{ .image.tag }}{{ end }}
+            args:
+            - node
+            - dist/jobs/emailProbationPractioner
+{{- include "deployment.envs" (index .Values "generic-service") | nindent 12 }}
+          restartPolicy: Never
+          activeDeadlineSeconds: 3600

--- a/jobs/emailProbationPractioner.ts
+++ b/jobs/emailProbationPractioner.ts
@@ -1,0 +1,23 @@
+import { initialiseAppInsights, buildAppInsightsClient, flush } from '../server/utils/azureAppInsights'
+import LicenceApiClient from '../server/data/licenceApiClient'
+import logger from '../logger'
+
+initialiseAppInsights()
+buildAppInsightsClient('create-and-vary-a-licence-email-probation-practioner-job')
+
+const emailPpIfEditedLicencesNotApprovedByCrd = async (): Promise<void> => {
+  const licenceApi = new LicenceApiClient()
+  const editedLicencesUnapprovedByCrd = await licenceApi.getEditedLicencesUnapprovedByCrd()
+  licenceApi
+    .notifyProbationPractionerOfEditedLicencesStillUnapprovedOnCrd(editedLicencesUnapprovedByCrd)
+    .then(() => {
+      // Flush logs to app insights and only exit when complete
+      flush({ callback: () => process.exit() }, 'success')
+    })
+    .catch((error: Error) => {
+      logger.error(error, 'Problem occurred while emailing the probation practioner')
+      flush({ callback: () => process.exit() }, 'failure')
+    })
+}
+
+emailPpIfEditedLicencesNotApprovedByCrd()

--- a/server/@types/licenceApiClientTypes.ts
+++ b/server/@types/licenceApiClientTypes.ts
@@ -29,3 +29,4 @@ export type ReferVariationRequest = components['schemas']['ReferVariationRequest
 export type EmailContact = components['schemas']['PromptLicenceCreationRequest']
 export type NotifyRequest = components['schemas']['NotifyRequest']
 export type OmuContact = components['schemas']['OmuContact']
+export type UnapprovedLicence = components['schemas']['UnapprovedLicence']

--- a/server/@types/licenceApiImport/index.d.ts
+++ b/server/@types/licenceApiImport/index.d.ts
@@ -156,6 +156,15 @@ export interface paths {
 
 export interface components {
   schemas: {
+    /** @description Editted Licences that were not approved by CRD */
+    UnapprovedLicence: {
+      crn: string
+      forename: string
+      surname: string
+      comFirstName: string
+      comLastName: string
+      comEmail: string
+    }
     /** @description Request object for updating / creating OMU email contact */
     UpdateOmuEmailRequest: {
       /**

--- a/server/data/licenceApiClient.test.ts
+++ b/server/data/licenceApiClient.test.ts
@@ -16,6 +16,7 @@ import {
   LicenceSummary,
   ReferVariationRequest,
   StatusUpdateRequest,
+  UnapprovedLicence,
   UpdateAdditionalConditionDataRequest,
   UpdateComRequest,
   UpdatePrisonInformationRequest,
@@ -569,6 +570,39 @@ describe('Licence API client tests', () => {
         },
         { username: 'USER' }
       )
+    })
+  })
+  describe('Unapproved licence: ', () => {
+    it('should GET unapproved licences from the api', async () => {
+      await licenceApiClient.getEditedLicencesUnapprovedByCrd()
+      expect(get).toHaveBeenCalledWith({
+        path: '/edited-licences-unapproved-by-crd',
+      })
+    })
+
+    it('should POST unapproved licences', async () => {
+      const unapprovedLicences = [
+        {
+          crn: 'A123',
+          forename: 'prisoner',
+          surname: 'one',
+          comFirstName: 'Com',
+          comLastName: 'One',
+          comEmail: 'com.one@gmail.com',
+        },
+        {
+          crn: 'B345',
+          forename: 'prisoner',
+          surname: 'two',
+          comFirstName: 'Com',
+          comLastName: 'Two',
+          comEmail: 'com.two@gmail.com',
+        },
+      ]
+      await licenceApiClient.notifyProbationPractionerOfEditedLicencesStillUnapprovedOnCrd(
+        unapprovedLicences as UnapprovedLicence[]
+      )
+      expect(post).toHaveBeenCalledWith({ path: '/notify-probation-of-unapproved-licences', data: unapprovedLicences })
     })
   })
 })

--- a/server/data/licenceApiClient.ts
+++ b/server/data/licenceApiClient.ts
@@ -29,7 +29,7 @@ import type {
 } from '../@types/licenceApiClientTypes'
 import config, { ApiConfig } from '../config'
 import { User } from '../@types/CvlUserDetails'
-import { UpdateComRequest } from '../@types/licenceApiClientTypes'
+import { UpdateComRequest, UnapprovedLicence } from '../@types/licenceApiClientTypes'
 
 export default class LicenceApiClient extends RestClient {
   constructor() {
@@ -367,5 +367,18 @@ export default class LicenceApiClient extends RestClient {
       },
       { username: user?.username }
     )) as LicenceEvent[]
+  }
+
+  async getEditedLicencesUnapprovedByCrd(): Promise<UnapprovedLicence[]> {
+    return (await this.get({
+      path: '/edited-licences-unapproved-by-crd',
+    })) as Promise<UnapprovedLicence[]>
+  }
+
+  async notifyProbationPractionerOfEditedLicencesStillUnapprovedOnCrd(data: UnapprovedLicence[]): Promise<void> {
+    await this.post({
+      path: '/notify-probation-of-unapproved-licences',
+      data,
+    })
   }
 }


### PR DESCRIPTION
New cronjob to email the probation practitioner of any edited licences that won't be approved in time for prisoner's release. The affected licences are obtained from the cvl api and the actual emailing is also done by the same api. However all the cron jobs have been set up in the front end. The relevant api endpoints are '/edited-licences-unapproved-by-crd' and '/notify-probation-of-unapproved-licences '