### PR TITLE
CVSL-709 swap moment for date-fns

### DIFF
--- a/jobs/promptLicenceCreation.ts
+++ b/jobs/promptLicenceCreation.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata'
 import _ from 'lodash'
-import moment, { Moment } from 'moment'
+import { add, startOfWeek, endOfWeek } from 'date-fns'
 import { buildAppInsightsClient, flush, initialiseAppInsights } from '../server/utils/azureAppInsights'
 import logger from '../logger'
 import { Prisoner } from '../server/@types/prisonerSearchApiClientTypes'
@@ -18,8 +18,8 @@ buildAppInsightsClient('create-and-vary-a-licence-prompt-licence-create-job')
 const { caseloadService, prisonerService, communityService, licenceService } = services
 
 const pollPrisonersDueForLicence = async (
-  earliestReleaseDate: Moment,
-  latestReleaseDate: Moment,
+  earliestReleaseDate: Date,
+  latestReleaseDate: Date,
   licenceStatus: LicenceStatus[],
   exclusionMessage: string
 ): Promise<ManagedCase[]> => {
@@ -112,14 +112,14 @@ const notifyComOfUpcomingReleases = async (emailGroups: EmailContact[]) => {
 
 Promise.all([
   pollPrisonersDueForLicence(
-    moment().add(12, 'weeks').startOf('isoWeek'),
-    moment().add(12, 'weeks').endOf('isoWeek'),
+    startOfWeek(add(new Date(), { weeks: 12 }), { weekStartsOn: 1 }),
+    endOfWeek(add(new Date(), { weeks: 12 }), { weekStartsOn: 1 }),
     [LicenceStatus.NOT_STARTED],
     'No licences that are NOT_STARTED'
   ),
   pollPrisonersDueForLicence(
-    moment().startOf('isoWeek'),
-    moment().add(3, 'weeks').endOf('isoWeek'),
+    startOfWeek(new Date(), { weekStartsOn: 1 }),
+    endOfWeek(add(new Date(), { weeks: 3 }), { weekStartsOn: 1 }),
     [LicenceStatus.NOT_STARTED, LicenceStatus.IN_PROGRESS],
     'No licences that are NOT_STARTED or IN_PROGRESS'
   ),

--- a/server/services/caseloadService.test.ts
+++ b/server/services/caseloadService.test.ts
@@ -1,5 +1,4 @@
-import moment from 'moment'
-import { addDays, format } from 'date-fns'
+import { addDays, add, format, startOfWeek, endOfWeek } from 'date-fns'
 import CaseloadService from './caseloadService'
 import PrisonerService from './prisonerService'
 import CommunityService from './communityService'
@@ -885,8 +884,8 @@ describe('Caseload Service', () => {
     const result = await serviceUnderTest.getOmuCaseload(user, ['p1', 'p2'])
 
     expect(prisonerService.searchPrisonersByReleaseDate).toHaveBeenCalledWith(
-      moment().startOf('isoWeek'),
-      moment().add(3, 'weeks').endOf('isoWeek'),
+      startOfWeek(new Date(), { weekStartsOn: 1 }),
+      endOfWeek(add(new Date(), { weeks: 3 }), { weekStartsOn: 1 }),
       ['p1', 'p2'],
       user
     )

--- a/server/services/caseloadService.ts
+++ b/server/services/caseloadService.ts
@@ -1,5 +1,5 @@
 import moment from 'moment'
-import { isFuture, parse } from 'date-fns'
+import { isFuture, parse, startOfWeek, add, endOfWeek } from 'date-fns'
 import CommunityService from './communityService'
 import PrisonerService from './prisonerService'
 import LicenceService from './licenceService'
@@ -77,8 +77,8 @@ export default class CaseloadService {
       .then(licences => this.mapLicencesToOffenders(licences))
 
     // Get cases due for release soon which do not have a submitted licence
-    const startOfThisWeek = moment().startOf('isoWeek')
-    const endOfTheFourthWeekFromNow = moment().add(3, 'weeks').endOf('isoWeek')
+    const startOfThisWeek = startOfWeek(new Date(), { weekStartsOn: 1 })
+    const endOfTheFourthWeekFromNow = endOfWeek(add(new Date(), { weeks: 3 }), { weekStartsOn: 1 })
     const casesPendingLicence = this.prisonerService
       .searchPrisonersByReleaseDate(startOfThisWeek, endOfTheFourthWeekFromNow, prisonCaseload, user)
       .then(caseload => this.wrap(caseload))

--- a/server/services/prisonerService.test.ts
+++ b/server/services/prisonerService.test.ts
@@ -1,6 +1,5 @@
 import { Readable } from 'stream'
 import fs from 'fs'
-import moment from 'moment'
 import { User } from '../@types/CvlUserDetails'
 import PrisonApiClient from '../data/prisonApiClient'
 import PrisonerSearchApiClient from '../data/prisonerSearchApiClient'
@@ -189,8 +188,8 @@ describe('Prisoner Service', () => {
     } as PagePrisoner)
 
     const actualResult = await prisonerService.searchPrisonersByReleaseDate(
-      moment('2022-01-01'),
-      moment('2022-01-01'),
+      new Date('2022-01-01'),
+      new Date('2022-01-01'),
       ['MDI'],
       user
     )

--- a/server/services/prisonerService.ts
+++ b/server/services/prisonerService.ts
@@ -1,6 +1,6 @@
 import { Readable } from 'stream'
 import fs from 'fs'
-import { Moment } from 'moment'
+import { format } from 'date-fns'
 import PrisonApiClient from '../data/prisonApiClient'
 import PrisonerSearchApiClient from '../data/prisonerSearchApiClient'
 import { PrisonApiPrisoner, PrisonInformation, PrisonDetail } from '../@types/prisonApiClientTypes'
@@ -105,15 +105,16 @@ export default class PrisonerService {
   }
 
   async searchPrisonersByReleaseDate(
-    earliestReleaseDate: Moment,
-    latestReleaseDate: Moment,
+    earliestReleaseDate: Date,
+    latestReleaseDate: Date,
     prisonIds?: string[],
     user?: User
   ): Promise<Prisoner[]> {
     return this.prisonerSearchApiClient
       .searchPrisonersByReleaseDate(
-        earliestReleaseDate.format('YYYY-MM-DD'),
-        latestReleaseDate.format('YYYY-MM-DD'),
+        format(earliestReleaseDate, 'yyyy-MM-dd'),
+        format(latestReleaseDate, 'yyyy-MM-dd'),
+
         prisonIds,
         user
       )


### PR DESCRIPTION
for reference 
Moment startOf('isoWeek') refers to a Monday
Date-fns weekStartsOn:1 is a Monday. Other wise default is a Sunday

moment().add(12, 'weeks').startOf('isoWeek')  returns Moment<2023-01-23T00:00:00+00:00>
startOfWeek(add(new Date(), { weeks: 12 }), { weekStartsOn: 1 })  returns 2023-01-23T00:00:00.000Z
(based on todays date of 2022-11-04)

prisonerSearchApiClient.searchPrisonersByReleaseDate() needs dates as a string like '2022-11-04'

Both   
moment('2022-11-04').format('YYYY-MM-DD') 
and 
format(new Date('2022-11-04'), 'yyyy-MM-dd') 
return string  '2022-11-04'