### PR TITLE
CVSL-164 move out of scope cases to prison view

### DIFF
--- a/server/routes/viewingLicences/handlers/viewCases.test.ts
+++ b/server/routes/viewingLicences/handlers/viewCases.test.ts
@@ -683,7 +683,8 @@ describe('Route handlers - View and print case list', () => {
     describe('GET_WITH_EXCLUSIONS', () => {
       it('should render list of licences and display the currently active caseload prison', async () => {
         res.locals.prisonCaseload = ['BAI']
-        caseloadService.getOmuCaseload.mockResolvedValue(new OmuCaselist(caseList))
+        const omuCaselist = new OmuCaselist(caseList)
+        caseloadService.getOmuCaseload.mockResolvedValue(omuCaselist)
 
         await handler.GET_WITH_EXCLUSIONS(req, res)
 
@@ -694,7 +695,7 @@ describe('Route handlers - View and print case list', () => {
           ['BAI']
         )
         expect(res.header).toHaveBeenCalledWith('Content-Type', 'application/json')
-        expect(res.send).toHaveBeenCalledWith(JSON.stringify({ cases: caseList }, null, 4))
+        expect(res.send).toHaveBeenCalledWith(JSON.stringify(omuCaselist.getPrisonView(), null, 4))
       })
     })
   })

--- a/server/routes/viewingLicences/handlers/viewCases.ts
+++ b/server/routes/viewingLicences/handlers/viewCases.ts
@@ -80,7 +80,8 @@ export default class ViewAndPrintCaseRoutes {
     const activeCaseload = allPrisons.filter(p => p.agencyId === user.activeCaseload)
     const prisonCaseloadToDisplay = caseloadsSelected.length ? caseloadsSelected : [activeCaseload[0].agencyId]
 
-    const cases = await this.caseloadService.getOmuCaseload(user, prisonCaseloadToDisplay)
+    const caselist = await this.caseloadService.getOmuCaseload(user, prisonCaseloadToDisplay)
+    const cases = req.query.view === 'probation' ? caselist.getProbationView() : caselist.getPrisonView()
     res.header('Content-Type', 'application/json')
     res.send(JSON.stringify(cases, null, 4))
   }

--- a/server/routes/viewingLicences/handlers/viewCases.ts
+++ b/server/routes/viewingLicences/handlers/viewCases.ts
@@ -20,9 +20,11 @@ export default class ViewAndPrintCaseRoutes {
     const allPrisons = await this.prisonerService.getPrisons()
     const activeCaseload = allPrisons.filter(p => p.agencyId === user.activeCaseload)
     const prisonCaseloadToDisplay = caseloadsSelected.length ? caseloadsSelected : [activeCaseload[0].agencyId]
+    const caselist = await this.caseloadService.getOmuCaseload(user, prisonCaseloadToDisplay)
 
-    const cases = await this.caseloadService.getOmuCaseload(user, prisonCaseloadToDisplay, view as string)
-    const caseloadViewModel = cases
+    const casesToView = view === 'prison' ? caselist.getPrisonView() : caselist.getProbationView()
+
+    const caseloadViewModel = casesToView
       .unwrap()
       .map(c => {
         return {
@@ -74,12 +76,11 @@ export default class ViewAndPrintCaseRoutes {
   GET_WITH_EXCLUSIONS = async (req: Request, res: Response): Promise<void> => {
     const { user } = res.locals
     const { caseloadsSelected = [] } = req.session
-    const view = req.query.view || 'prison'
     const allPrisons = await this.prisonerService.getPrisons()
     const activeCaseload = allPrisons.filter(p => p.agencyId === user.activeCaseload)
     const prisonCaseloadToDisplay = caseloadsSelected.length ? caseloadsSelected : [activeCaseload[0].agencyId]
 
-    const cases = await this.caseloadService.getOmuCaseload(user, prisonCaseloadToDisplay, view.toString())
+    const cases = await this.caseloadService.getOmuCaseload(user, prisonCaseloadToDisplay)
     res.header('Content-Type', 'application/json')
     res.send(JSON.stringify(cases, null, 4))
   }

--- a/server/services/caseloadService.test.ts
+++ b/server/services/caseloadService.test.ts
@@ -763,7 +763,7 @@ describe('Caseload Service', () => {
     ])
   })
 
-  it('OMU caseload for prison view', async () => {
+  it('OMU caseload', async () => {
     licenceService.getLicencesForOmu.mockResolvedValue([
       {
         nomisId: 'AB1234D',
@@ -787,7 +787,7 @@ describe('Caseload Service', () => {
         comUsername: 'joebloggs',
       },
       {
-        nomisId: 'AB1234H',
+        nomisId: 'AB1234F',
         licenceId: 4,
         licenceType: LicenceType.AP,
         licenceStatus: LicenceStatus.SUBMITTED,
@@ -826,7 +826,7 @@ describe('Caseload Service', () => {
         offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
       },
       {
-        otherIds: { nomsNumber: 'AB1234H', crn: 'X12350' },
+        otherIds: { nomsNumber: 'AB1234G', crn: 'X12350' },
         offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
       },
     ] as OffenderDetail[])
@@ -882,7 +882,7 @@ describe('Caseload Service', () => {
       },
     ] as OffenderDetail[])
 
-    const result = await serviceUnderTest.getOmuCaseload(user, ['p1', 'p2'], 'prison')
+    const result = await serviceUnderTest.getOmuCaseload(user, ['p1', 'p2'])
 
     expect(prisonerService.searchPrisonersByReleaseDate).toHaveBeenCalledWith(
       moment().startOf('isoWeek'),
@@ -890,7 +890,7 @@ describe('Caseload Service', () => {
       ['p1', 'p2'],
       user
     )
-    expect(result.unwrap()).toMatchObject([
+    expect(result.cases.unwrap()).toMatchObject([
       {
         deliusRecord: {
           offenderManagers: [
@@ -976,8 +976,8 @@ describe('Caseload Service', () => {
             },
           ],
           otherIds: {
-            crn: 'X12350',
-            nomsNumber: 'AB1234H',
+            crn: 'X12349',
+            nomsNumber: 'AB1234F',
           },
         },
         licences: [
@@ -991,8 +991,44 @@ describe('Caseload Service', () => {
         ],
         nomisRecord: {
           conditionalReleaseDate: tenDaysFromNow,
-          prisonerNumber: 'AB1234H',
+          prisonerNumber: 'AB1234F',
           status: 'ACTIVE IN',
+        },
+        probationPractitioner: {
+          name: 'Joe Bloggs',
+          staffCode: 'X1234',
+        },
+      },
+      {
+        deliusRecord: {
+          offenderManagers: [
+            {
+              active: true,
+              staff: {
+                code: 'X1234',
+                forenames: 'Joe',
+                surname: 'Bloggs',
+              },
+            },
+          ],
+          otherIds: {
+            crn: 'X12350',
+            nomsNumber: 'AB1234G',
+          },
+        },
+        licences: [
+          {
+            comUsername: 'joebloggs',
+            dateCreated: undefined,
+            id: 3,
+            status: 'ACTIVE',
+            type: 'AP',
+          },
+        ],
+        nomisRecord: {
+          conditionalReleaseDate: tenDaysFromNow,
+          prisonerNumber: 'AB1234G',
+          status: 'OUT',
         },
         probationPractitioner: {
           name: 'Joe Bloggs',
@@ -1031,125 +1067,6 @@ describe('Caseload Service', () => {
           conditionalReleaseDate: tenDaysFromNow,
           prisonerNumber: 'AB1234F',
           status: 'ACTIVE IN',
-        },
-        probationPractitioner: {
-          name: 'Joe Bloggs',
-          staffCode: 'X1234',
-        },
-      },
-    ])
-  })
-
-  it('OMU caseload for probation view', async () => {
-    licenceService.getLicencesForOmu.mockResolvedValue([
-      {
-        nomisId: 'AB1234D',
-        licenceId: 1,
-        licenceType: LicenceType.AP,
-        licenceStatus: LicenceStatus.ACTIVE,
-        comUsername: 'joebloggs',
-      },
-      {
-        nomisId: 'AB1234E',
-        licenceId: 2,
-        licenceType: LicenceType.AP,
-        licenceStatus: LicenceStatus.IN_PROGRESS,
-        comUsername: 'joebloggs',
-      },
-    ])
-
-    prisonerService.searchPrisonersByReleaseDate.mockResolvedValueOnce([
-      {
-        prisonerNumber: 'AB1234F',
-        conditionalReleaseDate: tenDaysFromNow,
-        status: 'ACTIVE IN',
-      } as Prisoner,
-    ])
-
-    communityService.getOffendersByNomsNumbers.mockResolvedValueOnce([
-      {
-        otherIds: { nomsNumber: 'AB1234D', crn: 'X12347' },
-        offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
-      } as OffenderDetail,
-      {
-        otherIds: { nomsNumber: 'AB1234E', crn: 'X12348' },
-        offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
-      } as OffenderDetail,
-    ])
-
-    communityService.getStaffDetailsByUsernameList.mockResolvedValue([
-      {
-        username: 'joebloggs',
-        staffCode: 'X1234',
-        staff: {
-          forenames: 'Joe',
-          surname: 'Bloggs',
-        },
-      },
-    ])
-
-    prisonerService.searchPrisonersByNomisIds.mockResolvedValue([
-      {
-        prisonerNumber: 'AB1234D',
-        conditionalReleaseDate: tenDaysFromNow,
-        status: 'OUT',
-      } as Prisoner,
-      {
-        prisonerNumber: 'AB1234E',
-        conditionalReleaseDate: tenDaysFromNow,
-        status: 'ACTIVE IN',
-      } as Prisoner,
-    ])
-    communityService.getOffendersByNomsNumbers.mockResolvedValueOnce([
-      {
-        otherIds: { nomsNumber: 'AB1234E', crn: 'X12348' },
-        offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
-      } as OffenderDetail,
-      {
-        otherIds: { nomsNumber: 'AB1234F', crn: 'X12349' },
-        offenderManagers: [{ active: true, staff: { forenames: 'Joe', surname: 'Bloggs', code: 'X1234' } }],
-      } as OffenderDetail,
-    ])
-
-    const result = await serviceUnderTest.getOmuCaseload(user, ['p1', 'p2'], 'probation')
-
-    expect(prisonerService.searchPrisonersByReleaseDate).toHaveBeenCalledWith(
-      moment().startOf('isoWeek'),
-      moment().add(3, 'weeks').endOf('isoWeek'),
-      ['p1', 'p2'],
-      user
-    )
-    expect(result.unwrap()).toMatchObject([
-      {
-        deliusRecord: {
-          offenderManagers: [
-            {
-              active: true,
-              staff: {
-                code: 'X1234',
-                forenames: 'Joe',
-                surname: 'Bloggs',
-              },
-            },
-          ],
-          otherIds: {
-            crn: 'X12347',
-            nomsNumber: 'AB1234D',
-          },
-        },
-        licences: [
-          {
-            comUsername: 'joebloggs',
-            dateCreated: undefined,
-            id: 1,
-            status: 'ACTIVE',
-            type: 'AP',
-          },
-        ],
-        nomisRecord: {
-          conditionalReleaseDate: tenDaysFromNow,
-          prisonerNumber: 'AB1234D',
-          status: 'OUT',
         },
         probationPractitioner: {
           name: 'Joe Bloggs',
@@ -1236,13 +1153,13 @@ describe('Caseload Service', () => {
       },
     ])
 
-    const result = await serviceUnderTest.getOmuCaseload(user, ['p1', 'p2'], 'prison')
+    const result = await serviceUnderTest.getOmuCaseload(user, ['p1', 'p2'])
 
-    expect(result.exclusions()).toMatchObject([
+    expect(result.cases.exclusions()).toMatchObject([
       [{ deliusRecord: { otherIds: { crn: 'X12349', nomsNumber: 'AB1234F' } } }, 'is dead'],
     ])
 
-    expect(result.unwrap()).toMatchObject([
+    expect(result.cases.unwrap()).toMatchObject([
       { deliusRecord: { otherIds: { crn: 'X12347', nomsNumber: 'AB1234D' } } },
       { deliusRecord: { otherIds: { crn: 'X12348', nomsNumber: 'AB1234E' } } },
     ])

--- a/server/services/caseloadService.ts
+++ b/server/services/caseloadService.ts
@@ -111,20 +111,34 @@ export default class CaseloadService {
       LicenceStatus.SUBMITTED,
     ]
 
+    const outOfScopePrisonViewStatuses = [LicenceStatus.NOT_IN_PILOT, LicenceStatus.OOS_RECALL, LicenceStatus.OOS_BOTUS]
+
     const probationViewStatuses = [
       LicenceStatus.ACTIVE,
       LicenceStatus.VARIATION_IN_PROGRESS,
       LicenceStatus.VARIATION_APPROVED,
       LicenceStatus.VARIATION_SUBMITTED,
-      LicenceStatus.NOT_IN_PILOT,
-      LicenceStatus.OOS_RECALL,
-      LicenceStatus.OOS_BOTUS,
     ]
-    const statuses = view === 'prison' ? prisonViewStatuses : probationViewStatuses
+
+    if (view === 'prison') {
+      return combinedCases.filter(c => {
+        const releaseDate =
+          c.nomisRecord.confirmedReleaseDate ||
+          c.nomisRecord.conditionalReleaseOverrideDate ||
+          c.nomisRecord.conditionalReleaseDate
+
+        return (
+          prisonViewStatuses.includes(c?.licences[0]?.status) ||
+          (releaseDate
+            ? outOfScopePrisonViewStatuses.includes(c?.licences[0]?.status) && isFuture(new Date(releaseDate))
+            : false)
+        )
+      }, `invalid status for prison view, not one ${prisonViewStatuses}`)
+    }
 
     return combinedCases.filter(
-      c => statuses.includes(c?.licences[0]?.status),
-      `invalid status for view ${view}, not one ${statuses}`
+      c => probationViewStatuses.includes(c?.licences[0]?.status),
+      `invalid status for probation view, not one ${probationViewStatuses}`
     )
   }
 

--- a/server/services/caseloadService.ts
+++ b/server/services/caseloadService.ts
@@ -3,6 +3,7 @@ import { isFuture, parse } from 'date-fns'
 import CommunityService from './communityService'
 import PrisonerService from './prisonerService'
 import LicenceService from './licenceService'
+import OmuCaselist from './omuCaselist'
 import { DeliusRecord, ManagedCase } from '../@types/managedCase'
 import LicenceStatus from '../enumeration/licenceStatus'
 import LicenceType from '../enumeration/licenceType'
@@ -69,7 +70,7 @@ export default class CaseloadService {
       .then(caseload => this.mapResponsibleComsToCases(caseload))
   }
 
-  async getOmuCaseload(user: User, prisonCaseload: string[], view: string): Promise<Container<ManagedCase>> {
+  async getOmuCaseload(user: User, prisonCaseload: string[]): Promise<OmuCaselist> {
     // Get cases with a licence in ACTIVE, APPROVED, SUBMITTED, IN_PROGRESS or VARIATION_IN_* state
     const casesWithLicences = this.licenceService
       .getLicencesForOmu(user, prisonCaseload)
@@ -99,47 +100,9 @@ export default class CaseloadService {
       })
 
     const [withLicence, pending] = await Promise.all([casesWithLicences, casesPendingLicence])
-    const casesFilteredByView = this.filterByPrisonOrProbationView(view, withLicence.concat(pending))
-    return this.mapResponsibleComsToCasesWithExclusions(casesFilteredByView)
-  }
+    const casesWithComs = await this.mapResponsibleComsToCasesWithExclusions(withLicence.concat(pending))
 
-  public filterByPrisonOrProbationView = (view: string, combinedCases: Container<ManagedCase>) => {
-    const prisonViewStatuses = [
-      LicenceStatus.NOT_STARTED,
-      LicenceStatus.IN_PROGRESS,
-      LicenceStatus.APPROVED,
-      LicenceStatus.SUBMITTED,
-    ]
-
-    const outOfScopePrisonViewStatuses = [LicenceStatus.NOT_IN_PILOT, LicenceStatus.OOS_RECALL, LicenceStatus.OOS_BOTUS]
-
-    const probationViewStatuses = [
-      LicenceStatus.ACTIVE,
-      LicenceStatus.VARIATION_IN_PROGRESS,
-      LicenceStatus.VARIATION_APPROVED,
-      LicenceStatus.VARIATION_SUBMITTED,
-    ]
-
-    if (view === 'prison') {
-      return combinedCases.filter(c => {
-        const releaseDate =
-          c.nomisRecord.confirmedReleaseDate ||
-          c.nomisRecord.conditionalReleaseOverrideDate ||
-          c.nomisRecord.conditionalReleaseDate
-
-        return (
-          prisonViewStatuses.includes(c?.licences[0]?.status) ||
-          (releaseDate
-            ? outOfScopePrisonViewStatuses.includes(c?.licences[0]?.status) && isFuture(new Date(releaseDate))
-            : false)
-        )
-      }, `invalid status for prison view, not one ${prisonViewStatuses}`)
-    }
-
-    return combinedCases.filter(
-      c => probationViewStatuses.includes(c?.licences[0]?.status),
-      `invalid status for probation view, not one ${probationViewStatuses}`
-    )
+    return new OmuCaselist(casesWithComs)
   }
 
   async getApproverCaseload(user: User, prisonCaseload: string[]): Promise<ManagedCase[]> {

--- a/server/services/omuCaselist.test.ts
+++ b/server/services/omuCaselist.test.ts
@@ -1,0 +1,175 @@
+import { add, sub } from 'date-fns'
+import OmuCaselist from './omuCaselist'
+import LicenceStatus from '../enumeration/licenceStatus'
+import LicenceType from '../enumeration/licenceType'
+import { ManagedCase } from '../@types/managedCase'
+import Container from './container'
+
+const cases = [
+  {
+    deliusRecord: { offenderId: 1 },
+    licences: [{ type: LicenceType.AP, status: LicenceStatus.SUBMITTED }],
+    nomisRecord: {
+      status: 'ACTIVE IN',
+      confirmedReleaseDate: '2023-04-25',
+      conditionalReleaseDate: '2023-02-19',
+      restrictedPatient: false,
+    },
+  },
+  {
+    deliusRecord: { offenderId: 2 },
+    licences: [{ type: LicenceType.AP, status: LicenceStatus.IN_PROGRESS }],
+    nomisRecord: {
+      status: 'ACTIVE IN',
+      confirmedReleaseDate: '2023-04-25',
+      conditionalReleaseDate: '2023-02-19',
+      restrictedPatient: false,
+    },
+  },
+  {
+    deliusRecord: { offenderId: 3 },
+    licences: [{ type: LicenceType.AP, status: LicenceStatus.ACTIVE }],
+    nomisRecord: {
+      status: 'OUT',
+      confirmedReleaseDate: '2023-04-25',
+      conditionalReleaseDate: '2023-02-19',
+      restrictedPatient: false,
+    },
+  },
+  {
+    deliusRecord: { offenderId: 4 },
+    licences: [{ type: LicenceType.AP, status: LicenceStatus.VARIATION_IN_PROGRESS }],
+    nomisRecord: {
+      status: 'ACTIVE OUT',
+      confirmedReleaseDate: '2023-04-25',
+      conditionalReleaseDate: '2023-02-19',
+      restrictedPatient: false,
+    },
+  },
+  {
+    deliusRecord: { offenderId: 5 },
+    licences: [{ type: LicenceType.AP, status: LicenceStatus.VARIATION_SUBMITTED }],
+    nomisRecord: {
+      status: 'ACTIVE OUT',
+      confirmedReleaseDate: '2023-04-25',
+      conditionalReleaseDate: '2023-02-19',
+      restrictedPatient: false,
+    },
+  },
+] as unknown as Container<ManagedCase>
+
+describe('omu caselist', () => {
+  it('should return prison view cases', () => {
+    const omuCaselist = new OmuCaselist(cases)
+    expect(omuCaselist.getPrisonView()).toEqual([
+      {
+        deliusRecord: { offenderId: 1 },
+        licences: [{ status: 'SUBMITTED', type: 'AP' }],
+        nomisRecord: {
+          conditionalReleaseDate: '2023-02-19',
+          confirmedReleaseDate: '2023-04-25',
+          restrictedPatient: false,
+          status: 'ACTIVE IN',
+        },
+      },
+      {
+        deliusRecord: { offenderId: 2 },
+        licences: [{ status: 'IN_PROGRESS', type: 'AP' }],
+        nomisRecord: {
+          conditionalReleaseDate: '2023-02-19',
+          confirmedReleaseDate: '2023-04-25',
+          restrictedPatient: false,
+          status: 'ACTIVE IN',
+        },
+      },
+    ])
+  })
+  it('prison view cases should not include out of cases with past release date', () => {
+    const oosCase = [
+      {
+        deliusRecord: { offenderId: 3 },
+        licences: [{ type: LicenceType.AP, status: LicenceStatus.OOS_RECALL }],
+        nomisRecord: {
+          status: 'ACTIVE IN',
+          confirmedReleaseDate: sub(new Date(), { weeks: 1 }),
+          conditionalReleaseDate: '2023-02-19',
+          restrictedPatient: false,
+        },
+      },
+    ] as unknown as Container<ManagedCase>
+
+    const omuCaselist = new OmuCaselist(oosCase)
+    expect(omuCaselist.getPrisonView()).toEqual([])
+  })
+  it('prison view cases should include out of cases with future release date', () => {
+    const futureDate = add(new Date(), { weeks: 1 })
+    const oosCase = [
+      {
+        deliusRecord: { offenderId: 3 },
+        licences: [{ type: LicenceType.AP, status: LicenceStatus.OOS_RECALL }],
+        nomisRecord: {
+          status: 'ACTIVE IN',
+          confirmedReleaseDate: futureDate,
+          conditionalReleaseDate: '2023-02-19',
+          restrictedPatient: false,
+        },
+      },
+    ] as unknown as Container<ManagedCase>
+
+    const omuCaselist = new OmuCaselist(oosCase)
+    expect(omuCaselist.getPrisonView()).toEqual([
+      {
+        deliusRecord: {
+          offenderId: 3,
+        },
+        licences: [
+          {
+            status: 'OOS_RECALL',
+            type: 'AP',
+          },
+        ],
+        nomisRecord: {
+          conditionalReleaseDate: '2023-02-19',
+          confirmedReleaseDate: futureDate,
+          restrictedPatient: false,
+          status: 'ACTIVE IN',
+        },
+      },
+    ])
+  })
+  it('should return probation view cases', () => {
+    const omuCaselist = new OmuCaselist(cases)
+    expect(omuCaselist.getProbationView()).toEqual([
+      {
+        deliusRecord: { offenderId: 3 },
+        licences: [{ status: 'ACTIVE', type: 'AP' }],
+        nomisRecord: {
+          conditionalReleaseDate: '2023-02-19',
+          confirmedReleaseDate: '2023-04-25',
+          restrictedPatient: false,
+          status: 'OUT',
+        },
+      },
+      {
+        deliusRecord: { offenderId: 4 },
+        licences: [{ status: 'VARIATION_IN_PROGRESS', type: 'AP' }],
+        nomisRecord: {
+          conditionalReleaseDate: '2023-02-19',
+          confirmedReleaseDate: '2023-04-25',
+          restrictedPatient: false,
+          status: 'ACTIVE OUT',
+        },
+      },
+      {
+        deliusRecord: { offenderId: 5 },
+        licences: [{ status: 'VARIATION_SUBMITTED', type: 'AP' }],
+        nomisRecord: {
+          conditionalReleaseDate: '2023-02-19',
+          confirmedReleaseDate: '2023-04-25',
+          restrictedPatient: false,
+          status: 'ACTIVE OUT',
+        },
+      },
+    ])
+  })
+})

--- a/server/services/omuCaselist.test.ts
+++ b/server/services/omuCaselist.test.ts
@@ -1,175 +1,187 @@
-import { add, sub } from 'date-fns'
+import { add, sub, format } from 'date-fns'
 import OmuCaselist from './omuCaselist'
 import LicenceStatus from '../enumeration/licenceStatus'
 import LicenceType from '../enumeration/licenceType'
-import { ManagedCase } from '../@types/managedCase'
 import Container from './container'
 
-const cases = [
-  {
-    deliusRecord: { offenderId: 1 },
-    licences: [{ type: LicenceType.AP, status: LicenceStatus.SUBMITTED }],
-    nomisRecord: {
-      status: 'ACTIVE IN',
-      confirmedReleaseDate: '2023-04-25',
-      conditionalReleaseDate: '2023-02-19',
-      restrictedPatient: false,
-    },
-  },
-  {
-    deliusRecord: { offenderId: 2 },
-    licences: [{ type: LicenceType.AP, status: LicenceStatus.IN_PROGRESS }],
-    nomisRecord: {
-      status: 'ACTIVE IN',
-      confirmedReleaseDate: '2023-04-25',
-      conditionalReleaseDate: '2023-02-19',
-      restrictedPatient: false,
-    },
-  },
-  {
-    deliusRecord: { offenderId: 3 },
-    licences: [{ type: LicenceType.AP, status: LicenceStatus.ACTIVE }],
-    nomisRecord: {
-      status: 'OUT',
-      confirmedReleaseDate: '2023-04-25',
-      conditionalReleaseDate: '2023-02-19',
-      restrictedPatient: false,
-    },
-  },
-  {
-    deliusRecord: { offenderId: 4 },
-    licences: [{ type: LicenceType.AP, status: LicenceStatus.VARIATION_IN_PROGRESS }],
-    nomisRecord: {
-      status: 'ACTIVE OUT',
-      confirmedReleaseDate: '2023-04-25',
-      conditionalReleaseDate: '2023-02-19',
-      restrictedPatient: false,
-    },
-  },
-  {
-    deliusRecord: { offenderId: 5 },
-    licences: [{ type: LicenceType.AP, status: LicenceStatus.VARIATION_SUBMITTED }],
-    nomisRecord: {
-      status: 'ACTIVE OUT',
-      confirmedReleaseDate: '2023-04-25',
-      conditionalReleaseDate: '2023-02-19',
-      restrictedPatient: false,
-    },
-  },
-] as unknown as Container<ManagedCase>
-
 describe('omu caselist', () => {
-  it('should return prison view cases', () => {
-    const omuCaselist = new OmuCaselist(cases)
-    expect(omuCaselist.getPrisonView()).toEqual([
-      {
-        deliusRecord: { offenderId: 1 },
-        licences: [{ status: 'SUBMITTED', type: 'AP' }],
-        nomisRecord: {
-          conditionalReleaseDate: '2023-02-19',
-          confirmedReleaseDate: '2023-04-25',
-          restrictedPatient: false,
-          status: 'ACTIVE IN',
-        },
-      },
-      {
-        deliusRecord: { offenderId: 2 },
-        licences: [{ status: 'IN_PROGRESS', type: 'AP' }],
-        nomisRecord: {
-          conditionalReleaseDate: '2023-02-19',
-          confirmedReleaseDate: '2023-04-25',
-          restrictedPatient: false,
-          status: 'ACTIVE IN',
-        },
-      },
-    ])
-  })
-  it('prison view cases should not include out of cases with past release date', () => {
-    const oosCase = [
-      {
-        deliusRecord: { offenderId: 3 },
-        licences: [{ type: LicenceType.AP, status: LicenceStatus.OOS_RECALL }],
-        nomisRecord: {
-          status: 'ACTIVE IN',
-          confirmedReleaseDate: sub(new Date(), { weeks: 1 }),
-          conditionalReleaseDate: '2023-02-19',
-          restrictedPatient: false,
-        },
-      },
-    ] as unknown as Container<ManagedCase>
+  it('should return prison view case', () => {
+    const today = format(new Date(), 'yyyy-MM-dd')
+    const omuCaselist = createCaselist(LicenceStatus.SUBMITTED, today, '2022-10-19')
 
-    const omuCaselist = new OmuCaselist(oosCase)
-    expect(omuCaselist.getPrisonView()).toEqual([])
-  })
-  it('prison view cases should include out of cases with future release date', () => {
-    const futureDate = add(new Date(), { weeks: 1 })
-    const oosCase = [
-      {
-        deliusRecord: { offenderId: 3 },
-        licences: [{ type: LicenceType.AP, status: LicenceStatus.OOS_RECALL }],
-        nomisRecord: {
-          status: 'ACTIVE IN',
-          confirmedReleaseDate: futureDate,
-          conditionalReleaseDate: '2023-02-19',
-          restrictedPatient: false,
-        },
-      },
-    ] as unknown as Container<ManagedCase>
-
-    const omuCaselist = new OmuCaselist(oosCase)
-    expect(omuCaselist.getPrisonView()).toEqual([
-      {
-        deliusRecord: {
-          offenderId: 3,
-        },
-        licences: [
-          {
-            status: 'OOS_RECALL',
-            type: 'AP',
+    expect(omuCaselist.getPrisonView()).toEqual({
+      excludedItems: [],
+      items: [
+        {
+          deliusRecord: {
+            offenderId: 1,
           },
-        ],
-        nomisRecord: {
-          conditionalReleaseDate: '2023-02-19',
-          confirmedReleaseDate: futureDate,
-          restrictedPatient: false,
-          status: 'ACTIVE IN',
+          licences: [
+            {
+              status: 'SUBMITTED',
+              type: 'AP',
+            },
+          ],
+          nomisRecord: {
+            conditionalReleaseDate: '2022-10-19',
+            confirmedReleaseDate: today,
+            restrictedPatient: false,
+            status: 'ACTIVE IN',
+          },
         },
-      },
-    ])
+      ],
+    })
   })
-  it('should return probation view cases', () => {
-    const omuCaselist = new OmuCaselist(cases)
-    expect(omuCaselist.getProbationView()).toEqual([
-      {
-        deliusRecord: { offenderId: 3 },
-        licences: [{ status: 'ACTIVE', type: 'AP' }],
-        nomisRecord: {
-          conditionalReleaseDate: '2023-02-19',
-          confirmedReleaseDate: '2023-04-25',
-          restrictedPatient: false,
-          status: 'OUT',
+
+  it('should exclude for prison view as incorrect status', () => {
+    const today = format(new Date(), 'yyyy-MM-dd')
+    const omuCaselist = createCaselist(LicenceStatus.ACTIVE, today, '2022-10-19')
+
+    expect(omuCaselist.getPrisonView()).toEqual({
+      excludedItems: [
+        [
+          {
+            deliusRecord: { offenderId: 1 },
+            licences: [{ status: 'ACTIVE', type: 'AP' }],
+            nomisRecord: {
+              conditionalReleaseDate: '2022-10-19',
+              confirmedReleaseDate: today,
+              restrictedPatient: false,
+              status: 'ACTIVE IN',
+            },
+          },
+          'invalid status for prison view, not one NOT_STARTED,IN_PROGRESS,APPROVED,SUBMITTED',
+        ],
+      ],
+      items: [],
+    })
+  })
+
+  it('should return out of scope (OOS) case for prison view', () => {
+    const futureDate = format(add(new Date(), { weeks: 1 }), 'yyyy-MM-dd')
+    const omuCaselist = createCaselist(LicenceStatus.OOS_BOTUS, futureDate, '2022-10-19')
+
+    expect(omuCaselist.getPrisonView()).toEqual({
+      excludedItems: [],
+      items: [
+        {
+          deliusRecord: { offenderId: 1 },
+          licences: [{ status: 'OOS_BOTUS', type: 'AP' }],
+          nomisRecord: {
+            conditionalReleaseDate: '2022-10-19',
+            confirmedReleaseDate: futureDate,
+            restrictedPatient: false,
+            status: 'ACTIVE IN',
+          },
         },
-      },
-      {
-        deliusRecord: { offenderId: 4 },
-        licences: [{ status: 'VARIATION_IN_PROGRESS', type: 'AP' }],
-        nomisRecord: {
-          conditionalReleaseDate: '2023-02-19',
-          confirmedReleaseDate: '2023-04-25',
-          restrictedPatient: false,
-          status: 'ACTIVE OUT',
+      ],
+    })
+  })
+  it('should exclude OOS case having a past CRD from prison view', () => {
+    const pastDate = format(sub(new Date(), { weeks: 1 }), 'yyyy-MM-dd')
+    const omuCaselist = createCaselist(LicenceStatus.OOS_BOTUS, pastDate, '2022-10-19')
+
+    expect(omuCaselist.getPrisonView()).toEqual({
+      excludedItems: [
+        [
+          {
+            deliusRecord: { offenderId: 1 },
+            licences: [{ status: 'OOS_BOTUS', type: 'AP' }],
+            nomisRecord: {
+              conditionalReleaseDate: '2022-10-19',
+              confirmedReleaseDate: pastDate,
+              restrictedPatient: false,
+              status: 'ACTIVE IN',
+            },
+          },
+          'is out of scope and in the past',
+        ],
+      ],
+      items: [],
+    })
+  })
+
+  it('should exclude OOS case with future conditional and past confirmed CRD from prison view', () => {
+    const pastDate = format(sub(new Date(), { weeks: 1 }), 'yyyy-MM-dd')
+    const futureDate = format(add(new Date(), { weeks: 1 }), 'yyyy-MM-dd')
+    const omuCaselist = createCaselist(LicenceStatus.OOS_BOTUS, pastDate, futureDate)
+
+    expect(omuCaselist.getPrisonView()).toEqual({
+      excludedItems: [
+        [
+          {
+            deliusRecord: { offenderId: 1 },
+            licences: [{ status: 'OOS_BOTUS', type: 'AP' }],
+            nomisRecord: {
+              conditionalReleaseDate: futureDate,
+              confirmedReleaseDate: pastDate,
+              restrictedPatient: false,
+              status: 'ACTIVE IN',
+            },
+          },
+          'is out of scope and in the past',
+        ],
+      ],
+      items: [],
+    })
+  })
+
+  it('should return probation view case', () => {
+    const omuCaselist = createCaselist(LicenceStatus.VARIATION_IN_PROGRESS, '2022-10-27', '2022-11-10')
+
+    expect(omuCaselist.getProbationView()).toEqual({
+      excludedItems: [],
+      items: [
+        {
+          deliusRecord: { offenderId: 1 },
+          licences: [{ status: 'VARIATION_IN_PROGRESS', type: 'AP' }],
+          nomisRecord: {
+            conditionalReleaseDate: '2022-11-10',
+            confirmedReleaseDate: '2022-10-27',
+            restrictedPatient: false,
+            status: 'ACTIVE IN',
+          },
         },
-      },
-      {
-        deliusRecord: { offenderId: 5 },
-        licences: [{ status: 'VARIATION_SUBMITTED', type: 'AP' }],
-        nomisRecord: {
-          conditionalReleaseDate: '2023-02-19',
-          confirmedReleaseDate: '2023-04-25',
-          restrictedPatient: false,
-          status: 'ACTIVE OUT',
-        },
-      },
-    ])
+      ],
+    })
+  })
+
+  it('should exclude for probation view as incorrect status', () => {
+    const omuCaselist = createCaselist(LicenceStatus.IN_PROGRESS, '2022-10-27', '2022-11-10')
+    expect(omuCaselist.getProbationView()).toEqual({
+      excludedItems: [
+        [
+          {
+            deliusRecord: { offenderId: 1 },
+            licences: [{ status: 'IN_PROGRESS', type: 'AP' }],
+            nomisRecord: {
+              conditionalReleaseDate: '2022-11-10',
+              confirmedReleaseDate: '2022-10-27',
+              restrictedPatient: false,
+              status: 'ACTIVE IN',
+            },
+          },
+          'invalid status for probation view, not one ACTIVE,VARIATION_IN_PROGRESS,VARIATION_APPROVED,VARIATION_SUBMITTED',
+        ],
+      ],
+      items: [],
+    })
   })
 })
+
+function createCaselist(status: LicenceStatus, confirmedReleaseDate: string, conditionalReleaseDate: string) {
+  return new OmuCaselist(
+    new Container([
+      {
+        deliusRecord: { offenderId: 1 },
+        licences: [{ type: LicenceType.AP, status }],
+        nomisRecord: {
+          status: 'ACTIVE IN',
+          confirmedReleaseDate,
+          conditionalReleaseDate,
+          restrictedPatient: false,
+        },
+      },
+    ])
+  )
+}

--- a/server/services/omuCaselist.ts
+++ b/server/services/omuCaselist.ts
@@ -1,0 +1,51 @@
+import { isFuture } from 'date-fns'
+import { ManagedCase } from '../@types/managedCase'
+import LicenceStatus from '../enumeration/licenceStatus'
+import Container from './container'
+
+const PRISON_VIEW_STATUSES = [
+  LicenceStatus.NOT_STARTED,
+  LicenceStatus.IN_PROGRESS,
+  LicenceStatus.APPROVED,
+  LicenceStatus.SUBMITTED,
+]
+
+const OUT_OF_SCOPE_PRISON_VIEW_STATUSES = [
+  LicenceStatus.NOT_IN_PILOT,
+  LicenceStatus.OOS_RECALL,
+  LicenceStatus.OOS_BOTUS,
+]
+
+const PROBATION_VIEW_STATUSES = [
+  LicenceStatus.ACTIVE,
+  LicenceStatus.VARIATION_IN_PROGRESS,
+  LicenceStatus.VARIATION_APPROVED,
+  LicenceStatus.VARIATION_SUBMITTED,
+]
+
+export default class OmuCaselist {
+  constructor(readonly cases: Container<ManagedCase>) {}
+
+  getPrisonView = () => {
+    return this.cases.filter(c => {
+      const releaseDate =
+        c.nomisRecord.confirmedReleaseDate ||
+        c.nomisRecord.conditionalReleaseOverrideDate ||
+        c.nomisRecord.conditionalReleaseDate
+
+      return (
+        PRISON_VIEW_STATUSES.includes(c?.licences[0]?.status) ||
+        (releaseDate
+          ? OUT_OF_SCOPE_PRISON_VIEW_STATUSES.includes(c?.licences[0]?.status) && isFuture(new Date(releaseDate))
+          : false)
+      )
+    }, `invalid status for prison view, not one ${PRISON_VIEW_STATUSES}`)
+  }
+
+  getProbationView = () => {
+    return this.cases.filter(
+      c => PROBATION_VIEW_STATUSES.includes(c?.licences[0]?.status),
+      `invalid status for probation view, not one ${PROBATION_VIEW_STATUSES}`
+    )
+  }
+}


### PR DESCRIPTION
Cases with status NOT_IN_PILOT, OOS_RECALL, OOS_BOTUS to be be moved from probation view to prison view. However they are only to be displayed if their CRD is in the future.