### PR TITLE
CVSL-637 fix accessibility issue

### DIFF
--- a/server/views/partials/header.njk
+++ b/server/views/partials/header.njk
@@ -2,10 +2,10 @@
     <div id="header-contents" class="govuk-width-container">
         <div id="site-header-block">
             <div id="logo">
-                <img alt="Ministry of Justice logo" src="/assets/images/crest.svg"/>
+                <img alt="" src="/assets/images/crest.svg"/>
             </div>
             <a id="hmpps-title" href="{{ authHome }}" class="govuk-header__link govuk-!-padding-top-1 govuk-!-padding-bottom-1">
-                HMPPS
+                HMPPS&nbsp;
             </a>
             <a id="main-title" href="/" class="govuk-header__link govuk-!-padding-top-1 govuk-!-padding-bottom-1">
                 {{applicationName}}


### PR DESCRIPTION
In the service header, make the alt attribute of the logo “null” and put a non-breaking space after “HMPPS”.