### PR TITLE
CVSL-1022 Add better caching of assets

### DIFF
--- a/server/applicationVersion.ts
+++ b/server/applicationVersion.ts
@@ -2,8 +2,8 @@
 import fs from 'fs'
 
 const packageData = JSON.parse(fs.readFileSync('./package.json').toString())
-const buildNumber = fs.existsSync('./build-info.json')
-  ? JSON.parse(fs.readFileSync('./build-info.json').toString()).buildNumber
-  : packageData.version
+const { buildNumber, gitRef } = fs.existsSync('./build-info.json')
+  ? JSON.parse(fs.readFileSync('./build-info.json').toString())
+  : { buildNumber: packageData.version, gitRef: 'xxxxxxxx' }
 
-export default { buildNumber, packageData }
+export default { buildNumber, packageData, shortHash: gitRef.substring(0, 8) }

--- a/server/config.ts
+++ b/server/config.ts
@@ -31,7 +31,7 @@ export interface ApiConfig {
 
 export default {
   https: production,
-  staticResourceCacheDuration: 20,
+  staticResourceCacheDuration: '1h',
   redis: {
     host: process.env.REDIS_HOST,
     port: parseInt(process.env.REDIS_PORT, 10) || 6379,

--- a/server/middleware/setUpStaticResources.ts
+++ b/server/middleware/setUpStaticResources.ts
@@ -11,7 +11,7 @@ export default function setUpStaticResources(): Router {
   router.use(compression())
 
   //  Static Resources Configuration
-  const cacheControl = { maxAge: config.staticResourceCacheDuration * 1000 }
+  const cacheControl = { maxAge: config.staticResourceCacheDuration }
   ;[
     '/assets',
     '/assets/stylesheets',

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -1,6 +1,7 @@
 import express, { Router, Response } from 'express'
 import helmet from 'helmet'
 import crypto from 'crypto'
+import config from '../config'
 
 export default function setUpWebSecurity(): Router {
   const router = express.Router()
@@ -39,6 +40,7 @@ export default function setUpWebSecurity(): Router {
           connectSrc: ["'self'", '*.googletagmanager.com', '*.google-analytics.com', '*.analytics.google.com'],
           styleSrc: ["'self'", 'code.jquery.com'],
           fontSrc: ["'self'"],
+          formAction: [`'self' ${config.apis.hmppsAuth.externalUrl}`],
         },
       },
     })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -7,6 +7,7 @@ import moment from 'moment'
 import { filesize } from 'filesize'
 import { FieldValidationError } from '../middleware/validationMiddleware'
 import config from '../config'
+import applicationVersion from '../applicationVersion'
 import {
   formatAddress,
   jsonDtTo12HourTime,
@@ -42,8 +43,8 @@ export default function nunjucksSetup(app: express.Express, conditionService: Co
 
   // Cachebusting version string
   if (production) {
-    // Version only changes on reboot
-    app.locals.version = Date.now().toString()
+    // Version only changes with each commit
+    app.locals.version = applicationVersion.shortHash
   } else {
     // Version changes every request
     app.use((req, res, next) => {


### PR DESCRIPTION
Currently the assets are only set to cache for 20 seconds. This should drastically reduce the number of requests to the server and also make browsing logs easier to see.

In production the css cache will be linked to the deployment version rather than pod start up time - currently the browser caches a version for each pod

There's also another little Helmet/CSP fix copied across from the template project to prevent user's being stuck on a page if they submit a page and the app detects their session has timed out. 
Previously CSP would have kicked in and an error would have been presented in terminal and the user would be stranded. Now the user will be redirected to auth. 