### PR TITLE
CVSL-1185 add allowlist to audit-ci file to stop false positive security alerts

### DIFF
--- a/audit-ci.json
+++ b/audit-ci.json
@@ -1,5 +1,9 @@
 {
   "low": true,
   "package-manager": "auto",
-  "registry": "https://registry.npmjs.org"
+  "registry": "https://registry.npmjs.org",
+  "allowlist": [
+    "GHSA-p8p7-x288-28g6|request>request-promise>uk-bank-holidays",
+    "GHSA-72xf-g2v4-qvf3|cypress>@cypress/request>tough-cookie"
+  ]
 }


### PR DESCRIPTION
Added allowlist to `audit-ci.json` to cease alerts for the following dependencies which we don't need to fix for now:

`request` pulls through a vulnerability to the `uk-bank-holidays` package and there is no fix available - in the future we'll need to add our own functionality rather than importing the `uk-bank-holidays` package. 

`tough-cookie` pulls through a vulnerability to cypress but as this is being used in development it poses a low risk and we deem it not worth fixing for now. 

## npm audit report

```request  *
Severity: moderate
Server-Side Request Forgery in Request - https://github.com/advisories/GHSA-p8p7-x288-28g6
Depends on vulnerable versions of tough-cookie
No fix available
node_modules/request
  request-promise  >=0.0.2
  Depends on vulnerable versions of request
  node_modules/request-promise
    uk-bank-holidays  *
    Depends on vulnerable versions of request-promise
    node_modules/uk-bank-holidays

tough-cookie  <4.1.3
Severity: moderate
tough-cookie Prototype Pollution vulnerability - https://github.com/advisories/GHSA-72xf-g2v4-qvf3
fix available via `npm audit fix --force`
Will install cypress@4.2.0, which is a breaking change
node_modules/tough-cookie
  @cypress/request  *
  Depends on vulnerable versions of tough-cookie
  node_modules/@cypress/request
    cypress  >=4.3.0
    Depends on vulnerable versions of @cypress/request
    node_modules/cypress
      cypress-axe  0.6.0 || >=1.0.0
      Depends on vulnerable versions of cypress
      node_modules/cypress-axe