### PR TITLE
CVSL-1143 fixing return to caseload links

### DIFF
--- a/run-local.sh
+++ b/run-local.sh
@@ -1,4 +1,5 @@
-#
+#!/bin/bash
+
 # This script is used to run the Create and Vary a licence UI locally, to sets up the containers and installs the
 # necessary dependencies required for the UI.
 #
@@ -25,13 +26,13 @@ docker compose -f docker-compose.yml pull
 docker compose -f docker-compose.yml up -d
 
 echo "Waiting for front end containers to be ready ..."
-until [ "`docker inspect -f {{.State.Health.Status}} gotenberg`" == "healthy" ]; do
+until [ "$(docker inspect -f {{.State.Health.Status}} gotenberg)" == "healthy" ]; do
     sleep 0.1;
 done;
-until [ "`docker inspect -f {{.State.Health.Status}} redis`" == "healthy" ]; do
+until [ "$(docker inspect -f {{.State.Health.Status}} redis)" == "healthy" ]; do
     sleep 0.1;
 done;
-until [ "`docker inspect -f {{.State.Health.Status}} localstack`" == "healthy" ]; do
+until [ "$(docker inspect -f {{.State.Health.Status}} localstack)" == "healthy" ]; do
     sleep 0.1;
 done;
 

--- a/server/routes/creatingLicences/handlers/caseload.test.ts
+++ b/server/routes/creatingLicences/handlers/caseload.test.ts
@@ -1,21 +1,18 @@
 import { Request, Response } from 'express'
 
 import CaseloadRoutes from './caseload'
-import LicenceService from '../../../services/licenceService'
 import CaseloadService from '../../../services/caseloadService'
 import statusConfig from '../../../licences/licenceStatus'
 import LicenceStatus from '../../../enumeration/licenceStatus'
 import LicenceType from '../../../enumeration/licenceType'
 import { ManagedCase } from '../../../@types/managedCase'
 
-const licenceService = new LicenceService(null, null, null, null) as jest.Mocked<LicenceService>
 const caseloadService = new CaseloadService(null, null, null) as jest.Mocked<CaseloadService>
 
