### PR TITLE
Changing confirmedReleaseDate from prisoner profile to ARD on the licence

### DIFF
--- a/jobs/updateLicences.ts
+++ b/jobs/updateLicences.ts
@@ -30,11 +30,8 @@ const pollLicencesToUpdate = async (): Promise<LicencesToUpdate> => {
    * and a confirmed release date exists, which is before or equal to today
    */
   const prisonersForRelease = prisonersWithApprovedLicences.filter(prisoner => {
-    return (
-      (prisoner.status.startsWith('INACTIVE') || prisoner.legalStatus === 'IMMIGRATION_DETAINEE') &&
-      prisoner.confirmedReleaseDate &&
-      moment(prisoner.confirmedReleaseDate, 'YYYY-MM-DD').isSameOrBefore(moment())
-    )
+    const licence = approvedLicences.find(l => l.nomisId === prisoner.prisonerNumber)
+    return validPrisonerForRelease(prisoner) && isPassedArd(licence)
   })
 
   const prisonerNumbers = prisonersForRelease.map(prisoner => prisoner.prisonerNumber)
@@ -110,6 +107,14 @@ const batchInactivateLicences = async (licenceIds: number[]): Promise<void> => {
   if (licenceIds.length > 0) {
     await new LicenceApiClient().batchInActivateLicences(licenceIds)
   }
+}
+
+const validPrisonerForRelease = (prisoner: Prisoner): boolean => {
+  return prisoner.status.startsWith('INACTIVE') || prisoner.legalStatus === 'IMMIGRATION_DETAINEE'
+}
+
+const isPassedArd = (licence: LicenceSummary): boolean => {
+  return licence.actualReleaseDate && moment(licence.actualReleaseDate, 'YYYY-MM-DD').isSameOrBefore(moment())
 }
 
 pollLicencesToUpdate()

--- a/jobs/updateLicences.ts
+++ b/jobs/updateLicences.ts
@@ -31,7 +31,7 @@ const pollLicencesToUpdate = async (): Promise<LicencesToUpdate> => {
    */
   const prisonersForRelease = prisonersWithApprovedLicences.filter(prisoner => {
     const licence = approvedLicences.find(l => l.nomisId === prisoner.prisonerNumber)
-    return validPrisonerForRelease(prisoner) && isPassedArdOrCrd(licence)
+    return validPrisonerForRelease(prisoner) && isPassedArdOrCrd(licence, prisoner)
   })
 
   const prisonerNumbers = prisonersForRelease.map(prisoner => prisoner.prisonerNumber)
@@ -113,8 +113,14 @@ const validPrisonerForRelease = (prisoner: Prisoner): boolean => {
   return prisoner.status.startsWith('INACTIVE') || prisoner.legalStatus === 'IMMIGRATION_DETAINEE'
 }
 
-const isPassedArdOrCrd = (licence: LicenceSummary): boolean => {
-  const releaseDate = licence.actualReleaseDate || licence.conditionalReleaseDate
+const isPassedArdOrCrd = (licence: LicenceSummary, prisoner: Prisoner): boolean => {
+  let releaseDate
+
+  if (prisoner.legalStatus === 'IMMIGRATION_DETAINEE') {
+    releaseDate = licence.actualReleaseDate || licence.conditionalReleaseDate
+  } else {
+    releaseDate = licence.actualReleaseDate
+  }
 
   if (releaseDate) {
     return moment(releaseDate, 'YYYY-MM-DD').isSameOrBefore(moment())

--- a/jobs/updateLicences.ts
+++ b/jobs/updateLicences.ts
@@ -31,7 +31,7 @@ const pollLicencesToUpdate = async (): Promise<LicencesToUpdate> => {
    */
   const prisonersForRelease = prisonersWithApprovedLicences.filter(prisoner => {
     const licence = approvedLicences.find(l => l.nomisId === prisoner.prisonerNumber)
-    return validPrisonerForRelease(prisoner) && isPassedArd(licence)
+    return validPrisonerForRelease(prisoner) && isPassedArdOrCrd(licence)
   })
 
   const prisonerNumbers = prisonersForRelease.map(prisoner => prisoner.prisonerNumber)
@@ -113,8 +113,14 @@ const validPrisonerForRelease = (prisoner: Prisoner): boolean => {
   return prisoner.status.startsWith('INACTIVE') || prisoner.legalStatus === 'IMMIGRATION_DETAINEE'
 }
 
-const isPassedArd = (licence: LicenceSummary): boolean => {
-  return licence.actualReleaseDate && moment(licence.actualReleaseDate, 'YYYY-MM-DD').isSameOrBefore(moment())
+const isPassedArdOrCrd = (licence: LicenceSummary): boolean => {
+  const releaseDate = licence.actualReleaseDate || licence.conditionalReleaseDate
+
+  if (releaseDate) {
+    return moment(releaseDate, 'YYYY-MM-DD').isSameOrBefore(moment())
+  }
+
+  return false
 }
 
 pollLicencesToUpdate()

--- a/server/listeners/eventHandlers/prisonEvents/datesChangedEventHandler.test.ts
+++ b/server/listeners/eventHandlers/prisonEvents/datesChangedEventHandler.test.ts
@@ -166,7 +166,7 @@ describe('Sentence dates changed event handler', () => {
   it('should not update sentence dates if the offender is an IS91 case and has a CRD in the past', async () => {
     const is91Prisoner = {
       ...prisoner,
-      imprisonmentStatus: 'DET',
+      legalStatus: 'IMMIGRATION_DETAINEE',
     } as PrisonApiPrisoner
 
     prisonerService.getPrisonerDetail.mockResolvedValue(is91Prisoner)
@@ -195,7 +195,7 @@ describe('Sentence dates changed event handler', () => {
   it('should not update sentence dates if the offender is an IS91 case and has a ARD of today', async () => {
     const is91Prisoner = {
       ...prisoner,
-      imprisonmentStatus: 'DET',
+      legalStatus: 'IMMIGRATION_DETAINEE',
     } as PrisonApiPrisoner
 
     prisonerService.getPrisonerDetail.mockResolvedValue(is91Prisoner)
@@ -224,7 +224,7 @@ describe('Sentence dates changed event handler', () => {
   it('should update the sentence dates if the offender is an IS91 case and has an ARD in the future', async () => {
     const is91Prisoner = {
       ...prisoner,
-      imprisonmentStatus: 'DET',
+      legalStatus: 'IMMIGRATION_DETAINEE',
     } as PrisonApiPrisoner
 
     prisonerService.getPrisonerDetail.mockResolvedValue(is91Prisoner)
@@ -258,7 +258,7 @@ describe('Sentence dates changed event handler', () => {
   it('should update the sentence dates if the offender is an IS91 case but it has no ARD', async () => {
     const is91Prisoner = {
       ...prisoner,
-      imprisonmentStatus: 'DET',
+      legalStatus: 'IMMIGRATION_DETAINEE',
     } as PrisonApiPrisoner
 
     prisonerService.getPrisonerDetail.mockResolvedValue(is91Prisoner)

--- a/server/listeners/eventHandlers/prisonEvents/datesChangedEventHandler.ts
+++ b/server/listeners/eventHandlers/prisonEvents/datesChangedEventHandler.ts
@@ -30,7 +30,7 @@ export default class DatesChangedEventHandler {
 
       // IS91 cases receive an update that wipes their CRD when their CRD passes.
       // We want to keep it in the service, so we should ignore any date-changing events that meet this criteria.
-      if (['DET', 'RECEP_IMM'].includes(prisoner.imprisonmentStatus) && isPassedArdOrCrd(licence)) {
+      if (prisoner.legalStatus === 'IMMIGRATION_DETAINEE' && isPassedArdOrCrd(licence)) {
         logger.info(
           `Ignoring date update event for NOMIS ID: ${nomisId}, CRN: ${licence.crn}, licence ID: ${licence.licenceId}`
         )


### PR DESCRIPTION
Changing licence activation check to use the ARD on the licence rather than confirmedReleaseDate in NOMIS

Explanation:
When an offender has an IS91 warrant as their primary conviction (resulting in the legalStatus being `IMMIGRATION_DETAINEE`), the confirmedReleaseDate in NOMIS will always be `NULL`. As such, we need to use the actualReleaseDate/ARD that's stored (and preserved) on the licence.

Also changing datesChangedEventHandler to use legalStatus rather than imprisonmentStatus for consistency, and to cover very rare edge cases.