### PR TITLE
CVSL-732 displays correct date and description for vary journey

### DIFF
--- a/server/routes/varyingLicences/index.ts
+++ b/server/routes/varyingLicences/index.ts
@@ -1,4 +1,4 @@
-import { RequestHandler, Router } from 'express'
+import { RequestHandler, Request, Response, NextFunction, Router } from 'express'
 import asyncMiddleware from '../../middleware/asyncMiddleware'
 import fetchLicence from '../../middleware/fetchLicenceMiddleware'
 import roleCheckMiddleware from '../../middleware/roleCheckMiddleware'
@@ -27,6 +27,13 @@ import PolicyChangesCallbackRoutes from './handlers/policyChangesCallback'
 import PolicyChangeRoutes from './handlers/policyChange'
 import PolicyChangesInputCallbackRoutes from './handlers/policyChangesInputCallback'
 
+function alterResObject() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    res.locals.isVaryJourney = true
+    next()
+  }
+}
+
 export default function Index({
   licenceService,
   caseloadService,
@@ -48,6 +55,7 @@ export default function Index({
       routePrefix(path),
       roleCheckMiddleware(['ROLE_LICENCE_RO']),
       fetchLicence(licenceService),
+      alterResObject(),
       asyncMiddleware(handler)
     )
 

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -1,5 +1,5 @@
 import * as cheerio from 'cheerio'
-import { format, addDays, addMonths } from 'date-fns'
+import { format, addDays, subDays, addMonths } from 'date-fns'
 import nunjucks, { Template } from 'nunjucks'
 import ConditionService from '../services/conditionService'
 import { registerNunjucks } from './nunjucksSetup'
@@ -294,6 +294,19 @@ describe('Nunjucks Filters', () => {
       const licence = {
         typeCode: 'AP_PSS',
         topupSupervisionStartDate: today,
+        topupSupervisionExpiryDate: tused,
+      } as Licence
+      const result = njkEnv.getFilter('dateToDisplay')(licence)
+      expect(result).toEqual(`PSS end date: ${tusedInLongerForm}`)
+    })
+
+    it('Should handle AP_PSS where led has passed and tused exists but no tussd', () => {
+      const yesterday = format(subDays(new Date(), 1), 'd/MM/yyyy')
+      const tused = format(addMonths(new Date(), 1), 'd/MM/yyyy')
+      const tusedInLongerForm = format(addMonths(new Date(), 1), 'd MMM yyy')
+      const licence = {
+        typeCode: 'AP_PSS',
+        licenceExpiryDate: yesterday,
         topupSupervisionExpiryDate: tused,
       } as Licence
       const result = njkEnv.getFilter('dateToDisplay')(licence)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -1,13 +1,21 @@
 /* eslint-disable no-param-reassign */
 import nunjucks, { Environment } from 'nunjucks'
+import { isToday, format } from 'date-fns'
 import express from 'express'
 import path from 'path'
 import moment from 'moment'
 import { filesize } from 'filesize'
 import { FieldValidationError } from '../middleware/validationMiddleware'
 import config from '../config'
-import { formatAddress, jsonDtTo12HourTime, jsonDtToDate, jsonDtToDateShort, jsonDtToDateWithDay } from './utils'
-import { AdditionalCondition, AdditionalConditionData } from '../@types/licenceApiClientTypes'
+import {
+  formatAddress,
+  jsonDtTo12HourTime,
+  jsonDtToDate,
+  jsonDtToDateShort,
+  jsonDtToDateWithDay,
+  toDate,
+} from './utils'
+import { AdditionalCondition, AdditionalConditionData, Licence } from '../@types/licenceApiClientTypes'
 import SimpleTime from '../routes/creatingLicences/types/time'
 import SimpleDate from '../routes/creatingLicences/types/date'
 import Address from '../routes/creatingLicences/types/address'
@@ -243,6 +251,37 @@ export function registerNunjucks(conditionService: ConditionService, app?: expre
       default:
         return mimeType
     }
+  })
+
+  njkEnv.addFilter('dateToDisplay', (licence: Licence) => {
+    const licenceType = licence.typeCode
+    const led = licence.licenceExpiryDate ? toDate(licence.licenceExpiryDate) : null
+    const tussd = licence.topupSupervisionStartDate ? toDate(licence.topupSupervisionStartDate) : null
+    const tused = licence.topupSupervisionExpiryDate ? toDate(licence.topupSupervisionExpiryDate) : null
+
+    let dateToDisplay: Date
+    let textToDisplay = ''
+
+    if (licenceType === 'AP') {
+      textToDisplay = 'Licence end date'
+      dateToDisplay = led
+    }
+
+    if (licenceType === 'AP_PSS') {
+      textToDisplay = isToday(tussd) ? 'PSS end date' : 'Licence end date'
+      dateToDisplay = isToday(tussd) ? tused : led
+    }
+
+    if (licenceType === 'PSS') {
+      textToDisplay = 'PSS end date'
+      dateToDisplay = tused
+    }
+
+    if (dateToDisplay) {
+      return `${textToDisplay}: ${format(dateToDisplay, 'd MMM yyy')}`
+    }
+
+    return `${textToDisplay}: not available`
   })
 
   return njkEnv

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 import nunjucks, { Environment } from 'nunjucks'
-import { isToday, format } from 'date-fns'
+import { isToday, isYesterday, format } from 'date-fns'
 import express from 'express'
 import path from 'path'
 import moment from 'moment'
@@ -262,17 +262,17 @@ export function registerNunjucks(conditionService: ConditionService, app?: expre
     let dateToDisplay: Date
     let textToDisplay = ''
 
-    if (licenceType === 'AP') {
+    if (licenceType === 'AP' || licenceType === 'AP_PSS') {
       textToDisplay = 'Licence end date'
       dateToDisplay = led
     }
 
-    if (licenceType === 'AP_PSS') {
-      textToDisplay = isToday(tussd) ? 'PSS end date' : 'Licence end date'
-      dateToDisplay = isToday(tussd) ? tused : led
-    }
+    const conditionsToDisplayTused =
+      (licenceType === 'AP_PSS' && tussd && isToday(tussd)) ||
+      (licenceType === 'AP_PSS' && !tussd && tused && led && isYesterday(led)) ||
+      licenceType === 'PSS'
 
-    if (licenceType === 'PSS') {
+    if (conditionsToDisplayTused) {
       textToDisplay = 'PSS end date'
       dateToDisplay = tused
     }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -10,6 +10,7 @@ import {
   stringToAddressObject,
   jsonDtTo12HourTime,
   jsonDtToDate,
+  toDate,
   removeDuplicates,
   filterCentralCaseload,
   jsonDtToDateWithDay,
@@ -148,6 +149,13 @@ describe('Convert date format', () => {
   it('should return YYYY-MM-DD date in format DD/MM/YYYY', () => {
     const date = '2015-04-26'
     expect(convertDateFormat(date)).toEqual('26/04/2015')
+  })
+})
+
+describe('Create date from string', () => {
+  it('should return date object', () => {
+    const dateString = '25/12/2022'
+    expect(toDate(dateString)).toStrictEqual(new Date('2022-12-25'))
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -110,6 +110,11 @@ const jsonDtTo12HourTime = (dt: string): string => {
   return momentTime.isValid() ? momentTime.format('hh:mm a') : null
 }
 
+const toDate = (date: string) => {
+  const [day, month, year] = date.split('/')
+  return new Date(`${year}-${month}-${day}`)
+}
+
 const removeDuplicates = (list: string[]): string[] => {
   return [...new Set(list)]
 }
@@ -200,6 +205,7 @@ export {
   jsonDtToDateShort,
   jsonDtToDateWithDay,
   jsonDtTo12HourTime,
+  toDate,
   convertDateFormat,
   removeDuplicates,
   filterCentralCaseload,

--- a/server/views/pages/create/checkAnswers.test.ts
+++ b/server/views/pages/create/checkAnswers.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
-import cheerio from 'cheerio'
+import * as cheerio from 'cheerio'
+import { addDays } from 'date-fns'
 import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../utils/nunjucksSetup'
 
@@ -402,5 +403,17 @@ describe('Create a Licence Views - Check Answers', () => {
     expect($('.govuk-summary-list__actions').length).toBe(0)
     expect($('.check-answers-header__change-link').length).toBe(0)
     expect($('[data-qa="send-licence-conditions"]').length).toBe(0)
+  })
+
+  it('should display correct date description for "non-vary" routes ', () => {
+    const tomorrow = addDays(new Date(), 1)
+
+    viewContext = {
+      isVaryJourney: false,
+      licence: { typeCode: 'AP', licenceExpiryDate: tomorrow },
+    }
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+    expect($('[data-qa=date]').text()).toContain('Release date')
+    expect($('[data-qa=date]').text()).not.toContain('Licence end date')
   })
 })

--- a/server/views/pages/vary/timeline.test.ts
+++ b/server/views/pages/vary/timeline.test.ts
@@ -51,4 +51,13 @@ describe('Timeline', () => {
     const $ = cheerio.load(compiledTemplate.render(viewContext))
     expect($('.moj-timeline__date').text()).not.toContain('Last update: ')
   })
+  it('should display correct date description for "vary" routes', () => {
+    viewContext = {
+      isVaryJourney: true,
+      licence: { typeCode: 'AP', licenceExpiryDate: '01/01/2022' },
+    }
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+    expect($('[data-qa=date]').text()).not.toContain('Release date: ')
+    expect($('[data-qa=date]').text()).toContain('Licence end date:')
+  })
 })

--- a/server/views/partials/licenceDetailsBanner.njk
+++ b/server/views/partials/licenceDetailsBanner.njk
@@ -8,7 +8,13 @@
                 {% if user.authSource == 'nomis' %}
                     <span class="pipe-separated__item">Prison number: {{ licence.nomsId }}</span>
                 {% endif %}
-                <span class="pipe-separated__item">Release date: {{ licence.actualReleaseDate | datetimeToDateShort or licence.conditionalReleaseDate | datetimeToDateShort }}</span>
+                    <span class="pipe-separated__item"  data-qa="date">
+                        {% if isVaryJourney %}
+                            {{ licence | dateToDisplay }} 
+                        {% else %} 
+                            Release date: {{ licence.actualReleaseDate | datetimeToDateShort or licence.conditionalReleaseDate | datetimeToDateShort }}
+                        {% endif %}
+                    </span>
                 <span class="pipe-separated__item">Date of birth: {{ licence.dateOfBirth | datetimeToDateShort }}</span>
             </div>
             <span class="govuk-heading-m">{{ licence.forename }} {{ licence.surname }}</span>


### PR DESCRIPTION
The date in header when displaying offender records is different for vary journey pages. 


**Jira ticket:**

<img width="483" alt="Screenshot 2022-11-24 at 11 18 31" src="https://user-images.githubusercontent.com/50441412/203771647-8e1e8537-1183-411e-a960-d84ade06ac03.png">

 