### PR TITLE
CVSL-465 handle licence in PSS period

### DIFF
--- a/server/enumeration/licenceStatus.ts
+++ b/server/enumeration/licenceStatus.ts
@@ -14,6 +14,8 @@ enum LicenceStatus {
   NOT_IN_PILOT = 'NOT_IN_PILOT',
   OOS_BOTUS = 'OOS_BOTUS',
   OOS_RECALL = 'OOS_RECALL',
+  // ON_PSS status is not saved within licence and only added here in order to show it as a label in the UI
+  ON_PSS = 'ON_PSS',
 }
 
 export default LicenceStatus

--- a/server/licences/licenceStatus.ts
+++ b/server/licences/licenceStatus.ts
@@ -82,6 +82,12 @@ const statusConfig: Record<LicenceStatus, LicenceStatusConfig> = {
     description: 'Recall',
     colour: 'grey',
   },
+  // ON_PSS status is not saved within licence and only added here in order to show it as a label in the UI
+  ON_PSS: {
+    label: 'On PSS',
+    description: 'On PSS',
+    colour: 'turquoise',
+  },
 }
 
 export default statusConfig

--- a/server/utils/nunjucksSetup.test.ts
+++ b/server/utils/nunjucksSetup.test.ts
@@ -1,5 +1,5 @@
 import * as cheerio from 'cheerio'
-import { format, addDays, subDays, addMonths } from 'date-fns'
+import { format, addDays, subDays, addMonths, startOfYesterday, startOfTomorrow } from 'date-fns'
 import nunjucks, { Template } from 'nunjucks'
 import ConditionService from '../services/conditionService'
 import { registerNunjucks } from './nunjucksSetup'
@@ -317,6 +317,34 @@ describe('Nunjucks Filters', () => {
       const licence = { typeCode: 'PSS', topupSupervisionExpiryDate: '13/12/2022' } as Licence
       const result = njkEnv.getFilter('dateToDisplay')(licence)
       expect(result).toEqual('PSS end date: 13 Dec 2022')
+    })
+  })
+  describe('check if AP_PSS licence is within pss period', () => {
+    it('should return true when today is in PSS period', () => {
+      const yesterday = format(startOfYesterday(), 'dd/MM/yyyy')
+      const tomorrow = format(startOfTomorrow(), 'dd/MM/yyyy')
+      const licence = { topupSupervisionStartDate: yesterday, topupSupervisionExpiryDate: tomorrow }
+      const result = njkEnv.getFilter('isApPssWithinPssPeriod')(licence)
+      expect(result).toEqual(true)
+    })
+    it('should return false when today is before PSS period', () => {
+      const tomorrow = format(startOfTomorrow(), 'dd/MM/yyyy')
+      const licence = { topupSupervisionStartDate: tomorrow, topupSupervisionExpiryDate: tomorrow }
+      const result = njkEnv.getFilter('isApPssWithinPssPeriod')(licence)
+      expect(result).toEqual(false)
+    })
+    it('should return false when today is after PSS period', () => {
+      const yesterday = format(startOfYesterday(), 'dd/MM/yyyy')
+      const licence = { topupSupervisionStartDate: yesterday, topupSupervisionExpiryDate: yesterday }
+      const result = njkEnv.getFilter('isApPssWithinPssPeriod')(licence)
+      expect(result).toEqual(false)
+    })
+
+    it('should handle missing date', () => {
+      const yesterday = format(startOfYesterday(), 'dd/MM/yyyy')
+      const licence = { topupSupervisionStartDate: null as string, topupSupervisionExpiryDate: yesterday }
+      const result = njkEnv.getFilter('isApPssWithinPssPeriod')(licence)
+      expect(result).toEqual(false)
     })
   })
 })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -14,6 +14,8 @@ import {
   jsonDtToDateShort,
   jsonDtToDateWithDay,
   toDate,
+  isWithinPssPeriod,
+  reformatDate,
 } from './utils'
 import { AdditionalCondition, AdditionalConditionData, Licence } from '../@types/licenceApiClientTypes'
 import SimpleTime from '../routes/creatingLicences/types/time'
@@ -282,6 +284,13 @@ export function registerNunjucks(conditionService: ConditionService, app?: expre
     }
 
     return `${textToDisplay}: Not available`
+  })
+
+  njkEnv.addFilter('isApPssWithinPssPeriod', (licence: Licence) => {
+    return isWithinPssPeriod(
+      reformatDate(licence.topupSupervisionStartDate),
+      reformatDate(licence.topupSupervisionExpiryDate)
+    )
   })
 
   return njkEnv

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,6 +1,6 @@
 import moment, { Moment } from 'moment'
 import { Holiday } from 'uk-bank-holidays'
