### PR TITLE
CVSL-716

### DIFF
--- a/jobs/promptLicenceCreation.ts
+++ b/jobs/promptLicenceCreation.ts
@@ -94,8 +94,13 @@ const buildEmailGroups = async (
 }
 
 const notifyComOfUpcomingReleases = async (emailGroups: EmailContact[]) => {
-  if (emailGroups.length > 0) {
-    await licenceService.notifyComsToPromptLicenceCreation(emailGroups)
+  if (emailGroups.length === 0) return
+  const workList = _.chunk(emailGroups, 30)
+
+  for (let i = 0; i < workList.length; i += 1) {
+    const probationOfficers = workList[i]
+    // eslint-disable-next-line no-await-in-loop
+    await licenceService.notifyComsToPromptLicenceCreation(probationOfficers)
   }
 }
 

--- a/jobs/promptLicenceCreation.ts
+++ b/jobs/promptLicenceCreation.ts
@@ -93,16 +93,16 @@ const buildEmailGroups = async (
     .value()
 }
 
+/* eslint-disable */
 const notifyComOfUpcomingReleases = async (emailGroups: EmailContact[]) => {
   if (emailGroups.length === 0) return
   const workList = _.chunk(emailGroups, 30)
 
-  for (let i = 0; i < workList.length; i += 1) {
-    const probationOfficers = workList[i]
-    // eslint-disable-next-line no-await-in-loop
+  for (const probationOfficers of workList) {
     await licenceService.notifyComsToPromptLicenceCreation(probationOfficers)
   }
 }
+/* eslint-enable */
 
 Promise.all([
   pollPrisonersDueForLicence(moment().add(12, 'weeks').startOf('isoWeek'), moment().add(12, 'weeks').endOf('isoWeek')),


### PR DESCRIPTION
Prevent HTTP timeout when calling licence API. Chunk requests into batches of 30.

Avoid using Promise.all to prevent overloading the API with, potentially, large numbers of email requests.