### PR TITLE
CVSL 709 refactor for tests

### DIFF
--- a/jobs/promptLicenceCreationService.test.ts
+++ b/jobs/promptLicenceCreationService.test.ts
@@ -15,6 +15,8 @@ const prisonerService = new PrisonerService(null, null) as jest.Mocked<PrisonerS
 
 const promptLicenceCreationService = new PromptLicenceCreationService(prisonerService, caseloadService)
 
+type OffenderManager = { active: boolean; fromDate: string }
+
 describe('prompt licence creation service ', () => {
   beforeEach(() => {
     prisonerService.searchPrisonersByReleaseDate = jest.fn()
@@ -28,65 +30,30 @@ describe('prompt licence creation service ', () => {
   })
 
   const managedCases = [
-    {
-      deliusRecord: { offenderId: 1, offenderManagers: [{ active: true, fromDate: format(new Date(), 'yyyy-MM-dd') }] },
-      nomisRecord: {
-        restrictedPatient: false,
-        prisonId: 'someId',
-        conditionalReleaseDate: format(new Date(), 'yyyy-MM-dd'),
-        status: 'someStatus',
-      },
-      licences: [{ status: LicenceStatus.NOT_STARTED, type: LicenceType.AP }],
-      probationPractitioner: { name: 'jim' },
-    },
-    {
-      deliusRecord: {
-        offenderId: 2,
-        offenderManagers: [
-          { active: true, fromDate: format(subDays(new Date(), 1), 'yyyy-MM-dd') },
-          { active: false, fromDate: format(subDays(new Date(), 1), 'yyyy-MM-dd') },
-        ],
-      },
+    createManagedCase([{ active: true, fromDate: format(new Date(), 'yyyy-MM-dd') }], LicenceStatus.NOT_STARTED),
 
-      nomisRecord: {
-        restrictedPatient: false,
-        prisonId: 'someId',
-        conditionalReleaseDate: format(new Date(), 'yyyy-MM-dd'),
-        status: 'someStatus',
-      },
-      licences: [{ status: LicenceStatus.APPROVED, type: LicenceType.AP }],
-      probationPractitioner: { name: 'tom' },
-    },
-    {
-      deliusRecord: {
-        offenderId: 3,
-        offenderManagers: [{ active: true, fromDate: format(subDays(new Date(), 7), 'yyyy-MM-dd') }, { active: false }],
-      },
-      nomisRecord: {
-        restrictedPatient: false,
-        prisonId: 'someId',
-        conditionalReleaseDate: format(new Date(), 'yyyy-MM-dd'),
-        status: 'someStatus',
-      },
-      licences: [{ status: LicenceStatus.IN_PROGRESS, type: LicenceType.AP }],
-      probationPractitioner: { name: 'jack' },
-    },
-    {
-      deliusRecord: {
-        offenderId: 4,
-        offenderManagers: [{ active: true, fromDate: format(subDays(new Date(), 8), 'yyyy-MM-dd') }],
-      },
+    createManagedCase(
+      [
+        { active: true, fromDate: format(subDays(new Date(), 1), 'yyyy-MM-dd') },
+        { active: false, fromDate: format(subDays(new Date(), 1), 'yyyy-MM-dd') },
+      ],
+      LicenceStatus.APPROVED
+    ),
 
-      nomisRecord: {
-        restrictedPatient: false,
-        prisonId: 'someId',
-        conditionalReleaseDate: format(new Date(), 'yyyy-MM-dd'),
-        status: 'someStatus',
-      },
-      licences: [{ status: LicenceStatus.IN_PROGRESS, type: LicenceType.AP }],
-      probationPractitioner: { name: 'andy' },
-    },
+    createManagedCase(
+      [
+        { active: true, fromDate: format(subDays(new Date(), 7), 'yyyy-MM-dd') },
+        { active: false, fromDate: format(subDays(new Date(), 7), 'yyyy-MM-dd') },
+      ],
+      LicenceStatus.IN_PROGRESS
+    ),
+
+    createManagedCase(
+      [{ active: true, fromDate: format(subDays(new Date(), 8), 'yyyy-MM-dd') }],
+      LicenceStatus.IN_PROGRESS
+    ),
   ]
+
   const containerOfManagedCases = new Container(managedCases)
 
   describe('pollPrisonersDueForLicence', () => {
@@ -114,3 +81,17 @@ describe('prompt licence creation service ', () => {
     })
   })
 })
+
+function createManagedCase(offenderManagers: OffenderManager[], licenceStatus: LicenceStatus) {
+  return {
+    deliusRecord: { offenderId: 1, offenderManagers },
+    nomisRecord: {
+      restrictedPatient: false,
+      prisonId: 'someId',
+      conditionalReleaseDate: format(new Date(), 'yyyy-MM-dd'),
+      status: 'someStatus',
+    },
+    licences: [{ status: licenceStatus, type: LicenceType.AP }],
+    probationPractitioner: { name: 'jim' },
+  }
+}

--- a/jobs/promptLicenceCreationService.test.ts
+++ b/jobs/promptLicenceCreationService.test.ts
@@ -1,0 +1,116 @@
+import { format, add, startOfISOWeek, endOfISOWeek, subDays } from 'date-fns'
+
+import LicenceStatus from '../server/enumeration/licenceStatus'
+import CaseloadService from '../server/services/caseloadService'
+import Container from '../server/services/container'
+import PrisonerService from '../server/services/prisonerService'
+import PromptLicenceCreationService from './promptLicenceCreationService'
+import LicenceType from '../server/enumeration/licenceType'
+
+jest.mock('../server/services/caseloadService')
+jest.mock('../server/services/prisonerService')
+
+const caseloadService = new CaseloadService(null, null, null) as jest.Mocked<CaseloadService>
+const prisonerService = new PrisonerService(null, null) as jest.Mocked<PrisonerService>
+
+const promptLicenceCreationService = new PromptLicenceCreationService(prisonerService, caseloadService)
+
+describe('prompt licence creation service ', () => {
+  beforeEach(() => {
+    prisonerService.searchPrisonersByReleaseDate = jest.fn()
+    caseloadService.pairNomisRecordsWithDelius = jest.fn()
+    caseloadService.filterOffendersEligibleForLicence = jest.fn()
+    caseloadService.mapOffendersToLicences = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const managedCases = [
+    {
+      deliusRecord: { offenderId: 1, offenderManagers: [{ active: true, fromDate: format(new Date(), 'yyyy-MM-dd') }] },
+      nomisRecord: {
+        restrictedPatient: false,
+        prisonId: 'someId',
+        conditionalReleaseDate: format(new Date(), 'yyyy-MM-dd'),
+        status: 'someStatus',
+      },
+      licences: [{ status: LicenceStatus.NOT_STARTED, type: LicenceType.AP }],
+      probationPractitioner: { name: 'jim' },
+    },
+    {
+      deliusRecord: {
+        offenderId: 2,
+        offenderManagers: [
+          { active: true, fromDate: format(subDays(new Date(), 1), 'yyyy-MM-dd') },
+          { active: false, fromDate: format(subDays(new Date(), 1), 'yyyy-MM-dd') },
+        ],
+      },
+
+      nomisRecord: {
+        restrictedPatient: false,
+        prisonId: 'someId',
+        conditionalReleaseDate: format(new Date(), 'yyyy-MM-dd'),
+        status: 'someStatus',
+      },
+      licences: [{ status: LicenceStatus.APPROVED, type: LicenceType.AP }],
+      probationPractitioner: { name: 'tom' },
+    },
+    {
+      deliusRecord: {
+        offenderId: 3,
+        offenderManagers: [{ active: true, fromDate: format(subDays(new Date(), 7), 'yyyy-MM-dd') }, { active: false }],
+      },
+      nomisRecord: {
+        restrictedPatient: false,
+        prisonId: 'someId',
+        conditionalReleaseDate: format(new Date(), 'yyyy-MM-dd'),
+        status: 'someStatus',
+      },
+      licences: [{ status: LicenceStatus.IN_PROGRESS, type: LicenceType.AP }],
+      probationPractitioner: { name: 'jack' },
+    },
+    {
+      deliusRecord: {
+        offenderId: 4,
+        offenderManagers: [{ active: true, fromDate: format(subDays(new Date(), 8), 'yyyy-MM-dd') }],
+      },
+
+      nomisRecord: {
+        restrictedPatient: false,
+        prisonId: 'someId',
+        conditionalReleaseDate: format(new Date(), 'yyyy-MM-dd'),
+        status: 'someStatus',
+      },
+      licences: [{ status: LicenceStatus.IN_PROGRESS, type: LicenceType.AP }],
+      probationPractitioner: { name: 'andy' },
+    },
+  ]
+  const containerOfManagedCases = new Container(managedCases)
+
+  describe('pollPrisonersDueForLicence', () => {
+    it('should only return cases with specific statuses', async () => {
+      prisonerService.searchPrisonersByReleaseDate.mockResolvedValue([])
+      caseloadService.mapOffendersToLicences.mockResolvedValue(containerOfManagedCases)
+
+      const earliestReleaseDate = startOfISOWeek(add(new Date(), { weeks: 12 }))
+      const latestReleaseDate = endOfISOWeek(add(new Date(), { weeks: 12 }))
+
+      const result = await promptLicenceCreationService.pollPrisonersDueForLicence(
+        earliestReleaseDate,
+        latestReleaseDate,
+        [LicenceStatus.IN_PROGRESS, LicenceStatus.NOT_STARTED]
+      )
+
+      expect(result).toHaveLength(3)
+    })
+  })
+
+  describe('excludeCasesNotAssignedToPpWithinPast7Days', () => {
+    it('should exclude allocations not made in past 7 days', () => {
+      const actualResult = promptLicenceCreationService.excludeCasesNotAssignedToPpWithinPast7Days(managedCases)
+      expect(actualResult).toHaveLength(2)
+    })
+  })
+})

--- a/jobs/promptLicenceCreationService.ts
+++ b/jobs/promptLicenceCreationService.ts
@@ -1,0 +1,46 @@
+import { subDays } from 'date-fns'
+
+import config from '../server/config'
+import Container from '../server/services/container'
+import { ManagedCase } from '../server/@types/managedCase'
+import LicenceStatus from '../server/enumeration/licenceStatus'
+import PrisonerService from '../server/services/prisonerService'
+import CaseloadService from '../server/services/caseloadService'
+
+export default class PromptLicenceCreationService {
+  constructor(private readonly prisonerService: PrisonerService, private readonly caseloadService: CaseloadService) {}
+
+  pollPrisonersDueForLicence = async (
+    earliestReleaseDate: Date,
+    latestReleaseDate: Date,
+    licenceStatus: LicenceStatus[]
+  ): Promise<ManagedCase[]> => {
+    const prisonCodes = config.rollout.prisons
+
+    return this.prisonerService
+      .searchPrisonersByReleaseDate(earliestReleaseDate, latestReleaseDate, prisonCodes)
+      .then(prisoners => prisoners.filter(offender => offender.status && offender.status.startsWith('ACTIVE')))
+      .then(caseload => new Container(caseload))
+      .then(caseload => this.caseloadService.pairNomisRecordsWithDelius(caseload))
+      .then(caseload => this.caseloadService.filterOffendersEligibleForLicence(caseload))
+      .then(prisoners => this.caseloadService.mapOffendersToLicences(prisoners))
+      .then(caseload => caseload.unwrap())
+      .then(prisoners =>
+        prisoners.filter(offender => licenceStatus.some(status => offender.licences.find(l => l.status === status)))
+      )
+  }
+
+  excludeCasesNotAssignedToPpWithinPast7Days = (caseload: ManagedCase[]): ManagedCase[] => {
+    const startOf7Days = subDays(new Date(), 7)
+    const endOf7Days = new Date()
+    const isWithinPast7Days = (c: ManagedCase) => {
+      if (c.deliusRecord.offenderManagers) {
+        const dateAllocatedToPp = new Date(c.deliusRecord.offenderManagers.find(om => om.active).fromDate)
+        return dateAllocatedToPp >= startOf7Days && dateAllocatedToPp < endOf7Days
+      }
+      return false
+    }
+
+    return caseload.filter(isWithinPast7Days)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "record-build-info": "node ./bin/record-build-info",
     "lint": "eslint . --cache --max-warnings 0",
     "typecheck": "tsc",
-    "test": "jest --collectCoverage=true --detectOpenHandles",
+    "test": "jest --collectCoverage=true",
     "test:ci": "jest --maxWorkers=2 --collectCoverage=true --testPathPattern=/server/.*",
     "integrationTest": "jest --runInBand --testPathPattern=/integration_tests/.*",
     "security_audit": "better-npm-audit audit",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "record-build-info": "node ./bin/record-build-info",
     "lint": "eslint . --cache --max-warnings 0",
     "typecheck": "tsc",
-    "test": "jest --collectCoverage=true --testPathPattern=/server/.*",
+    "test": "jest --collectCoverage=true --detectOpenHandles",
     "test:ci": "jest --maxWorkers=2 --collectCoverage=true --testPathPattern=/server/.*",
     "integrationTest": "jest --runInBand --testPathPattern=/integration_tests/.*",
     "security_audit": "better-npm-audit audit",
@@ -50,6 +50,7 @@
     ],
     "testMatch": [
       "<rootDir>/server/**/?(*.)(spec|test).{ts,js,jsx,mjs}",
+      "<rootDir>/jobs/**/?(*.)(spec|test).{ts,js,jsx,mjs}",
       "<rootDir>/integration_tests/gotenberg/?(*.)(spec|test).{ts,js,jsx,mjs}"
     ],
     "setupFilesAfterEnv": [


### PR DESCRIPTION
1, The logic within excludeCasesNotAssignedToPpWithinPast7Days was wrong. It was thought the allocationDate referred to the date a PP was allocated. In fact the allocationDate is part of the offenderCrn object. 
A call is made to probation-offender-search to get the offender details. The returned object contains the offenderManagers array exampled below. The relevant data from the offenderManagers array is in bold. 
"offenderManagers": [
           {
               "staff": {
                   "code": "A123456B",
                   "forenames": "some",
                   "surname": "practioner"
               },
               "partitionArea": "National Data",
               "softDeleted": false,
               "team": {
                   "code": "someTeamCode",
                   "description": "Durham & Darlington IOM",
                   "district": {
                       "code": "someDistrictCode",
                       "description": "Durham"
                   },
                   "borough": {
                       "code": "someBoroughCode",
                       "description": "County Durham and Darlington"
                   }
               },
               "probationArea": {
                   "code": "N54",
                   "description": "North East Region",
                   "nps": false
               },
               **"fromDate": "2022-11-02",
               "active": true,**
               "allocationReason": {
                   "code": "someReason",
                   "description": "Caseload Adjustment"
               }
           }
       ],


2, some logic extracted out of promptLicenceCreation.ts  for code simplification and to enable testing
3, calls to promptLicenceCreationService changed to be in a more natural chronological order. 
