### PR TITLE
CVSL-645 Exposing exclusion information

### DIFF
--- a/server/routes/viewingLicences/index.ts
+++ b/server/routes/viewingLicences/index.ts
@@ -34,6 +34,7 @@ export default function Index({
   const comDetailsHandler = new ComDetailsRoutes(communityService)
 
   get('/cases', viewCasesHandler.GET)
+  get('/cases-with-exclusions.json', viewCasesHandler.GET_WITH_EXCLUSIONS)
   get('/probation-practitioner/staffCode/:staffCode', comDetailsHandler.GET)
   get('/id/:licenceId/show', viewLicenceHandler.GET)
   get('/id/:licenceId/html-print', printHandler.preview)

--- a/server/services/caseloadService.test.ts
+++ b/server/services/caseloadService.test.ts
@@ -118,22 +118,11 @@ describe('Caseload Service', () => {
     expect(result).toMatchObject([
       {
         deliusRecord: {
-          offenderCrn: 'X12349',
-        },
-        nomisRecord: {
-          prisonerNumber: 'AB1234F',
-          conditionalReleaseDate: '2022-10-30',
-        },
-        licences: [
-          {
-            status: 'NOT_STARTED',
-            type: 'AP',
-          },
-        ],
-      },
-      {
-        deliusRecord: {
           offenderCrn: 'X12350',
+          otherIds: {
+            crn: 'X12350',
+            nomsNumber: 'AB1234G',
+          },
         },
         nomisRecord: {
           prisonerNumber: 'AB1234G',
@@ -901,7 +890,7 @@ describe('Caseload Service', () => {
       ['p1', 'p2'],
       user
     )
-    expect(result).toMatchObject([
+    expect(result.unwrap()).toMatchObject([
       {
         deliusRecord: {
           offenderManagers: [
@@ -1130,7 +1119,7 @@ describe('Caseload Service', () => {
       ['p1', 'p2'],
       user
     )
-    expect(result).toMatchObject([
+    expect(result.unwrap()).toMatchObject([
       {
         deliusRecord: {
           offenderManagers: [
@@ -1169,6 +1158,96 @@ describe('Caseload Service', () => {
       },
     ])
   })
+
+  it('returns exclusions', async () => {
+    licenceService.getLicencesForOmu.mockResolvedValue([
+      {
+        nomisId: 'AB1234D',
+        licenceId: 1,
+        licenceType: LicenceType.AP,
+        licenceStatus: LicenceStatus.APPROVED,
+        comUsername: 'joebloggs',
+      },
+      {
+        nomisId: 'AB1234E',
+        licenceId: 2,
+        licenceType: LicenceType.AP,
+        licenceStatus: LicenceStatus.IN_PROGRESS,
+        comUsername: 'joebloggs',
+      },
+    ])
+    prisonerService.searchPrisonersByReleaseDate.mockResolvedValueOnce([
+      {
+        prisonerNumber: 'AB1234F',
+        conditionalReleaseDate: tenDaysFromNow,
+        status: 'ACTIVE IN',
+        legalStatus: 'DEAD',
+      } as Prisoner,
+    ])
+    communityService.getOffendersByNomsNumbers.mockResolvedValueOnce([
+      {
+        otherIds: { nomsNumber: 'AB1234D', crn: 'X12347' },
+        offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
+      } as OffenderDetail,
+      {
+        otherIds: { nomsNumber: 'AB1234E', crn: 'X12348' },
+        offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
+      } as OffenderDetail,
+    ])
+    communityService.getStaffDetailsByUsernameList.mockResolvedValue([
+      {
+        username: 'joebloggs',
+        staffCode: 'X1234',
+        staff: {
+          forenames: 'Joe',
+          surname: 'Bloggs',
+        },
+      },
+    ])
+    prisonerService.searchPrisonersByNomisIds.mockResolvedValue([
+      {
+        prisonerNumber: 'AB1234D',
+        conditionalReleaseDate: tenDaysFromNow,
+        status: 'ACTIVE IN',
+      } as Prisoner,
+      {
+        prisonerNumber: 'AB1234E',
+        conditionalReleaseDate: tenDaysFromNow,
+        status: 'ACTIVE IN',
+      } as Prisoner,
+    ])
+    communityService.getOffendersByNomsNumbers.mockResolvedValueOnce([
+      {
+        otherIds: { nomsNumber: 'AB1234E', crn: 'X12348' },
+        offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
+      } as OffenderDetail,
+      {
+        otherIds: { nomsNumber: 'AB1234F', crn: 'X12349' },
+        offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
+      } as OffenderDetail,
+    ])
+    licenceService.getLicencesByNomisIdsAndStatus.mockResolvedValue([
+      {
+        nomisId: 'AB1234E',
+        licenceId: 2,
+        licenceType: LicenceType.AP,
+        licenceStatus: LicenceStatus.IN_PROGRESS,
+        comUsername: 'joebloggs',
+      },
+    ])
+
+    const result = await serviceUnderTest.getOmuCaseload(user, ['p1', 'p2'], 'prison')
+
+    expect(result.exclusions()).toMatchObject([
+      [{ deliusRecord: { otherIds: { crn: 'X12349', nomsNumber: 'AB1234F' } } }, 'is dead'],
+    ])
+
+    expect(result.unwrap()).toMatchObject([
+      { deliusRecord: { otherIds: { crn: 'X12347', nomsNumber: 'AB1234D' } } },
+      { deliusRecord: { otherIds: { crn: 'X12348', nomsNumber: 'AB1234E' } } },
+    ])
+  })
+
   it('builds the approver caseload', async () => {
     licenceService.getLicencesForApproval.mockResolvedValue([
       {

--- a/server/services/caseloadService.ts
+++ b/server/services/caseloadService.ts
@@ -11,6 +11,7 @@ import { prisonInRollout, probationAreaInRollout } from '../utils/rolloutUtils'
 import { CommunityApiManagedOffender } from '../@types/communityClientTypes'
 import { Prisoner } from '../@types/prisonerSearchApiClientTypes'
 import { LicenceSummary } from '../@types/licenceApiClientTypes'
+import Container from './container'
 
 export default class CaseloadService {
   constructor(
@@ -68,9 +69,9 @@ export default class CaseloadService {
       .then(caseload => this.mapResponsibleComsToCases(caseload))
   }
 
-  async getOmuCaseload(user: User, prisonCaseload: string[], view: string): Promise<ManagedCase[]> {
+  async getOmuCaseload(user: User, prisonCaseload: string[], view: string): Promise<Container<ManagedCase>> {
     // Get cases with a licence in ACTIVE, APPROVED, SUBMITTED, IN_PROGRESS or VARIATION_IN_* state
-    const casesWithLicences = await this.licenceService
+    const casesWithLicences = this.licenceService
       .getLicencesForOmu(user, prisonCaseload)
       .then(licences => this.mapLicencesToOffenders(licences))
 
@@ -79,27 +80,30 @@ export default class CaseloadService {
     const endOfTheFourthWeekFromNow = moment().add(3, 'weeks').endOf('isoWeek')
     const casesPendingLicence = this.prisonerService
       .searchPrisonersByReleaseDate(startOfThisWeek, endOfTheFourthWeekFromNow, prisonCaseload, user)
+      .then(caseload => this.wrap(caseload))
       .then(caseload => this.pairNomisRecordsWithDelius(caseload))
       .then(caseload => this.filterOffendersEligibleForLicence(caseload, user))
       .then(caseload => this.mapOffendersToLicences(caseload, user))
       .then(caseload => this.buildCreateCaseload(caseload))
       .then(caseload => {
-        return caseload.filter(c =>
-          [
-            LicenceStatus.NOT_STARTED,
-            LicenceStatus.NOT_IN_PILOT,
-            LicenceStatus.OOS_RECALL,
-            LicenceStatus.OOS_BOTUS,
-          ].some(status => c.licences.find(l => l.status === status))
+        return caseload.filter(
+          c =>
+            [
+              LicenceStatus.NOT_STARTED,
+              LicenceStatus.NOT_IN_PILOT,
+              LicenceStatus.OOS_RECALL,
+              LicenceStatus.OOS_BOTUS,
+            ].some(status => c.licences.find(l => l.status === status)),
+          'Has no licence in NOT_STARTED, NOT_IN_PILOT, OOS_RECALL, OOS_BOTUS'
         )
       })
 
-    const combinedCases = await Promise.all([casesWithLicences, casesPendingLicence]).then(c => c.flat())
-    const casesFilteredByView = this.filterByPrisonOrProbationView(view, combinedCases)
-    return this.mapResponsibleComsToCases(casesFilteredByView)
+    const [withLicence, pending] = await Promise.all([casesWithLicences, casesPendingLicence])
+    const casesFilteredByView = this.filterByPrisonOrProbationView(view, withLicence.concat(pending))
+    return this.mapResponsibleComsToCasesWithExclusions(casesFilteredByView)
   }
 
-  public filterByPrisonOrProbationView = (view: string, combinedCases: ManagedCase[]) => {
+  public filterByPrisonOrProbationView = (view: string, combinedCases: Container<ManagedCase>) => {
     const prisonViewStatuses = [
       LicenceStatus.NOT_STARTED,
       LicenceStatus.IN_PROGRESS,
@@ -118,7 +122,10 @@ export default class CaseloadService {
     ]
     const statuses = view === 'prison' ? prisonViewStatuses : probationViewStatuses
 
-    return combinedCases.filter(c => statuses.includes(c?.licences[0]?.status))
+    return combinedCases.filter(
+      c => statuses.includes(c?.licences[0]?.status),
+      `invalid status for view ${view}, not one ${statuses}`
+    )
   }
 
   async getApproverCaseload(user: User, prisonCaseload: string[]): Promise<ManagedCase[]> {
@@ -142,8 +149,9 @@ export default class CaseloadService {
       .then(caseload => this.mapResponsibleComsToCases(caseload))
   }
 
-  public pairNomisRecordsWithDelius = async (prisoners: Prisoner[]): Promise<ManagedCase[]> => {
+  public pairNomisRecordsWithDelius = async (prisoners: Container<Prisoner>): Promise<Container<ManagedCase>> => {
     const caseloadNomisIds = prisoners
+      .unwrap()
       .filter(offender => offender.prisonerNumber)
       .map(offender => offender.prisonerNumber)
 
@@ -161,14 +169,17 @@ export default class CaseloadService {
             },
           }
         }
-        return {}
+        return { nomisRecord: offender }
       })
-      .filter(offender => offender.nomisRecord && offender.deliusRecord)
+      .filter(offender => offender.nomisRecord && offender.deliusRecord, 'Unable to find delius record')
   }
 
-  public mapOffendersToLicences = async (offenders: ManagedCase[], user?: User): Promise<ManagedCase[]> => {
+  public mapOffendersToLicences = async (
+    offenders: Container<ManagedCase>,
+    user?: User
+  ): Promise<Container<ManagedCase>> => {
     const existingLicences = await this.licenceService.getLicencesByNomisIdsAndStatus(
-      offenders.map(offender => offender.nomisRecord.prisonerNumber),
+      offenders.map(offender => offender.nomisRecord.prisonerNumber).unwrap(),
       [
         LicenceStatus.ACTIVE,
         LicenceStatus.IN_PROGRESS,
@@ -226,12 +237,15 @@ export default class CaseloadService {
     })
   }
 
-  public filterOffendersEligibleForLicence = async (offenders: ManagedCase[], user?: User) => {
+  public filterOffendersEligibleForLicence = async (offenders: Container<ManagedCase>, user?: User) => {
     const eligibleOffenders = offenders
-      .filter(offender => !CaseloadService.isParoleEligible(offender.nomisRecord.paroleEligibilityDate))
-      .filter(offender => offender.nomisRecord.legalStatus !== 'DEAD')
-      .filter(offender => !offender.nomisRecord.indeterminateSentence)
-      .filter(offender => offender.nomisRecord.conditionalReleaseDate)
+      .filter(
+        offender => !CaseloadService.isParoleEligible(offender.nomisRecord.paroleEligibilityDate),
+        'is eligible for parole'
+      )
+      .filter(offender => offender.nomisRecord.legalStatus !== 'DEAD', 'is dead')
+      .filter(offender => !offender.nomisRecord.indeterminateSentence, 'on indeterminate sentence')
+      .filter(offender => offender.nomisRecord.conditionalReleaseDate, 'has no conditional release date')
       // TODO: Following filter rule can be removed after 7th November 2022
       .filter(
         offender =>
@@ -272,61 +286,76 @@ export default class CaseloadService {
           moment(offender.nomisRecord.conditionalReleaseDate, 'YYYY-MM-DD').isSameOrAfter(
             moment('2022-11-07', 'YYYY-MM-DD'),
             'day'
-          )
+          ),
+        'Limited due to new rollout prison'
       )
 
-    if (eligibleOffenders.length === 0) return eligibleOffenders
+    if (eligibleOffenders.isEmpty()) return eligibleOffenders
 
     const hdcStatuses = await this.prisonerService.getHdcStatuses(
-      eligibleOffenders.map(c => c.nomisRecord),
+      eligibleOffenders.map(c => c.nomisRecord).unwrap(),
       user
     )
 
     return eligibleOffenders.filter(offender => {
       const hdcRecord = hdcStatuses.find(hdc => hdc.bookingId === offender.nomisRecord.bookingId)
       return !hdcRecord || hdcRecord.approvalStatus !== 'APPROVED'
-    })
+    }, 'approved for HDC')
   }
 
-  private buildCreateCaseload = (managedOffenders: ManagedCase[]): ManagedCase[] => {
+  private buildCreateCaseload = (managedOffenders: Container<ManagedCase>): Container<ManagedCase> => {
     return managedOffenders
       .filter(
         offender =>
           offender.nomisRecord.status &&
-          (offender.nomisRecord.status.startsWith('ACTIVE') || offender.nomisRecord.status === 'INACTIVE TRN')
+          (offender.nomisRecord.status.startsWith('ACTIVE') || offender.nomisRecord.status === 'INACTIVE TRN'),
+        'status is not ACTIVE or INACTIVE TRN'
       )
-      .filter(offender =>
-        moment(
-          moment(offender.nomisRecord.confirmedReleaseDate || offender.nomisRecord.conditionalReleaseDate, 'YYYY-MM-DD')
-        ).isSameOrAfter(moment(), 'day')
+      .filter(
+        offender =>
+          moment(
+            moment(
+              offender.nomisRecord.confirmedReleaseDate || offender.nomisRecord.conditionalReleaseDate,
+              'YYYY-MM-DD'
+            )
+          ).isSameOrAfter(moment(), 'day'),
+        'confirmed release date (or conditional release date) is before today'
       )
-      .filter(offender =>
-        [
-          LicenceStatus.OOS_RECALL,
-          LicenceStatus.OOS_BOTUS,
-          LicenceStatus.NOT_IN_PILOT,
-          LicenceStatus.NOT_STARTED,
-          LicenceStatus.IN_PROGRESS,
-          LicenceStatus.SUBMITTED,
-          LicenceStatus.APPROVED,
-        ].some(status => offender.licences.find(l => l.status === status))
+      .filter(
+        offender =>
+          [
+            LicenceStatus.OOS_RECALL,
+            LicenceStatus.OOS_BOTUS,
+            LicenceStatus.NOT_IN_PILOT,
+            LicenceStatus.NOT_STARTED,
+            LicenceStatus.IN_PROGRESS,
+            LicenceStatus.SUBMITTED,
+            LicenceStatus.APPROVED,
+          ].some(status => offender.licences.find(l => l.status === status)),
+        'licence status is not one of OOS_RECALL, OOS_BOTUS, NOT_IN_PILOT, NOT_STARTED, IN_PROGRESS, SUBMITTED, APPROVED,'
       )
   }
 
-  private buildVaryCaseload = (managedOffenders: ManagedCase[]): ManagedCase[] => {
-    return managedOffenders.filter(offender =>
-      [
-        LicenceStatus.ACTIVE,
-        LicenceStatus.VARIATION_IN_PROGRESS,
-        LicenceStatus.VARIATION_SUBMITTED,
-        LicenceStatus.VARIATION_APPROVED,
-        LicenceStatus.VARIATION_REJECTED,
-      ].some(status => offender.licences.find(l => l.status === status))
+  private buildVaryCaseload = (managedOffenders: Container<ManagedCase>): Container<ManagedCase> => {
+    return managedOffenders.filter(
+      offender =>
+        [
+          LicenceStatus.ACTIVE,
+          LicenceStatus.VARIATION_IN_PROGRESS,
+          LicenceStatus.VARIATION_SUBMITTED,
+          LicenceStatus.VARIATION_APPROVED,
+          LicenceStatus.VARIATION_REJECTED,
+        ].some(status => offender.licences.find(l => l.status === status)),
+      'licence status is not one of ACTIVE, VARIATION_IN_PROGRESS, VARIATION_SUBMITTED, VARIATION_APPROVED, VARIATION_REJECTED'
     )
   }
 
-  private pairDeliusRecordsWithNomis = async (managedOffenders: DeliusRecord[], user: User): Promise<ManagedCase[]> => {
+  private pairDeliusRecordsWithNomis = async (
+    managedOffenders: Container<DeliusRecord>,
+    user: User
+  ): Promise<Container<ManagedCase>> => {
     const caseloadNomisIds = managedOffenders
+      .unwrap()
       .filter(offender => offender.otherIds?.nomsNumber)
       .map(offender => offender.otherIds?.nomsNumber)
 
@@ -339,13 +368,13 @@ export default class CaseloadService {
           nomisRecord: nomisRecords.find(nomisRecord => nomisRecord.prisonerNumber === offender.otherIds?.nomsNumber),
         }
       })
-      .filter(offender => offender.nomisRecord)
+      .filter(offender => offender.nomisRecord, 'unable to find prison record')
   }
 
-  private mapLicencesToOffenders = async (licences: LicenceSummary[], user?: User): Promise<ManagedCase[]> => {
+  private mapLicencesToOffenders = async (licences: LicenceSummary[], user?: User): Promise<Container<ManagedCase>> => {
     const nomisIds = licences.map(l => l.nomisId)
     const deliusRecords = await this.communityService.getOffendersByNomsNumbers(nomisIds)
-    const offenders = await this.pairDeliusRecordsWithNomis(deliusRecords, user)
+    const offenders = await this.pairDeliusRecordsWithNomis(this.wrap(deliusRecords), user)
     return offenders.map(offender => {
       return {
         ...offender,
@@ -364,8 +393,11 @@ export default class CaseloadService {
     })
   }
 
-  private async mapResponsibleComsToCases(caseload: ManagedCase[]): Promise<ManagedCase[]> {
+  private async mapResponsibleComsToCasesWithExclusions(
+    caseload: Container<ManagedCase>
+  ): Promise<Container<ManagedCase>> {
     const comUsernames = caseload
+      .unwrap()
       .map(
         offender =>
           offender.licences.find(l => offender.licences.length === 1 || l.status !== LicenceStatus.ACTIVE).comUsername
@@ -409,6 +441,10 @@ export default class CaseloadService {
     })
   }
 
+  private async mapResponsibleComsToCases(caseload: Container<ManagedCase>): Promise<ManagedCase[]> {
+    return this.mapResponsibleComsToCasesWithExclusions(caseload).then(it => it.unwrap())
+  }
+
   private getLicenceType = (nomisRecord: Prisoner): LicenceType => {
     if (!nomisRecord.topupSupervisionExpiryDate) {
       return LicenceType.AP
@@ -421,15 +457,17 @@ export default class CaseloadService {
 
   private mapManagedOffenderRecordToOffenderDetail = async (
     caseload: CommunityApiManagedOffender[]
-  ): Promise<DeliusRecord[]> => {
+  ): Promise<Container<DeliusRecord>> => {
     const crns = caseload.map(c => c.offenderCrn)
     const offenders = await this.communityService.getOffendersByCrn(crns)
-    return offenders.map(o => {
-      return {
-        ...o,
-        ...caseload.find(c => c.offenderCrn === o.otherIds?.crn),
-      }
-    })
+    return this.wrap(
+      offenders.map(o => {
+        return {
+          ...o,
+          ...caseload.find(c => c.offenderCrn === o.otherIds?.crn),
+        }
+      })
+    )
   }
 
   private isRecall = (offender: ManagedCase): boolean => {
@@ -470,5 +508,9 @@ export default class CaseloadService {
     if (!ped) return false
     const pedDate = parse(ped, 'yyyy-MM-dd', new Date())
     return isFuture(pedDate)
+  }
+
+  wrap<T>(items: T[]): Container<T> {
+    return new Container(items)
   }
 }

--- a/server/services/container.test.ts
+++ b/server/services/container.test.ts
@@ -1,0 +1,79 @@
+import Container from './container'
+
+describe('Container', () => {
+  test('filter', () => {
+    const filteredContainer = new Container(['a', 'bb', 'ccc']).filter(i => i.length >= 2, 'less than 2 chars')
+
+    expect(filteredContainer).toStrictEqual(new Container(['bb', 'ccc'], [['a', 'less than 2 chars']]))
+  })
+
+  test('map', () => {
+    expect(new Container(['a', 'bb', 'ccc']).map(i => i.length)).toStrictEqual(new Container([1, 2, 3]))
+  })
+
+  test('isEmpty', () => {
+    expect(new Container(['1']).isEmpty()).toBeFalsy()
+    expect(new Container([]).isEmpty()).toBeTruthy()
+  })
+
+  test('concat', () => {
+    expect(new Container([]).concat(new Container([]))).toStrictEqual(new Container([]))
+    expect(new Container(['1']).concat(new Container([]))).toStrictEqual(new Container(['1']))
+    expect(new Container(['1']).concat(new Container(['2']))).toStrictEqual(new Container(['1', '2']))
+    expect(new Container([]).concat(new Container(['2']))).toStrictEqual(new Container(['2']))
+
+    expect(new Container(['1'], [['2', 'no good']]).concat(new Container(['2'], [['3', 'bad']]))).toStrictEqual(
+      new Container(
+        ['1', '2'],
+        [
+          ['2', 'no good'],
+          ['3', 'bad'],
+        ]
+      )
+    )
+  })
+
+  test('unwrap', () => {
+    expect(new Container([]).unwrap()).toStrictEqual([])
+    expect(new Container(['1']).unwrap()).toStrictEqual(['1'])
+  })
+
+  test('complex map/filter example', () => {
+    const filteredContainer = new Container(['apple', 'ball', 'cat', 'dragon', 'elephants', 'balloon', 'elephants'])
+      .filter(item => !item.startsWith('ba'), 'starts with ba')
+      .map(item => item.toUpperCase())
+      .filter((_, i) => i !== 3, 'at index 3')
+      .filter(item => item.length > 3, '3 characters or less')
+      .map(item => item.length)
+      .filter(item => item !== 5, "is '5'")
+
+    expect(filteredContainer).toStrictEqual(
+      new Container(
+        [6, 9],
+        [
+          ['ball', 'starts with ba'],
+          ['balloon', 'starts with ba'],
+          ['ELEPHANTS', 'at index 3'],
+          ['CAT', '3 characters or less'],
+          [5, "is '5'"],
+        ]
+      )
+    )
+  })
+
+  test('immutable', () => {
+    const filteredContainer = new Container(['aaa', 'bbbb'])
+
+    const result1 = filteredContainer
+      .map(item => item.toUpperCase())
+      .filter(item => item.length > 3, '3 characters or less')
+
+    const result2 = filteredContainer
+      .map(item => item.toLowerCase())
+      .filter(item => item.length < 4, 'more than 4 characters')
+
+    expect(result1).toStrictEqual(new Container(['BBBB'], [['AAA', '3 characters or less']]))
+
+    expect(result2).toStrictEqual(new Container(['aaa'], [['bbbb', 'more than 4 characters']]))
+  })
+})

--- a/server/services/container.ts
+++ b/server/services/container.ts
@@ -1,0 +1,40 @@
+type FilterParams<T> = (value: T, index: number, array: T[]) => unknown
+type MapParams<T, R> = (t: T, index: number, array: T[]) => R
+type ExcludedItem = [item: unknown, reason: string]
+
+export default class Container<T> {
+  constructor(private readonly items: T[], private readonly excludedItems: ExcludedItem[] = []) {}
+
+  filter(filterParams: FilterParams<T>, exclusionReason: string): Container<T> {
+    const included: T[] = []
+    const excluded = [...this.excludedItems]
+    this.items.forEach((item, i, all) => {
+      if (filterParams(item, i, all)) {
+        included.push(item)
+      } else {
+        excluded.push([item, exclusionReason])
+      }
+    })
+    return new Container(included, excluded)
+  }
+
+  map<R>(mapParams: MapParams<T, R>): Container<R> {
+    return new Container(this.items.map(mapParams), [...this.excludedItems])
+  }
+
+  isEmpty(): boolean {
+    return this.items.length === 0
+  }
+
+  concat(other: Container<T>): Container<T> {
+    return new Container(this.items.concat(other.items), this.excludedItems.concat(other.excludedItems))
+  }
+
+  unwrap(): T[] {
+    return [...this.items]
+  }
+
+  exclusions(): ExcludedItem[] {
+    return [...this.excludedItems]
+  }
+}


### PR DESCRIPTION
Added a new wrapper object that acts like an array but `filter` takes an additional parameter as an exclusion reason. 
Items that are filtered out are kept in a separate array internally and passed along through maps, filters and concats so they can be inspected at the end of the pipeline. 

This is then exposed on a `/licence/view/cases-with-exclusions.json` url, which just dumps out the cases, cases that were excluded and their reason for exclusion.

All the caseload methods have been altered to use this structure as they share a lot of the same functionality but only currently exposed this for the OMU caseload