-jest.mock('../../../services/licenceService')
 jest.mock('../../../services/caseloadService')
 
 describe('Route Handlers - Create Licence - Caseload', () => {
-  const handler = new CaseloadRoutes(licenceService, caseloadService)
+  const handler = new CaseloadRoutes(caseloadService)
   let req: Request
   let res: Response
 

--- a/server/routes/creatingLicences/handlers/caseload.ts
+++ b/server/routes/creatingLicences/handlers/caseload.ts
@@ -1,7 +1,6 @@
 import { Request, Response } from 'express'
 import moment from 'moment'
 import _ from 'lodash'
-import LicenceService from '../../../services/licenceService'
 import CaseloadService from '../../../services/caseloadService'
 import { convertToTitleCase } from '../../../utils/utils'
 import statusConfig from '../../../licences/licenceStatus'
@@ -9,7 +8,7 @@ import LicenceStatus from '../../../enumeration/licenceStatus'
 import logger from '../../../../logger'
 
 export default class CaseloadRoutes {
-  constructor(private readonly licenceService: LicenceService, private readonly caseloadService: CaseloadService) {}
+  constructor(private readonly caseloadService: CaseloadService) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
     const teamView = req.query.view === 'team'

--- a/server/routes/creatingLicences/handlers/checkAnswers.test.ts
+++ b/server/routes/creatingLicences/handlers/checkAnswers.test.ts
@@ -26,7 +26,7 @@ describe('Route Handlers - Create Licence - Check Answers', () => {
         licenceId: '1',
       },
       session: {
-        returnToCase: '/licence/vary/caseload',
+        returnToCase: 'some-back-link',
       },
       flash: jest.fn(),
     } as unknown as Request
@@ -69,6 +69,27 @@ describe('Route Handlers - Create Licence - Check Answers', () => {
         backLink: req.session.returnToCase,
       })
       expect(licenceService.recordAuditEvent).not.toHaveBeenCalled()
+    })
+
+    it('should render default return to caseload link if no session state', async () => {
+      const reqWithEmptySession = {
+        params: {
+          licenceId: '1',
+        },
+        session: {},
+        flash: jest.fn(),
+      } as unknown as Request
+
+      conditionService.additionalConditionsCollection.mockReturnValue({
+        additionalConditions: [],
+        conditionsWithUploads: [],
+      })
+      await handler.GET(reqWithEmptySession, res)
+      expect(res.render).toHaveBeenCalledWith('pages/create/checkAnswers', {
+        additionalConditions: [],
+        conditionsWithUploads: [],
+        backLink: '/licence/create/caseload',
+      })
     })
 
     it('should render view and record audit event (not owner)', async () => {

--- a/server/routes/creatingLicences/handlers/checkAnswers.ts
+++ b/server/routes/creatingLicences/handlers/checkAnswers.ts
@@ -13,7 +13,7 @@ export default class CheckAnswersRoutes {
 
   GET = async (req: Request, res: Response): Promise<void> => {
     const { licence, user } = res.locals
-    const backLink = req.session.returnToCase
+    const backLink = req.session.returnToCase || '/licence/create/caseload'
 
     // Record the view event only when an officer views a licence which is not their own
     if (licence?.comStaffId !== user?.deliusStaffIdentifier) {

--- a/server/routes/creatingLicences/handlers/confirmCreate.test.ts
+++ b/server/routes/creatingLicences/handlers/confirmCreate.test.ts
@@ -32,7 +32,7 @@ describe('Route Handlers - Create Licence - Confirm Create', () => {
         nomisId: 'ABC123',
       },
       session: {
-        returnToCase: '/licence/create/caseload',
+        returnToCase: 'some-back-link',
       },
       user: {
         username: 'joebloggs',
@@ -85,6 +85,30 @@ describe('Route Handlers - Create Licence - Confirm Create', () => {
         },
         releaseIsOnBankHolidayOrWeekend: true,
         backLink: req.session.returnToCase,
+      })
+    })
+
+    it('should render default return to caseload link if no session state', async () => {
+      const reqWithEmptySession = {
+        params: {
+          licenceId: '1',
+        },
+        session: {},
+        flash: jest.fn(),
+      } as unknown as Request
+
+      await handler.GET(reqWithEmptySession, res)
+      expect(res.render).toHaveBeenCalledWith('pages/create/confirmCreate', {
+        licence: {
+          conditionalReleaseDate: '21/11/2022',
+          actualReleaseDate: '20/11/2022',
+          crn: 'X1234',
+          dateOfBirth: '10/11/1960',
+          forename: 'Patrick',
+          surname: 'Holmes',
+        },
+        releaseIsOnBankHolidayOrWeekend: true,
+        backLink: '/licence/create/caseload',
       })
     })
 

--- a/server/routes/creatingLicences/handlers/confirmCreate.ts
+++ b/server/routes/creatingLicences/handlers/confirmCreate.ts
@@ -18,7 +18,7 @@ export default class ConfirmCreateRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {
     const { nomisId } = req.params
     const { user } = res.locals
-    const backLink = req.session.returnToCase
+    const backLink = req.session.returnToCase || '/licence/create/caseload'
 
     const [nomisRecord, deliusRecord, bankHolidays] = await Promise.all([
       this.prisonerService.getPrisonerDetail(nomisId, user),

--- a/server/routes/creatingLicences/handlers/confirmation.test.ts
+++ b/server/routes/creatingLicences/handlers/confirmation.test.ts
@@ -13,7 +13,7 @@ describe('Route Handlers - Create Licence - Confirmation', () => {
         licenceId: 1,
       },
       session: {
-        returnToCase: '/licence/create/caseload',
+        returnToCase: 'some-back-link',
       },
     } as unknown as Request
 
@@ -39,6 +39,26 @@ describe('Route Handlers - Create Licence - Confirmation', () => {
           'We have sent the licence and post sentence supervision order to Leeds (HMP) for approval.',
         titleText: 'Licence and post sentence supervision order for Bobby Zamora sent',
         backLink: req.session.returnToCase,
+      })
+    })
+
+    it('should render default return to caseload link if no session state', async () => {
+      const reqWithEmptySession = {
+        params: {
+          licenceId: '1',
+        },
+        session: {},
+        flash: jest.fn(),
+      } as unknown as Request
+
+      res.locals.licence.typeCode = 'AP_PSS'
+
+      await handler.GET(reqWithEmptySession, res)
+      expect(res.render).toHaveBeenCalledWith('pages/create/confirmation', {
+        confirmationMessage:
+          'We have sent the licence and post sentence supervision order to Leeds (HMP) for approval.',
+        titleText: 'Licence and post sentence supervision order for Bobby Zamora sent',
+        backLink: '/licence/create/caseload',
       })
     })
 

--- a/server/routes/creatingLicences/handlers/confirmation.ts
+++ b/server/routes/creatingLicences/handlers/confirmation.ts
@@ -4,7 +4,7 @@ import LicenceType from '../../../enumeration/licenceType'
 export default class ConfirmationRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {
     const { licence } = res.locals
-    const backLink = req.session.returnToCase
+    const backLink = req.session.returnToCase || '/licence/create/caseload'
 
     let titleText
     let confirmationMessage

--- a/server/routes/creatingLicences/index.ts
+++ b/server/routes/creatingLicences/index.ts
@@ -88,7 +88,7 @@ export default function Index({
       asyncMiddleware(handler)
     )
 
-  const caseloadHandler = new CaseloadRoutes(licenceService, caseloadService)
+  const caseloadHandler = new CaseloadRoutes(caseloadService)
   const comDetailsHandler = new ComDetailsRoutes(communityService)
   const confirmCreateHandler = new ConfirmCreateRoutes(
     communityService,

--- a/server/routes/varyingLicences/handlers/confirmDiscardVariation.test.ts
+++ b/server/routes/varyingLicences/handlers/confirmDiscardVariation.test.ts
@@ -61,5 +61,20 @@ describe('Route Handlers - Vary Licence - Confirm discard variation', () => {
       expect(licenceService.discard).not.toHaveBeenCalled()
       expect(res.redirect).toHaveBeenCalledWith('/licence/vary/id/1/view')
     })
+
+    it('should redirect to default if no session state', async () => {
+      const reqWithEmptySession = {
+        params: {
+          licenceId: '1',
+        },
+        body: { answer: 'Yes' },
+        session: {},
+        flash: jest.fn(),
+      } as unknown as Request
+
+      await handler.POST(reqWithEmptySession, res)
+
+      expect(res.redirect).toHaveBeenCalledWith('/licence/vary/caseload')
+    })
   })
 })

--- a/server/routes/varyingLicences/handlers/confirmDiscardVariation.ts
+++ b/server/routes/varyingLicences/handlers/confirmDiscardVariation.ts
@@ -13,7 +13,7 @@ export default class ConfirmDiscardVariationRoutes {
     const { licenceId } = req.params
     const { answer } = req.body
     const { user } = res.locals
-    const backLink = req.session.returnToCase
+    const backLink = req.session.returnToCase || '/licence/vary/caseload'
 
     if (answer === YesOrNo.YES) {
       await this.licenceService.discard(licenceId, user)

--- a/server/routes/varyingLicences/handlers/confirmation.test.ts
+++ b/server/routes/varyingLicences/handlers/confirmation.test.ts
@@ -40,6 +40,26 @@ describe('Route Handlers - Vary Licence - Confirmation', () => {
       })
     })
 
+    it('should render default backlink if no session state', async () => {
+      const reqWithEmptySession = {
+        params: {
+          licenceId: '1',
+        },
+        body: { answer: 'Yes' },
+        session: {},
+        flash: jest.fn(),
+      } as unknown as Request
+
+      res.locals.licence.typeCode = 'AP_PSS'
+
+      await handler.GET(reqWithEmptySession, res)
+      expect(res.render).toHaveBeenCalledWith('pages/vary/confirmation', {
+        licenceType: 'licence and post sentence supervision order',
+        titleText: 'Variation for Joe Bloggs sent',
+        backLink: '/licence/vary/caseload',
+      })
+    })
+
     it('should render view for AP licence type', async () => {
       res.locals.licence.typeCode = 'AP'
 

--- a/server/routes/varyingLicences/handlers/confirmation.ts
+++ b/server/routes/varyingLicences/handlers/confirmation.ts
@@ -4,7 +4,7 @@ import LicenceType from '../../../enumeration/licenceType'
 export default class ConfirmationRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {
     const { licence } = res.locals
-    const backLink = req.session.returnToCase
+    const backLink = req.session.returnToCase || '/licence/vary/caseload'
 
     let titleText
     let licenceType

--- a/server/views/pages/create/checkAnswers.njk
+++ b/server/views/pages/create/checkAnswers.njk
@@ -130,7 +130,7 @@
                         
                     {% endif %}
                     
-                    <a href={{ backLink }} class="govuk-link govuk-!-font-size-19">Return to caselist</a>
+                    <a href="{{ backLink }}" class="govuk-link govuk-!-font-size-19">Return to caselist</a>
 
                 </div>
             </form>


### PR DESCRIPTION
Currently the "return to caseload" links rely on storing the destination location in the session.

When the application session times out the user will be redirected to auth and assuming the user's auth session is still active they will be redirected back to the application where a new application session will be created. 

This happens transparently and the user will returned to the page where they were on.

The lack of a return destination in the session breaks the session.

This change puts in a sensible default location for each link. (Might be nicer to move to a central middleware or better different paths for each destination - which would massively improve observability but that would require quite a lot of restructuring)