-import { format } from 'date-fns'
+import { format, startOfToday, startOfDay } from 'date-fns'
 import AuthRole from '../enumeration/authRole'
 import SimpleDateTime from '../routes/creatingLicences/types/simpleDateTime'
 import SimpleDate from '../routes/creatingLicences/types/date'
@@ -37,6 +37,17 @@ const hasAuthSource = (user: Express.User, source: string): boolean => user?.aut
  * @returns date converted to format DD/MM/YYYY.
  */
 const convertDateFormat = (date: string): string => (date ? moment(date, 'YYYY-MM-DD').format('DD/MM/YYYY') : undefined)
+
+/**
+ * converts dd/mm/yyyy to yyyy-mm-dd so that it can be consumed by new Date()
+ */
+const reformatDate = (date: string) => {
+  if (date) {
+    const [day, month, year] = date.split('/')
+    return `${year}-${month}-${day}`
+  }
+  return undefined
+}
 
 /**
  * Converts a SimpleDateTime display value to a JSON string format dd/mm/yyyy hh:mm
@@ -192,6 +203,13 @@ const selectReleaseDate = (nomisRecord: Prisoner) => {
   return dateString
 }
 
+const isWithinPssPeriod = (topupSupervisionStartDate: string, topupSupervisionExpiryDate: string) => {
+  const today = startOfToday()
+  const tussd = topupSupervisionStartDate ? startOfDay(new Date(topupSupervisionStartDate)) : undefined
+  const tused = topupSupervisionExpiryDate ? startOfDay(new Date(topupSupervisionExpiryDate)) : undefined
+  return today >= tussd && today < tused
+}
+
 export {
   convertToTitleCase,
   hasRole,
@@ -206,6 +224,7 @@ export {
   jsonDtToDateWithDay,
   jsonDtTo12HourTime,
   toDate,
+  reformatDate,
   convertDateFormat,
   removeDuplicates,
   filterCentralCaseload,
@@ -214,4 +233,5 @@ export {
   isBankHolidayOrWeekend,
   licenceIsTwoDaysToRelease,
   selectReleaseDate,
+  isWithinPssPeriod,
 }

--- a/server/views/layout.njk
+++ b/server/views/layout.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set continueOrReturnToCheckAnswers = "Return to check your answers" if fromReview else "Continue" %}
 

--- a/server/views/pages/vary/caseload.test.ts
+++ b/server/views/pages/vary/caseload.test.ts
@@ -3,6 +3,7 @@ import * as cheerio from 'cheerio'
 import nunjucks, { Template } from 'nunjucks'
 import { registerNunjucks } from '../../../utils/nunjucksSetup'
 import ConditionService from '../../../services/conditionService'
+import statusConfig from '../../../licences/licenceStatus'
 
 const snippet = fs.readFileSync('server/views/pages/vary/caseload.njk')
 
@@ -31,24 +32,13 @@ describe('Caseload', () => {
           probationPractitioner: { staffCode: 'X12342', name: 'CVL COM' },
         },
       ],
-      statusConfig: {
-        ACTIVE: {
-          label: 'Active',
-          description: 'Approved by the prison and is now the currently active licence',
-          colour: 'turquoise',
-        },
-        VARIATION_IN_PROGRESS: {
-          label: 'Variation in progress',
-          description: 'Variation in progress',
-          colour: 'blue',
-        },
-      },
+      statusConfig,
     }
     const $ = cheerio.load(compiledTemplate.render(viewContext))
     expect($('.status-badge')).toHaveLength(0)
   })
 
-  it('should display badge', () => {
+  it('should display Variation in progress badge', () => {
     viewContext = {
       caseload: [
         {
@@ -61,21 +51,30 @@ describe('Caseload', () => {
           probationPractitioner: { staffCode: 'X12342', name: 'CVL COM' },
         },
       ],
-      statusConfig: {
-        ACTIVE: {
-          label: 'Active',
-          description: 'Approved by the prison and is now the currently active licence',
-          colour: 'turquoise',
-        },
-        VARIATION_IN_PROGRESS: {
-          label: 'Variation in progress',
-          description: 'Variation in progress',
-          colour: 'blue',
-        },
-      },
+      statusConfig,
     }
 
     const $ = cheerio.load(compiledTemplate.render(viewContext))
     expect($('.status-badge').text().toString()).toContain('Variation in progress')
+  })
+
+  it('should display On PSS badge', () => {
+    viewContext = {
+      caseload: [
+        {
+          licenceId: 3,
+          name: 'Biydaav Griya',
+          crnNumber: 'Z882661',
+          licenceType: 'AP_PSS',
+          releaseDate: '13 Feb 2023',
+          licenceStatus: 'ON_PSS',
+          probationPractitioner: { staffCode: 'X12342', name: 'CVL COM' },
+        },
+      ],
+      statusConfig,
+    }
+
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+    expect($('.status-badge').text().toString()).toContain('On PSS')
   })
 })

--- a/server/views/pages/vary/confirmVaryQuestion.njk
+++ b/server/views/pages/vary/confirmVaryQuestion.njk
@@ -6,11 +6,16 @@
 {% set pageTitle = applicationName + " - Vary a licence - Are you sure?" %}
 {% set pageId = "confirm-vary-question-page" %}
 {% set backLinkHref = "/licence/vary/id/" + licence.id + "/view" %}
-
+{% set apPssLicenceIsWithinPssPeriod = licence | isApPssWithinPssPeriod %}
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-three-quarters">
-            <h1 class="govuk-heading-l">Are you sure you want to vary this licence?</h1>
+            {% if licence.typeCode === 'AP_PSS' and apPssLicenceIsWithinPssPeriod %}
+                <h1 class="govuk-heading-l">Are you sure you want to vary this post sentence supervision order?</h1>
+                <p class="govuk-hint">This person reached their LED on {{licence.licenceExpiryDate | datetimeToDateShort}}, so only their post sentence supervision order can be varied.</p>
+            {% else %}
+                <h1 class="govuk-heading-l">Are you sure you want to vary this licence?</h1>
+            {% endif %}
         </div>
     </div>
     <form method="POST">

--- a/server/views/pages/vary/confirmVaryQuestion.test.ts
+++ b/server/views/pages/vary/confirmVaryQuestion.test.ts
@@ -1,0 +1,48 @@
+import fs from 'fs'
+import * as cheerio from 'cheerio'
+import { format, addDays, subDays } from 'date-fns'
+import nunjucks, { Template } from 'nunjucks'
+import { registerNunjucks } from '../../../utils/nunjucksSetup'
+import ConditionService from '../../../services/conditionService'
+
+const snippet = fs.readFileSync('server/views/pages/vary/confirmVaryQuestion.njk')
+
+describe('Confirm vary', () => {
+  let compiledTemplate: Template
+  let viewContext: Record<string, unknown>
+
+  const conditionService = new ConditionService(null) as jest.Mocked<ConditionService>
+  const njkEnv = registerNunjucks(conditionService)
+
+  beforeEach(() => {
+    compiledTemplate = nunjucks.compile(snippet.toString(), njkEnv)
+    viewContext = {}
+  })
+
+  it('should display the hint text', () => {
+    viewContext = {
+      licence: {
+        typeCode: 'AP_PSS',
+        topupSupervisionStartDate: '19/12/2022',
+        topupSupervisionExpiryDate: format(addDays(new Date(), 10), 'dd/MM/yyyy'),
+        licenceExpiryDate: '18/12/2022',
+      },
+    }
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+    expect($('.govuk-hint').text()).toContain(
+      'This person reached their LED on 18 Dec 2022, so only their post sentence supervision order can be varied.'
+    )
+  })
+  it('should not display the hint text', () => {
+    viewContext = {
+      licence: {
+        typeCode: 'AP_PSS',
+        topupSupervisionStartDate: format(subDays(new Date(), 10), 'dd/MM/yyyy'),
+        topupSupervisionExpiryDate: format(subDays(new Date(), 8), 'dd/MM/yyyy'),
+        licenceExpiryDate: '18/12/2022',
+      },
+    }
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+    expect($('.govuk-hint').text().length).toBe(0)
+  })
+})

--- a/server/views/pages/vary/viewActive.njk
+++ b/server/views/pages/vary/viewActive.njk
@@ -10,6 +10,7 @@
 {% set pageTitle = applicationName + " - Vary a licence - Active licence" %}
 {% set pageId = "view-active-licence-page" %}
 {% set backLinkHref = "/licence/vary/caseload" %}
+{% set apPssLicenceIsWithinPssPeriod = licence | isApPssWithinPssPeriod %}
 
 {% block content %}
     <div class="govuk-grid-row">
@@ -28,12 +29,28 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
-            {% if licence.typeCode === 'AP' or licence.typeCode === 'AP_PSS' %}
+            {% if (licence.typeCode === 'AP' or licence.typeCode === 'AP_PSS') and not apPssLicenceIsWithinPssPeriod %}
                 {{ additionalLicenceConditions(licence, additionalConditions, conditionsWithUploads, null, [], 'Additional licence conditions') }}
                 {{ bespokeConditions(licence, null, 'Bespoke licence conditions') }}
             {% endif %}
+
             {% if licence.typeCode === 'PSS' or licence.typeCode === 'AP_PSS' %}
                 {{ additionalPssConditions(licence, null, [], 'Additional post sentence supervision requirements') }}
+            {% endif %}
+
+            {% if licence.typeCode === 'AP_PSS' and apPssLicenceIsWithinPssPeriod %}
+                <h2 class="govuk-heading-m" data-qa='expired-licence-heading'>Conditions from expired licence </h2>
+
+                <p  data-qa='expired-licence-text'>This person reached their LED on {{licence.licenceExpiryDate | datetimeToDateShort}}, so the conditions from their standard determinate 
+                    licence can no longer be varied. </p>
+  
+                     
+                {{ govukDetails({
+                    summaryText: "View conditions from expired licence",
+                    html:   additionalLicenceConditions(licence, additionalConditions, conditionsWithUploads, null, [], 'Additional licence conditions') 
+                            + bespokeConditions(licence, null, 'Bespoke licence conditions')
+                }) }}
+
             {% endif %}
         </div>
     </div>

--- a/server/views/pages/vary/viewActive.test.ts
+++ b/server/views/pages/vary/viewActive.test.ts
@@ -1,0 +1,55 @@
+import fs from 'fs'
+import * as cheerio from 'cheerio'
+import nunjucks, { Template } from 'nunjucks'
+import { addDays, format } from 'date-fns'
+import { registerNunjucks } from '../../../utils/nunjucksSetup'
+import ConditionService from '../../../services/conditionService'
+import { AdditionalConditionPss } from '../../../@types/licenceApiClientTypes'
+
+const snippet = fs.readFileSync('server/views/pages/vary/viewActive.njk')
+
+describe('View active licence', () => {
+  let compiledTemplate: Template
+
+  const conditionService = new ConditionService(null) as jest.Mocked<ConditionService>
+  conditionService.getAdditionalConditionByCode = jest.fn()
+  conditionService.getAdditionalConditionByCode.mockResolvedValue({} as AdditionalConditionPss)
+  const njkEnv = registerNunjucks(conditionService)
+
+  beforeEach(() => {
+    compiledTemplate = nunjucks.compile(snippet.toString(), njkEnv)
+  })
+
+  let viewContext = {} as unknown as Record<string, unknown>
+
+  it('should display the Conditions from expired licence section', () => {
+    viewContext = {
+      licence: {
+        typeCode: 'AP_PSS',
+        topupSupervisionStartDate: '19/12/2022',
+        topupSupervisionExpiryDate: format(addDays(new Date(), 10), 'dd/MM/yyyy'),
+        licenceExpiryDate: '18/12/2022',
+      },
+    }
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+    expect($('[data-qa=expired-licence-heading]')).toHaveLength(1)
+    expect($('[data-qa=expired-licence-text]')).toHaveLength(1)
+    expect($('[data-qa=expired-licence-text]').text()).toContain('This person reached their LED on 18 Dec 2022, so')
+    expect($('.govuk-details__summary-text')).toHaveLength(1)
+  })
+
+  it('should NOT display the Conditions from expired licence section', () => {
+    viewContext = {
+      licence: {
+        typeCode: 'AP_PSS',
+        topupSupervisionStartDate: format(addDays(new Date(), 2), 'dd/MM/yyyy'),
+        topupSupervisionExpiryDate: format(addDays(new Date(), 10), 'dd/MM/yyyy'),
+        licenceExpiryDate: '18/12/2022',
+      },
+    }
+    const $ = cheerio.load(compiledTemplate.render(viewContext))
+    expect($('[data-qa=expired-licence-heading]')).toHaveLength(0)
+    expect($('[data-qa=expired-licence-text]')).toHaveLength(0)
+    expect($('.govuk-details__summary-text')).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
The changes in this PR relate to AC's 1, 2 and 3 out of 7. So 4,5,6 and 7 still need doing
The tests for all the new code are done but _may_ want to add more for viewActive.njk or integration tests.

The vary caseload needs to display the 'On PSS' badge for all AP_PSS cases that are between the tussd and tused. 
Have created  isWithinPssPeriod utility to compare the dates and used it inside the caseload.ts  controller as it already loops through every case. 
Have added logging to help fault finding when dates are missing. 

In contrast to caseload.ts  viewActive and confirmVaryQuestions pages target a single offender and for those pages, the checks on whether the licence is of type AP_PSS and whether it is within the PSS period are done in the HTML. The logic here still accesses the isWithinPssPeriod function hence the reason the isWithinPssPeriod was extracted out into the common utility.ts.

