### PR TITLE
FB split script in two one for ui and one for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,15 +94,11 @@ These are:
 2. Copy `.env.example` to `.env` in the root of the project and customise.
 For the client ID and secrets present in the file, you will need to retrieve these values from the kubernetes dev environment. 
 
-3. Start the required containers.
+3. Run the script to start the required containers and start the local service, which will use the `.env` file to set up its environment to reference the DEV APIs.
 
-   `$ docker-compose up -d` 
+`$ ./run-local.sh`
 
-
-4. Start a local `create-and-vary-a-licence` service with `$ npm run start:dev`, which will use the `.env` file to set up its environment to reference the DEV APIs.
-   
-
-5. Bear in mind that the login details, and all data you will see, will be from the `licence-db` and APIs in the DEV environment. Only the redis functions and any use of the gotenberg container will be local operations.
+4. Bear in mind that the login details, and all data you will see, will be from the `licence-db` and APIs in the DEV environment. Only the redis functions and any use of the gotenberg container will be local operations.
 
 ### Run linter
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,16 @@ services:
     image: 'redis:5.0'
     networks:
       - hmpps
-    container_name: redis 
+    container_name: redis
     environment:
       - ALLOW_EMPTY_PASSWORD=yes
     ports:
       - '6379:6379'
+    healthcheck:
+      test: [ "CMD-SHELL", "redis-cli ping | grep PONG" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   gotenberg:
     image: thecodingmachine/gotenberg:7.5.0
@@ -21,6 +26,9 @@ services:
     restart: always
     healthcheck:
       test: [ 'CMD', 'curl', '-f', 'http://localhost:3000/health' ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
   localstack:
     image: localstack/localstack:0.13.2
@@ -42,6 +50,11 @@ services:
     volumes:
       - './.localstack:/tmp/localstack'
       - $PWD/localstack:/docker-entrypoint-initaws.d
+    healthcheck:
+      test: awslocal sqs list-queues
+      interval: 5s
+      timeout: 3s
+      retries: 5
 
 networks:
   hmpps:

--- a/run-local.sh
+++ b/run-local.sh
@@ -1,0 +1,44 @@
+#
+# This script is used to run the Create and Vary a licence UI locally, to sets up the containers and installs the
+# necessary dependencies required for the UI.
+#
+# Following this, the script starts the UI locally
+#
+
+# Bring up the front end containers needed for the application
+echo "Bringing down current containers ..."
+docker compose down
+
+#Prune existing containers
+#Comment in if you wish to perform a fresh install of all containers are removed and deleted
+#You will be prompted to continue with the deletion in the terminal
+#docker system prune --all
+
+#Install npm and relevant dependencies for the service
+echo "Installing npm ..."
+npm install
+
+#Pull the latest versions of the containers required for the service and bring them up, waiting for them to be in a
+#healthy state before starting the service
+echo "Pulling front end containers ..."
+docker compose -f docker-compose.yml pull
+docker compose -f docker-compose.yml up -d
+
+echo "Waiting for front end containers to be ready ..."
+until [ "`docker inspect -f {{.State.Health.Status}} gotenberg`" == "healthy" ]; do
+    sleep 0.1;
+done;
+until [ "`docker inspect -f {{.State.Health.Status}} redis`" == "healthy" ]; do
+    sleep 0.1;
+done;
+until [ "`docker inspect -f {{.State.Health.Status}} localstack`" == "healthy" ]; do
+    sleep 0.1;
+done;
+
+echo "Front end containers are now ready ..."
+
+# Start the service using the start:dev script
+echo "Starting the UI locally"
+npm run start:dev
+
+# End


### PR DESCRIPTION
This PR takes the previous work around automation done on the API one step further and creates two local scripts which can be used to build front and back end containers and run the respective services. This includes the script needed to build and run the UI service along with changes to `docker-compose.yml` file to accommodate health checks and an update to the README. 