### PR TITLE
CVSL-639 make input accessibility compliant

### DIFF
--- a/server/views/pages/create/initialMeetingPerson.njk
+++ b/server/views/pages/create/initialMeetingPerson.njk
@@ -8,34 +8,45 @@
 {% set pageId = "appointment-person-page" %}
 {% set backLinkHref = "/licence/create/caseload" %}
 
+{% set contactName = licence.appointmentPerson | fillFormResponse(formResponses.contactName) %}
+{% set errorMessage = validationErrors | findError('contactName') %}
+{% set isError = errorMessage.text %}
+
 {% block content %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">Who is the initial appointment with?</h1>
-        </div>
-    </div>
     <form method="POST">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}">
         <div class="govuk-grid-row">
             <div class="govuk-grid-column-full">
-                {% if releaseIsOnBankHolidayOrWeekend %}
-                    {{ govukWarningText({
-                        text: "The release date is on a weekend or bank holiday. Check the release date with the prison OMU.",
-                        iconFallbackText: "Warning"
-                    }) }}
-                {% endif %}
+                <div class="govuk-form-group {{ "govuk-form-group--error" if isError }}">
+                    
+                    <h1 class="govuk-label-wrapper">
+                        <label class="govuk-label govuk-label--l" for="contactName"> 
+                            Who is the initial appointment with? 
+                        </label> 
+                    </h1> 
 
-                {{ govukInput({
-                    id: "contactName",
-                    name: "contactName",
-                    label: {
-                        text: "contact name",
-                        classes: "govuk-visually-hidden"
-                    },
-                    classes: "govuk-!-width-one-third",
-                    errorMessage: validationErrors | findError('contactName'),
-                    value: licence.appointmentPerson | fillFormResponse(formResponses.contactName)
-                }) }}
+                    {% if releaseIsOnBankHolidayOrWeekend %}
+                        {{ govukWarningText({
+                            text: "The release date is on a weekend or bank holiday. Check the release date with the prison OMU.",
+                            iconFallbackText: "Warning"
+                        }) }}
+                    {% endif %}
+                    
+                    {% if isError %}
+                        <p class="govuk-error-message">
+                            <span class="govuk-visually-hidden">Error:</span> {{ errorMessage.text }}
+                        </p>
+                    {% endif %}
+
+                    <input 
+                        class="govuk-input govuk-!-width-one-third {{ "govuk-input--error" if isError }}" 
+                        id="contactName" 
+                        name="contactName" 
+                        type="text"
+                        value="{{ contactName }}"
+                        aria-describedby="contactName"
+                        >  
+                </div>
 
                 {{ govukButton({
                     text: continueOrReturnToCheckAnswers,


### PR DESCRIPTION
AC: Implement the code in the ticket to make it easier for users of speech recognition software to navigate the page

Could have removed the H1 altogether and retained the govukInput nunjucks component and set isPageHeader to true. However there is an govukWarningText component (only displays if dates aren't compatible) that then wouldn't render in the correct place. It would sit above the H1. So have changed from using nunjucks component to straight HTML. 

**Retaining the nunjucks component would have presented like this**
<img width="600" alt="would have looked" src="https://user-images.githubusercontent.com/50441412/206128755-0636654a-873b-4e26-b54b-9103e93d1b3b.png">

**instead of** 
<img width="600" alt="required look" src="https://user-images.githubusercontent.com/50441412/206128776-8c15de2f-1d09-4ee1-947c-3590ff31f009.png">
