### PR TITLE
CVSL-777 - Removing reference to SED in licence type logic

### DIFF
--- a/server/services/caseloadService.ts
+++ b/server/services/caseloadService.ts
@@ -382,12 +382,17 @@ export default class CaseloadService {
   }
 
   private getLicenceType = (nomisRecord: Prisoner): LicenceType => {
-    if (!nomisRecord.topupSupervisionExpiryDate) {
-      return LicenceType.AP
-    }
-    if (!nomisRecord.licenceExpiryDate && !nomisRecord.sentenceExpiryDate) {
+    const tused = nomisRecord.topupSupervisionExpiryDate
+    const led = nomisRecord.licenceExpiryDate
+
+    if (!led) {
       return LicenceType.PSS
     }
+
+    if (!tused || moment(tused, 'YYYY-MM-DD') <= moment(led, 'YYYY-MM-DD')) {
+      return LicenceType.AP
+    }
+
     return LicenceType.AP_PSS
   }
 

--- a/server/services/licenceService.test.ts
+++ b/server/services/licenceService.test.ts
@@ -107,17 +107,41 @@ describe('Licence Service', () => {
     })
 
     describe('Licence Types', () => {
-      it('Should create an AP licence when a TUSED is not set in NOMIS', async () => {
-        prisonerService.getPrisonerDetail.mockResolvedValue({} as PrisonApiPrisoner)
+      it('Should create an AP licence when a TUSED is not set but a LED is set in NOMIS', async () => {
+        prisonerService.getPrisonerDetail.mockResolvedValue({
+          sentenceDetail: { licenceExpiryDate: '26/12/2022' },
+        } as PrisonApiPrisoner)
         const expectedLicence = expect.objectContaining({ typeCode: 'AP' })
 
         await licenceService.createLicence('ABC1234', user)
         expect(licenceApiClient.createLicence).toBeCalledWith(expectedLicence, user)
       })
 
-      it('Should create a PSS licence when LED and SED is not set but TUSED is set', async () => {
+      it('Should create an AP licence when TUSED is less than LED', async () => {
         prisonerService.getPrisonerDetail.mockResolvedValue({
-          sentenceDetail: { topupSupervisionExpiryDate: '26/12/2022' },
+          sentenceDetail: { licenceExpiryDate: '2022-12-26', topupSupervisionExpiryDate: '2022-12-20' },
+        } as PrisonApiPrisoner)
+
+        const expectedLicence = expect.objectContaining({ typeCode: 'AP' })
+
+        await licenceService.createLicence('ABC1234', user)
+        expect(licenceApiClient.createLicence).toBeCalledWith(expectedLicence, user)
+      })
+
+      it('Should create an AP licence when TUSED is equal to LED', async () => {
+        prisonerService.getPrisonerDetail.mockResolvedValue({
+          sentenceDetail: { licenceExpiryDate: '2022-12-26', topupSupervisionExpiryDate: '2022-12-26' },
+        } as PrisonApiPrisoner)
+
+        const expectedLicence = expect.objectContaining({ typeCode: 'AP' })
+
+        await licenceService.createLicence('ABC1234', user)
+        expect(licenceApiClient.createLicence).toBeCalledWith(expectedLicence, user)
+      })
+
+      it('Should create a PSS licence when LED is not set but TUSED is set', async () => {
+        prisonerService.getPrisonerDetail.mockResolvedValue({
+          sentenceDetail: { topupSupervisionExpiryDate: '2022-12-26' },
         } as PrisonApiPrisoner)
         const expectedLicence = expect.objectContaining({ typeCode: 'PSS' })
 
@@ -125,38 +149,11 @@ describe('Licence Service', () => {
         expect(licenceApiClient.createLicence).toBeCalledWith(expectedLicence, user)
       })
 
-      it('Should create a AP_PSS licence when LED is not set but TUSED and SED is set', async () => {
+      it('Should create a AP_PSS licence when both TUSED is after LED', async () => {
         prisonerService.getPrisonerDetail.mockResolvedValue({
           sentenceDetail: {
-            topupSupervisionExpiryDate: '26/12/2022',
-            sentenceExpiryDate: '26/12/2023',
-          },
-        } as PrisonApiPrisoner)
-        const expectedLicence = expect.objectContaining({ typeCode: 'AP_PSS' })
-
-        await licenceService.createLicence('ABC1234', user)
-        expect(licenceApiClient.createLicence).toBeCalledWith(expectedLicence, user)
-      })
-
-      it('Should create a AP_PSS licence when SED is not set but TUSED and LED is set', async () => {
-        prisonerService.getPrisonerDetail.mockResolvedValue({
-          sentenceDetail: {
-            topupSupervisionExpiryDate: '26/12/2022',
-            licenceExpiryDate: '26/12/2023',
-          },
-        } as PrisonApiPrisoner)
-        const expectedLicence = expect.objectContaining({ typeCode: 'AP_PSS' })
-
-        await licenceService.createLicence('ABC1234', user)
-        expect(licenceApiClient.createLicence).toBeCalledWith(expectedLicence, user)
-      })
-
-      it('Should create a AP_PSS licence when SLED and TUSED are set', async () => {
-        prisonerService.getPrisonerDetail.mockResolvedValue({
-          sentenceDetail: {
-            topupSupervisionExpiryDate: '26/12/2022',
-            licenceExpiryDate: '26/12/2023',
-            sentenceExpiryDate: '26/12/2023',
+            topupSupervisionExpiryDate: '2023-12-26',
+            licenceExpiryDate: '2022-12-26',
           },
         } as PrisonApiPrisoner)
         const expectedLicence = expect.objectContaining({ typeCode: 'AP_PSS' })

--- a/server/services/licenceService.ts
+++ b/server/services/licenceService.ts
@@ -2,6 +2,7 @@ import { Readable } from 'stream'
 import fs from 'fs'
 import _ from 'lodash'
 import { format } from 'date-fns'
+import moment from 'moment'
 import {
   AdditionalCondition,
   AdditionalConditionsRequest,
@@ -620,14 +621,13 @@ export default class LicenceService {
   private getLicenceType = (nomisRecord: PrisonApiPrisoner): LicenceType => {
     const tused = nomisRecord.sentenceDetail?.topupSupervisionExpiryDate
     const led = nomisRecord.sentenceDetail?.licenceExpiryDate
-    const sed = nomisRecord.sentenceDetail?.sentenceExpiryDate
 
-    if (!tused) {
-      return LicenceType.AP
+    if (!led) {
+      return LicenceType.PSS
     }
 
-    if (!led && !sed) {
-      return LicenceType.PSS
+    if (!tused || moment(tused, 'YYYY-MM-DD') <= moment(led, 'YYYY-MM-DD')) {
+      return LicenceType.AP
     }
 
     return LicenceType.AP_PSS


### PR DESCRIPTION
The inclusion of SED in the logic to determine PSS licences has meant that all licences that should be PSS are instead AP_PSS.
It's sufficient to check whether LED is missing for PSS licences, so references to SED have been removed.
Some additional logic has also been added to prevent licences that should be AP (based on TUSED vs LED dates) from becoming AP_PSS.