### PR TITLE
CVSL-730 chunk args passed in api calls

### DIFF
--- a/jobs/promptLicenceCreation.ts
+++ b/jobs/promptLicenceCreation.ts
@@ -36,8 +36,15 @@ const buildEmailGroups = async (
     managedCases.map(prisoner => prisoner.deliusRecord.offenderManagers.find(manager => manager.active)?.staff.code)
   )
 
-  const staff = await communityService.getStaffDetailByStaffCodeList(staffCodes)
+  const staffDetails = []
+  /* eslint-disable */
+  for (const codes of _.chunk(staffCodes, 500)) {
+    const partResult = await await communityService.getStaffDetailByStaffCodeList(codes)
+    staffDetails.push(partResult)
+  }
+  /* eslint-enable */
 
+  const staff = staffDetails.flat()
   const prisonersWithCom = managedCases
     .map(prisoner => {
       const responsibleComStaffCode = prisoner.deliusRecord.offenderManagers.find(manager => manager.active)?.staff.code

--- a/server/services/communityService.ts
+++ b/server/services/communityService.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import CommunityApiClient from '../data/communityApiClient'
 import ProbationSearchApiClient from '../data/probationSearchApiClient'
 import { OffenderDetail, SearchDto } from '../@types/probationSearchApiClientTypes'
@@ -78,8 +79,15 @@ export default class CommunityService {
   }
 
   async getOffendersByNomsNumbers(nomsNumbers: string[]): Promise<OffenderDetail[]> {
+    const offenderDetails = []
     if (nomsNumbers.length > 0) {
-      return this.probationSearchApiClient.getOffendersByNomsNumbers(nomsNumbers)
+      /* eslint-disable */
+      for (const nomsNums of _.chunk(nomsNumbers, 500)) {
+        const partResult = await this.probationSearchApiClient.getOffendersByNomsNumbers(nomsNums)
+        offenderDetails.push(partResult)
+      }
+      /* eslint-enable */
+      return offenderDetails.flat()
     }
     return []
   }


### PR DESCRIPTION
The apis were throwing exceptions because too much data was passed in one go.  This was preventing promptLicenceCreation cronjob from completing.  Args chunked to 500.

app insights:
prison-api
<img width="500" alt="Screenshot 2022-11-22 at 11 35 38" src="https://user-images.githubusercontent.com/50441412/203306477-dc1384db-b883-4676-a94c-0f02cc7b6202.png">

probation-offender-search
<img width="500" alt="Screenshot 2022-11-22 at 11 42 20" src="https://user-images.githubusercontent.com/50441412/203306519-febaf6de-8933-4b43-af8b-ec3a783f804f.png">


