### PR TITLE
CVSL-537

### DIFF
--- a/server/routes/approvingLicences/handlers/approvalCases.ts
+++ b/server/routes/approvingLicences/handlers/approvalCases.ts
@@ -4,8 +4,6 @@ import { format, getUnixTime } from 'date-fns'
 import CaseloadService from '../../../services/caseloadService'
 import PrisonerService from '../../../services/prisonerService'
 import { convertToTitleCase, selectReleaseDate } from '../../../utils/utils'
-import { Prisoner } from '../../../@types/prisonerSearchApiClientTypes'
-import logger from '../../../../logger'
 
 export default class ApprovalCaseRoutes {
   constructor(private readonly caseloadService: CaseloadService, private readonly prisonerService: PrisonerService) {}

--- a/server/routes/approvingLicences/handlers/approvalCases.ts
+++ b/server/routes/approvingLicences/handlers/approvalCases.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import _ from 'lodash'
-import { format, getUnixTime } from 'date-fns'
+import { getUnixTime } from 'date-fns'
 import CaseloadService from '../../../services/caseloadService'
 import PrisonerService from '../../../services/prisonerService'
 import { convertToTitleCase, selectReleaseDate } from '../../../utils/utils'

--- a/server/routes/approvingLicences/handlers/approvalCases.ts
+++ b/server/routes/approvingLicences/handlers/approvalCases.ts
@@ -3,8 +3,9 @@ import _ from 'lodash'
 import { format, getUnixTime } from 'date-fns'
 import CaseloadService from '../../../services/caseloadService'
 import PrisonerService from '../../../services/prisonerService'
-import { convertToTitleCase } from '../../../utils/utils'
+import { convertToTitleCase, selectReleaseDate } from '../../../utils/utils'
 import { Prisoner } from '../../../@types/prisonerSearchApiClientTypes'
+import logger from '../../../../logger'
 
 export default class ApprovalCaseRoutes {
   constructor(private readonly caseloadService: CaseloadService, private readonly prisonerService: PrisonerService) {}
@@ -27,7 +28,7 @@ export default class ApprovalCaseRoutes {
           name: convertToTitleCase(`${c.nomisRecord.firstName} ${c.nomisRecord.lastName}`.trim()),
           prisonerNumber: c.nomisRecord.prisonerNumber,
           probationPractitioner: c.probationPractitioner,
-          releaseDate: format(new Date(this.selectReleaseDate(c.nomisRecord)), 'dd MMM yyyy'),
+          releaseDate: selectReleaseDate(c.nomisRecord),
           releaseDateLabel: c.nomisRecord.confirmedReleaseDate ? 'Confirmed release date' : 'CRD',
         }
       })
@@ -54,15 +55,5 @@ export default class ApprovalCaseRoutes {
       prisonsToDisplay,
       hasMultipleCaseloadsInNomis,
     })
-  }
-
-  selectReleaseDate(nomisRecord: Prisoner) {
-    if (nomisRecord.confirmedReleaseDate) {
-      return nomisRecord.confirmedReleaseDate
-    }
-    if (nomisRecord.conditionalReleaseOverrideDate) {
-      return nomisRecord.conditionalReleaseOverrideDate
-    }
-    return nomisRecord.conditionalReleaseDate
   }
 }

--- a/server/routes/viewingLicences/handlers/viewCases.ts
+++ b/server/routes/viewingLicences/handlers/viewCases.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express'
-import { format, getUnixTime } from 'date-fns'
+import { getUnixTime } from 'date-fns'
 import _ from 'lodash'
 import statusConfig from '../../../licences/licenceStatus'
 import CaseloadService from '../../../services/caseloadService'

--- a/server/routes/viewingLicences/handlers/viewCases.ts
+++ b/server/routes/viewingLicences/handlers/viewCases.ts
@@ -6,8 +6,6 @@ import CaseloadService from '../../../services/caseloadService'
 import { convertToTitleCase, selectReleaseDate } from '../../../utils/utils'
 import LicenceStatus from '../../../enumeration/licenceStatus'
 import PrisonerService from '../../../services/prisonerService'
