### PR TITLE
refs cvsl-768

### DIFF
--- a/server/routes/support/handlers/offenderAudit.ts
+++ b/server/routes/support/handlers/offenderAudit.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from 'express'
 import _ from 'lodash'
-import moment from 'moment'
+import { subYears } from 'date-fns'
 import LicenceService from '../../../services/licenceService'
 import PrisonerService from '../../../services/prisonerService'
 import { convertToTitleCase } from '../../../utils/utils'
@@ -16,8 +16,8 @@ export default class OffenderAuditRoutes {
     const audit = await this.licenceServer.getAuditEvents(
       parseInt(licenceId, 10),
       null,
-      moment().subtract(2, 'years').toDate(),
-      moment().toDate(),
+      subYears(new Date(), 2),
+      new Date(),
       user
     )
 

--- a/server/services/licenceService.test.ts
+++ b/server/services/licenceService.test.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream'
-import moment from 'moment'
+import { format, parse } from 'date-fns'
 import { User } from '../@types/CvlUserDetails'
 import LicenceApiClient from '../data/licenceApiClient'
 import LicenceService from './licenceService'
@@ -859,16 +859,16 @@ describe('Licence Service', () => {
   })
 
   describe('Audit events', () => {
-    const eventTime = moment('13/01/2022 11:00:00', 'DD/MM/YYYY HH:mm:ss').toDate()
-    const eventStart = moment('12/01/2022 10:45:00', 'DD/MM/YYYY HH:mm:ss').toDate()
-    const eventEnd = moment('13/01/2022 10:45:00', 'DD/MM/YYYY HH:mm:ss').toDate()
+    const eventTime = parse('13/01/2022 11:00:00', 'dd/MM/yyyy HH:mm:ss', new Date())
+    const eventStart = parse('12/01/2022 10:45:00', 'dd/MM/yyyy HH:mm:ss', new Date())
+    const eventEnd = parse('13/01/2022 10:45:00', 'dd/MM/yyyy HH:mm:ss', new Date())
 
     it('will record a new audit event', async () => {
       await licenceService.recordAuditEvent('Summary', 'Detail', 1, eventTime, user)
       expect(licenceApiClient.recordAuditEvent).toHaveBeenCalledWith(
         {
           username: user.username,
-          eventTime: moment(eventTime).format('DD/MM/YYYY HH:mm:ss'),
+          eventTime: format(eventTime, 'dd/MM/yyyy HH:mm:ss'),
           eventType: 'USER_EVENT',
           licenceId: 1,
           fullName: `${user.firstName} ${user.lastName}`,
@@ -885,8 +885,8 @@ describe('Licence Service', () => {
         {
           username: 'username',
           licenceId: null,
-          startTime: moment(eventStart).format('DD/MM/YYYY HH:mm:ss'),
-          endTime: moment(eventEnd).format('DD/MM/YYYY HH:mm:ss'),
+          startTime: format(eventStart, 'dd/MM/yyyy HH:mm:ss'),
+          endTime: format(eventEnd, 'dd/MM/yyyy HH:mm:ss'),
         },
         user
       )
@@ -898,8 +898,8 @@ describe('Licence Service', () => {
         {
           username: null,
           licenceId: 1,
-          startTime: moment(eventStart).format('DD/MM/YYYY HH:mm:ss'),
-          endTime: moment(eventEnd).format('DD/MM/YYYY HH:mm:ss'),
+          startTime: format(eventStart, 'dd/MM/yyyy HH:mm:ss'),
+          endTime: format(eventEnd, 'dd/MM/yyyy HH:mm:ss'),
         },
         user
       )

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'stream'
 import fs from 'fs'
-import moment from 'moment'
 import _ from 'lodash'
+import { format } from 'date-fns'
 import {
   AdditionalCondition,
   AdditionalConditionsRequest,
@@ -456,7 +456,7 @@ export default class LicenceService {
   ): Promise<void> {
     const requestBody = {
       username: user.username,
-      eventTime: moment(eventTime).format('DD/MM/YYYY HH:mm:ss'),
+      eventTime: format(eventTime, 'dd/MM/yyyy HH:mm:ss'),
       eventType: user ? 'USER_EVENT' : 'SYSTEM_EVENT',
       licenceId,
       fullName: `${user.firstName} ${user.lastName}`,
@@ -477,8 +477,8 @@ export default class LicenceService {
     const requestBody = {
       username: forUsername || null,
       licenceId: forLicenceId || null,
-      startTime: moment(startTime).format('DD/MM/YYYY hh:mm:ss'),
-      endTime: moment(endTime).format('DD/MM/YYYY hh:mm:ss'),
+      startTime: format(startTime, 'dd/MM/yyyy HH:mm:ss'),
+      endTime: format(endTime, 'dd/MM/yyyy HH:mm:ss'),
     } as AuditRequest
 
     return this.licenceApiClient.getAuditEvents(requestBody, user)


### PR DESCRIPTION
Replace moment with date-fns and use the correct date format specified in the API schema. The correct date format for use with the CVL API is 'dd/MM/yyyy HH:mm:ss'