### PR TITLE
CVSL-720 - Swapping probation search for Community API

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -92,6 +92,7 @@ export default defineConfig({
         stubGetAnOffendersManagers: community.stubGetAnOffendersManagers,
         stubGetUserDetailsByUsername: community.stubGetUserDetailsByUsername,
         stubAssignRole: community.stubAssignRole,
+        stubGetSingleOffender: community.stubGetSingleOffender,
 
         searchPrisonersByNomisIds: prisonerSearch.searchPrisonersByNomisIds,
         searchPrisonersByBookingIds: prisonerSearch.searchPrisonersByBookingIds,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -92,7 +92,7 @@ export default defineConfig({
         stubGetAnOffendersManagers: community.stubGetAnOffendersManagers,
         stubGetUserDetailsByUsername: community.stubGetUserDetailsByUsername,
         stubAssignRole: community.stubAssignRole,
-        stubGetSingleOffender: community.stubGetSingleOffender,
+        stubGetSingleOffenderByCrn: community.stubGetSingleOffenderByCrn,
 
         searchPrisonersByNomisIds: prisonerSearch.searchPrisonersByNomisIds,
         searchPrisonersByBookingIds: prisonerSearch.searchPrisonersByBookingIds,

--- a/integration_tests/integration/eventHandlers.cy.ts
+++ b/integration_tests/integration/eventHandlers.cy.ts
@@ -30,7 +30,7 @@ context('Event handlers', () => {
 
   describe('Probation events', () => {
     it('should listen to the offender manager changed event and call endpoint to update responsible COM', () => {
-      cy.task('stubGetProbationer')
+      cy.task('stubGetSingleOffender')
       cy.task('stubGetAnOffendersManagers')
       cy.task('stubGetStaffDetailsByStaffId')
       cy.task('stubGetUserDetailsByUsername')

--- a/integration_tests/integration/eventHandlers.cy.ts
+++ b/integration_tests/integration/eventHandlers.cy.ts
@@ -30,7 +30,7 @@ context('Event handlers', () => {
 
   describe('Probation events', () => {
     it('should listen to the offender manager changed event and call endpoint to update responsible COM', () => {
-      cy.task('stubGetSingleOffender')
+      cy.task('stubGetSingleOffenderByCrn')
       cy.task('stubGetAnOffendersManagers')
       cy.task('stubGetStaffDetailsByStaffId')
       cy.task('stubGetUserDetailsByUsername')
@@ -41,7 +41,7 @@ context('Event handlers', () => {
       cy.task(
         'sendProbationEvent',
         `{
-          "Message": "{\\"crn\\":\\"X1234\\"}",
+          "Message": "{\\"crn\\":\\"X2345\\"}",
           "MessageAttributes": {
             "eventType": {
               "Type": "String",
@@ -52,8 +52,8 @@ context('Event handlers', () => {
       )
 
       cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/secure/users/JSMITH/roles/LHDCBT002', times: 1 })
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/offender/crn/X1234/responsible-com', times: 1 })
-      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/offender/crn/X1234/probation-team', times: 1 })
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/offender/crn/X2345/responsible-com', times: 1 })
+      cy.task('verifyEndpointCalled', { verb: 'PUT', path: '/offender/crn/X2345/probation-team', times: 1 })
     })
   })
 

--- a/integration_tests/mockApis/community.ts
+++ b/integration_tests/mockApis/community.ts
@@ -324,50 +324,48 @@ export default {
     })
   },
 
-  stubGetSingleOffender: (): SuperAgentRequest => {
+  stubGetSingleOffenderByCrn: (): SuperAgentRequest => {
     return stubFor({
       request: {
-        method: 'POST',
+        method: 'GET',
         urlPattern: `/secure/offenders/crn/(.)*/all`,
       },
       response: {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: [
-          {
-            otherIds: {
-              crn: 'X2345',
-              pncNumber: '1234/12345',
-              croNumber: '1/12345',
-            },
-            offenderManagers: [
-              {
-                active: true,
-                staff: {
-                  code: 'X12345',
-                  forenames: 'Joe',
-                  surname: 'Bloggs',
+        jsonBody: {
+          otherIds: {
+            crn: 'X2345',
+            pncNumber: '1234/12345',
+            croNumber: '1/12345',
+          },
+          offenderManagers: [
+            {
+              active: true,
+              staff: {
+                code: 'X12345',
+                forenames: 'Joe',
+                surname: 'Bloggs',
+              },
+              probationArea: {
+                code: 'N01',
+                description: 'Area N01',
+              },
+              team: {
+                code: 'A',
+                description: 'Team A',
+                borough: {
+                  code: 'PDU1',
+                  description: 'PDU one',
                 },
-                probationArea: {
-                  code: 'N01',
-                  description: 'Area N01',
-                },
-                team: {
-                  code: 'A',
-                  description: 'Team A',
-                  borough: {
-                    code: 'PDU1',
-                    description: 'PDU one',
-                  },
-                  district: {
-                    code: 'LAU1',
-                    description: 'LAU one',
-                  },
+                district: {
+                  code: 'LAU1',
+                  description: 'LAU one',
                 },
               },
-            ],
-          },
-        ],
+            },
+          ],
+        },
       },
     })
   },

--- a/integration_tests/mockApis/community.ts
+++ b/integration_tests/mockApis/community.ts
@@ -323,4 +323,52 @@ export default {
       },
     })
   },
+
+  stubGetSingleOffender: (): SuperAgentRequest => {
+    return stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: `/secure/offenders/crn/(.)*/all`,
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: [
+          {
+            otherIds: {
+              crn: 'X2345',
+              pncNumber: '1234/12345',
+              croNumber: '1/12345',
+            },
+            offenderManagers: [
+              {
+                active: true,
+                staff: {
+                  code: 'X12345',
+                  forenames: 'Joe',
+                  surname: 'Bloggs',
+                },
+                probationArea: {
+                  code: 'N01',
+                  description: 'Area N01',
+                },
+                team: {
+                  code: 'A',
+                  description: 'Team A',
+                  borough: {
+                    code: 'PDU1',
+                    description: 'PDU one',
+                  },
+                  district: {
+                    code: 'LAU1',
+                    description: 'LAU one',
+                  },
+                },
+              },
+            ],
+          },
+        ],
+      },
+    })
+  },
 }

--- a/server/@types/communityClientTypes.ts
+++ b/server/@types/communityClientTypes.ts
@@ -5,3 +5,4 @@ export type CommunityApiOffenderManager = definitions['CommunityOrPrisonOffender
 export type CommunityApiManagedOffender = definitions['ManagedOffenderCrn']
 export type CommunityApiUserDetails = definitions['UserDetails']
 export type CommunityApiLocalDeliveryUnits = definitions['ProbationAreaWithLocalDeliveryUnits']
+export type CommunityApiOffenderDetail = definitions['OffenderDetail']

--- a/server/data/communityApiClient.ts
+++ b/server/data/communityApiClient.ts
@@ -80,6 +80,6 @@ export default class CommunityApiClient extends RestClient {
   }
 
   async getOffenderDetails(crn: string): Promise<OffenderDetail> {
-    return (await this.get({ path: `secure/offenders/crn/${crn}/all` })) as Promise<OffenderDetail>
+    return (await this.get({ path: `/secure/offenders/crn/${crn}/all` })) as Promise<OffenderDetail>
   }
 }

--- a/server/data/communityApiClient.ts
+++ b/server/data/communityApiClient.ts
@@ -6,6 +6,7 @@ import {
   CommunityApiManagedOffender,
   CommunityApiUserDetails,
 } from '../@types/communityClientTypes'
+import { OffenderDetail } from '../@types/probationSearchApiClientTypes'
 
 export default class CommunityApiClient extends RestClient {
   constructor() {
@@ -76,5 +77,9 @@ export default class CommunityApiClient extends RestClient {
 
   async getPduHeads(pduCode: string): Promise<CommunityApiStaffDetails[]> {
     return (await this.get({ path: `/secure/staff/pduHeads/${pduCode}` })) as Promise<CommunityApiStaffDetails[]>
+  }
+
+  async getOffenderDetails(crn: string): Promise<OffenderDetail> {
+    return (await this.get({ path: `secure/offenders/crn/${crn}/all` })) as Promise<OffenderDetail>
   }
 }

--- a/server/listeners/eventHandlers/probationEvents/offenderManagerChangedEventHandler.test.ts
+++ b/server/listeners/eventHandlers/probationEvents/offenderManagerChangedEventHandler.test.ts
@@ -26,7 +26,7 @@ describe('Offender manager changed event handler', () => {
 
   it('should handle case where the offender has no managers allocated', async () => {
     communityService.getAnOffendersManagers.mockResolvedValue([])
-    communityService.getProbationer.mockResolvedValue({ offenderManagers: [] } as OffenderDetail)
+    communityService.getSingleOffenderByCrn.mockResolvedValue({ offenderManagers: [] } as OffenderDetail)
 
     const event = {
       crn: 'X1234',
@@ -40,7 +40,7 @@ describe('Offender manager changed event handler', () => {
   })
 
   it('should update the responsible COM to the current RO in delius', async () => {
-    communityService.getProbationer.mockResolvedValue({
+    communityService.getSingleOffenderByCrn.mockResolvedValue({
       offenderManagers: [
         {
           active: true,
@@ -88,7 +88,7 @@ describe('Offender manager changed event handler', () => {
   })
 
   it('should update the probation team', async () => {
-    communityService.getProbationer.mockResolvedValue({
+    communityService.getSingleOffenderByCrn.mockResolvedValue({
       offenderManagers: [
         {
           active: true,
@@ -145,7 +145,7 @@ describe('Offender manager changed event handler', () => {
   })
 
   it('should not update the responsible COM if the COM does not have a username', async () => {
-    communityService.getProbationer.mockResolvedValue({
+    communityService.getSingleOffenderByCrn.mockResolvedValue({
       offenderManagers: [
         {
           active: true,
@@ -182,7 +182,7 @@ describe('Offender manager changed event handler', () => {
   })
 
   it('should assign the COM to a role if they do not have it already', async () => {
-    communityService.getProbationer.mockResolvedValue({
+    communityService.getSingleOffenderByCrn.mockResolvedValue({
       offenderManagers: [
         {
           active: true,

--- a/server/listeners/eventHandlers/probationEvents/offenderManagerChangedEventHandler.ts
+++ b/server/listeners/eventHandlers/probationEvents/offenderManagerChangedEventHandler.ts
@@ -10,7 +10,7 @@ export default class OffenderManagerChangedEventHandler {
 
   handle = async (event: ProbationEventMessage): Promise<void> => {
     const { crn } = event
-    const deliusRecord = await this.communityService.getProbationer({ crn })
+    const deliusRecord = await this.communityService.getSingleOffenderByCrn(crn)
     const offenderManagers = await this.communityService.getAnOffendersManagers(crn)
     const responsibleOfficer = deliusRecord.offenderManagers.find(om => om.active)
 

--- a/server/services/communityService.ts
+++ b/server/services/communityService.ts
@@ -91,4 +91,10 @@ export default class CommunityService {
     }
     return []
   }
+
+  // Has slower lookup than probation offender search /crns, but also has no lag-time after Community API event raised
+  // Only to be used when probation offender search api is return outdated information.
+  async getSingleOffenderByCrn(crn: string): Promise<OffenderDetail> {
+    return this.communityApiClient.getOffenderDetails(crn)
+  }
 }


### PR DESCRIPTION
The `OFFENDER_MANAGER_CHANGED` event handler is failing due to outdated data being returned by the Probation Offender Search API. From speaking to the Delius team, the long-term plan is to create a new API bespoke for CVL, but for the interim period, the Search API call is being swapped for a slower Community API call that will return the correct data instantly.