### PR TITLE
CVSL-820 - Adding username to API call when overriding licence status so it's visible in the audit log

### DIFF
--- a/server/data/licenceApiClient.test.ts
+++ b/server/data/licenceApiClient.test.ts
@@ -467,11 +467,16 @@ describe('Licence API client tests', () => {
   })
 
   it('Override licence status code', async () => {
-    await licenceApiClient.overrideStatusCode(1, { reason: 'Test Reason', statusCode: LicenceStatus.APPROVED })
-    expect(post).toHaveBeenCalledWith({
-      path: `/licence/id/1/override/status`,
-      data: { reason: 'Test Reason', statusCode: LicenceStatus.APPROVED },
-    })
+    await licenceApiClient.overrideStatusCode(1, { reason: 'Test Reason', statusCode: LicenceStatus.APPROVED }, {
+      username: 'Test User',
+    } as User)
+    expect(post).toHaveBeenCalledWith(
+      {
+        path: `/licence/id/1/override/status`,
+        data: { reason: 'Test Reason', statusCode: LicenceStatus.APPROVED },
+      },
+      { username: 'Test User' }
+    )
   })
 
   describe('Exclusion zone file', () => {

--- a/server/data/licenceApiClient.ts
+++ b/server/data/licenceApiClient.ts
@@ -422,7 +422,7 @@ export default class LicenceApiClient extends RestClient {
     })
   }
 
-  async overrideStatusCode(licenceId: number, request: { reason: string; statusCode: LicenceStatus }) {
-    await this.post({ path: `/licence/id/${licenceId}/override/status`, data: request })
+  async overrideStatusCode(licenceId: number, request: { reason: string; statusCode: LicenceStatus }, user?: User) {
+    await this.post({ path: `/licence/id/${licenceId}/override/status`, data: request }, { username: user?.username })
   }
 }

--- a/server/routes/support/handlers/offenderLicenceStatus.test.ts
+++ b/server/routes/support/handlers/offenderLicenceStatus.test.ts
@@ -5,6 +5,7 @@ import OffenderLicenceStatusRoutes from './offenderLicenceStatus'
 import LicenceStatus from '../../../enumeration/licenceStatus'
 import { LicenceSummary } from '../../../@types/licenceApiClientTypes'
 import statusConfig from '../../../licences/licenceStatus'
+import { User } from '../../../@types/CvlUserDetails'
 
 const licenceService = new LicenceService(null, null, null, null) as jest.Mocked<LicenceService>
 const overrideService = new LicenceOverrideService(null) as jest.Mocked<LicenceOverrideService>
@@ -31,11 +32,13 @@ describe('Route Handlers - Licence Status Override', () => {
     } as LicenceSummary,
   ]
 
+  const user = { username: 'Test User' } as User
+
   beforeEach(() => {
     jest.resetAllMocks()
     res = {
       locals: {
-        user: {},
+        user,
       },
       render: jest.fn(),
       redirect: jest.fn(),
@@ -89,7 +92,12 @@ describe('Route Handlers - Licence Status Override', () => {
 
       await handler.POST(req, res)
 
-      expect(overrideService.overrideStatusCode).toHaveBeenCalledWith(1, LicenceStatus.APPROVED.toString(), reason)
+      expect(overrideService.overrideStatusCode).toHaveBeenCalledWith(
+        1,
+        LicenceStatus.APPROVED.toString(),
+        reason,
+        user
+      )
 
       expect(res.redirect).toHaveBeenCalledWith(`/support/offender/ABC123/licences`)
     })

--- a/server/routes/support/handlers/offenderLicenceStatus.ts
+++ b/server/routes/support/handlers/offenderLicenceStatus.ts
@@ -50,7 +50,7 @@ export default class OffenderLicenceStatusRoutes {
     const { status, statusChangeReason } = req.body
 
     if (status && statusChangeReason) {
-      await this.licenceOverrideService.overrideStatusCode(parseInt(licenceId, 10), status, statusChangeReason)
+      await this.licenceOverrideService.overrideStatusCode(parseInt(licenceId, 10), status, statusChangeReason, user)
       res.redirect(`/support/offender/${nomsId}/licences`)
       return
     }

--- a/server/services/licenceOverrideService.test.ts
+++ b/server/services/licenceOverrideService.test.ts
@@ -1,6 +1,7 @@
 import LicenceApiClient from '../data/licenceApiClient'
 import LicenceOverrideService from './licenceOverrideService'
 import LicenceStatus from '../enumeration/licenceStatus'
+import { User } from '../@types/CvlUserDetails'
 
 jest.mock('../data/licenceApiClient')
 
@@ -8,10 +9,14 @@ describe('Licence Override Service', () => {
   const licenceApiClient = new LicenceApiClient() as jest.Mocked<LicenceApiClient>
   const overrideStatus = new LicenceOverrideService(licenceApiClient)
   it('Updates licence status code', () => {
-    overrideStatus.overrideStatusCode(1, LicenceStatus.IN_PROGRESS, 'Test Reason')
-    expect(licenceApiClient.overrideStatusCode).toHaveBeenCalledWith(1, {
-      statusCode: LicenceStatus.IN_PROGRESS,
-      reason: 'Test Reason',
-    })
+    overrideStatus.overrideStatusCode(1, LicenceStatus.IN_PROGRESS, 'Test Reason', { username: 'Test User' } as User)
+    expect(licenceApiClient.overrideStatusCode).toHaveBeenCalledWith(
+      1,
+      {
+        statusCode: LicenceStatus.IN_PROGRESS,
+        reason: 'Test Reason',
+      },
+      { username: 'Test User' }
+    )
   })
 })

--- a/server/services/licenceOverrideService.ts
+++ b/server/services/licenceOverrideService.ts
@@ -1,14 +1,15 @@
+import { User } from '../@types/CvlUserDetails'
 import LicenceApiClient from '../data/licenceApiClient'
 import LicenceStatus from '../enumeration/licenceStatus'
 
 export default class LicenceOverrideService {
   constructor(private licenceApiClient: LicenceApiClient) {}
 
-  async overrideStatusCode(licenceId: number, statusCode: LicenceStatus, reason: string) {
+  async overrideStatusCode(licenceId: number, statusCode: LicenceStatus, reason: string, user?: User) {
     const request = {
       statusCode,
       reason,
     }
-    await this.licenceApiClient.overrideStatusCode(licenceId, request)
+    await this.licenceApiClient.overrideStatusCode(licenceId, request, user)
   }
 }


### PR DESCRIPTION
Fixes issue where CVL-staff usernames were not visible in the audit log when overriding a licence status.