-import { Prisoner } from '../../../@types/prisonerSearchApiClientTypes'
-import logger from '../../../../logger'
 
 export default class ViewAndPrintCaseRoutes {
   constructor(private readonly caseloadService: CaseloadService, private readonly prisonerService: PrisonerService) {}

--- a/server/routes/viewingLicences/handlers/viewCases.ts
+++ b/server/routes/viewingLicences/handlers/viewCases.ts
@@ -3,7 +3,7 @@ import { format, getUnixTime } from 'date-fns'
 import _ from 'lodash'
 import statusConfig from '../../../licences/licenceStatus'
 import CaseloadService from '../../../services/caseloadService'
-import { convertToTitleCase } from '../../../utils/utils'
+import { convertToTitleCase, selectReleaseDate } from '../../../utils/utils'
 import LicenceStatus from '../../../enumeration/licenceStatus'
 import PrisonerService from '../../../services/prisonerService'
 import { Prisoner } from '../../../@types/prisonerSearchApiClientTypes'
@@ -32,7 +32,7 @@ export default class ViewAndPrintCaseRoutes {
           name: convertToTitleCase(`${c.nomisRecord.firstName} ${c.nomisRecord.lastName}`.trim()),
           prisonerNumber: c.nomisRecord.prisonerNumber,
           probationPractitioner: c.probationPractitioner,
-          releaseDate: this.selectReleaseDate(c.nomisRecord),
+          releaseDate: selectReleaseDate(c.nomisRecord),
           releaseDateLabel: c.nomisRecord.confirmedReleaseDate ? 'Confirmed release date' : 'CRD',
           licenceStatus: _.head(c.licences).status,
           isClickable:
@@ -84,27 +84,5 @@ export default class ViewAndPrintCaseRoutes {
     const cases = await this.caseloadService.getOmuCaseload(user, prisonCaseloadToDisplay, view.toString())
     res.header('Content-Type', 'application/json')
     res.send(JSON.stringify(cases, null, 4))
-  }
-
-  selectReleaseDate(nomisRecord: Prisoner) {
-    let dateString = nomisRecord.conditionalReleaseDate
-
-    if (nomisRecord.confirmedReleaseDate) {
-      dateString = nomisRecord.confirmedReleaseDate
-    }
-
-    if (nomisRecord.conditionalReleaseOverrideDate) {
-      dateString = nomisRecord.conditionalReleaseOverrideDate
-    }
-
-    try {
-      dateString = format(new Date(dateString), 'dd MMM yyyy')
-    } catch (e) {
-      logger.error(
-        `Date error: ${e.message} for prisonerNumber: ${nomisRecord.prisonerNumber} using date: ${dateString}`
-      )
-    }
-
-    return dateString
   }
 }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -17,6 +17,7 @@ import {
   hasAuthSource,
   isBankHolidayOrWeekend,
   licenceIsTwoDaysToRelease,
+  selectReleaseDate,
 } from './utils'
 import AuthRole from '../enumeration/authRole'
 import SimpleTime, { AmPm } from '../routes/creatingLicences/types/time'
@@ -25,6 +26,7 @@ import SimpleDateTime from '../routes/creatingLicences/types/simpleDateTime'
 import Address from '../routes/creatingLicences/types/address'
 import { Licence } from '../@types/licenceApiClientTypes'
 import LicenceStatus from '../enumeration/licenceStatus'
+import { Prisoner } from '../@types/prisonerSearchApiClientTypes'
 
 describe('Convert to title case', () => {
   it('null string', () => {
@@ -357,5 +359,49 @@ describe('Check licence is close to release', () => {
       statusCode: LicenceStatus.APPROVED,
     } as Licence
     expect(licenceIsTwoDaysToRelease(licence)).toBeTruthy()
+  })
+})
+
+describe('Get prisoner release date from Nomis', () => {
+  it('No date returns "not found', () => {
+    const nomisRecord = {
+      conditionalReleaseDate: null,
+    } as Prisoner
+
+    expect(selectReleaseDate(nomisRecord)).toBe('not found')
+  })
+
+  it('Release date should be Conditional Release Date 22 Nov 2035', () => {
+    const nomisRecord = {
+      conditionalReleaseDate: '2035-11-22',
+    } as Prisoner
+
+    expect(selectReleaseDate(nomisRecord)).toBe('22 Nov 2035')
+  })
+
+  it('Release date should be Confirmed Release Date 22 Oct 2035', () => {
+    const nomisRecord = {
+      conditionalReleaseDate: '2035-11-22',
+      confirmedReleaseDate: '2035-10-22',
+    } as Prisoner
+
+    expect(selectReleaseDate(nomisRecord)).toBe('22 Oct 2035')
+  })
+
+  it('Release date should be Conditional Release Override Date 22 Nov 2036', () => {
+    const nomisRecord = {
+      conditionalReleaseDate: '2036-11-01',
+      conditionalReleaseOverrideDate: '2036-11-22',
+    } as Prisoner
+
+    expect(selectReleaseDate(nomisRecord)).toBe('22 Nov 2036')
+  })
+
+  it('Returns malformed date as is', () => {
+    const nomisRecord = {
+      conditionalReleaseDate: 'aaa2036-11-01',
+    } as Prisoner
+
+    expect(selectReleaseDate(nomisRecord)).toBe('aaa2036-11-01')
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -171,10 +171,17 @@ const selectReleaseDate = (nomisRecord: Prisoner) => {
     dateString = nomisRecord.conditionalReleaseOverrideDate
   }
 
+  if (!dateString) {
+    logger.error(`No release date found for prisonerNumber: ${nomisRecord.prisonerNumber}`)
+    return 'not found'
+  }
+
   try {
     dateString = format(new Date(dateString), 'dd MMM yyyy')
   } catch (e) {
-    logger.error(`Date error: ${e.message} for prisonerNumber: ${nomisRecord.prisonerNumber} using date: ${dateString}`)
+    logger.error(
+      `Invalid date error: ${e.message} for prisonerNumber: ${nomisRecord.prisonerNumber} using date: ${dateString}`
+    )
   }
 
   return dateString

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,11 +1,14 @@
 import moment, { Moment } from 'moment'
 import { Holiday } from 'uk-bank-holidays'
+import { format } from 'date-fns'
 import AuthRole from '../enumeration/authRole'
 import SimpleDateTime from '../routes/creatingLicences/types/simpleDateTime'
 import SimpleDate from '../routes/creatingLicences/types/date'
 import SimpleTime, { AmPm } from '../routes/creatingLicences/types/time'
 import Address from '../routes/creatingLicences/types/address'
 import { Licence } from '../@types/licenceApiClientTypes'
+import { Prisoner } from '../@types/prisonerSearchApiClientTypes'
+import logger from '../../logger'
 
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
@@ -157,6 +160,26 @@ const isBankHolidayOrWeekend = (date: Moment, bankHolidays: Holiday[]) => {
 const licenceIsTwoDaysToRelease = (licence: Licence) =>
   moment(licence.conditionalReleaseDate, 'DD/MM/YYYY').diff(moment(), 'days') <= 2
 
+const selectReleaseDate = (nomisRecord: Prisoner) => {
+  let dateString = nomisRecord.conditionalReleaseDate
+
+  if (nomisRecord.confirmedReleaseDate) {
+    dateString = nomisRecord.confirmedReleaseDate
+  }
+
+  if (nomisRecord.conditionalReleaseOverrideDate) {
+    dateString = nomisRecord.conditionalReleaseOverrideDate
+  }
+
+  try {
+    dateString = format(new Date(dateString), 'dd MMM yyyy')
+  } catch (e) {
+    logger.error(`Date error: ${e.message} for prisonerNumber: ${nomisRecord.prisonerNumber} using date: ${dateString}`)
+  }
+
+  return dateString
+}
+
 export {
   convertToTitleCase,
   hasRole,
@@ -177,4 +200,5 @@ export {
   formatAddress,
   isBankHolidayOrWeekend,
   licenceIsTwoDaysToRelease,
+  selectReleaseDate,
 }


### PR DESCRIPTION
Wrap dateFormat in try catch to avoid page crash when viewing null dates. Longer term fix should filter out none dated records, or handle according to business requirment.