### PR TITLE
Fixing a bug where variations would not trigger the validation to ensure all conditions had data inputs

### DIFF
--- a/server/routes/creatingLicences/handlers/checkAnswers.ts
+++ b/server/routes/creatingLicences/handlers/checkAnswers.ts
@@ -64,6 +64,10 @@ export default class CheckAnswersRoutes {
       await this.licenceService.updateStandardConditions(licenceId, newStdConditions, user)
     }
 
+    if (licence.isVariation) {
+      return res.redirect(`/licence/vary/id/${licence.id}/reason-for-variation`)
+    }
+
     await this.licenceService.submitLicence(licenceId, user)
 
     return res.redirect(`/licence/create/id/${licenceId}/confirmation`)

--- a/server/views/pages/create/checkAnswers.njk
+++ b/server/views/pages/create/checkAnswers.njk
@@ -13,6 +13,11 @@
 {% set isInProgress = licence.statusCode == 'IN_PROGRESS' or licence.statusCode == 'VARIATION_IN_PROGRESS' %}
 {% set canChooseToEdit = licence.statusCode == 'APPROVED' or licence.statusCode == 'SUBMITTED' %}
 {% set canChooseToPrint = licence.statusCode == 'APPROVED' %}
+{% if licence.isVariation %} 
+  {% set submitButtonText = 'View summary and add notes' %}
+{% else %} 
+  {% set submitButtonText = 'Send to prison for approval'%}
+{% endif %}
 
 {% block content %}
     <div class="govuk-grid-row">
@@ -80,28 +85,12 @@
                 {{ additionalPssConditions(licence, isInProgress, validationErrors) }}
             {% endif %}
 
-            {% if isInProgress and licence.isVariation %}
-                <div class="govuk-button-group">
-                    {{ govukButton({
-                        text: "View summary and add notes",
-                        attributes: { 'data-qa': 'add-notes' },
-                        href: '/licence/vary/id/' + licence.id + '/reason-for-variation'
-                    }) }}
-                    {{ govukButton({
-                        text: "Discard changes",
-                        classes: "govuk-button--secondary",
-                        attributes: { 'data-qa': 'discard' },
-                        href: '/licence/vary/id/' + licence.id + '/confirm-discard-variation'
-                    }) }}
-                </div>
-            {% endif %}
-
             <form method="POST">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}">
                 <div class="govuk-button-group">
-                    {% if isInProgress and not licence.isVariation %}
+                    {% if isInProgress %}
                         {{ govukButton({
-                            text: "Send to prison for approval",
+                            text: submitButtonText,
                             attributes: { 'data-qa': 'send-licence-conditions' }
                         }) }}
                     {% endif %}
@@ -129,6 +118,16 @@
                     {% endif %}
                 </div>
             </form>
+
+            {% if isInProgress and licence.isVariation %}
+                    {{ govukButton({
+                        text: "Discard changes",
+                        classes: "govuk-button--secondary",
+                        attributes: { 'data-qa': 'discard' },
+                        href: '/licence/vary/id/' + licence.id + '/confirm-discard-variation'
+                    }) }}
+                </div>
+            {% endif %}
 
             {% if licence.isVariation %}
                 <a href="/licence/vary/caseload" class="govuk-link govuk-!-font-size-19">Return to caselist</a>


### PR DESCRIPTION
When viewing the check-answers page, there should be a validation that prevents a user from submitting a licence with placeholders still within the condition text (ie, they haven't entered the required data in the child page).
This validation triggers on newly created licences, but was not triggering on variations.

This PR makes it trigger on variations.