### PR TITLE
CVSL-1287 Splitting out MEZ and normal condition templates

### DIFF
--- a/server/routes/manageConditions/handlers/additionalLicenceConditionInput.test.ts
+++ b/server/routes/manageConditions/handlers/additionalLicenceConditionInput.test.ts
@@ -128,64 +128,6 @@ describe('Route Handlers - Create Licence - Additional Licence Condition Input',
     })
   })
 
-  describe('POST with file upload', () => {
-    beforeEach(() => {
-      const uploadFile = {
-        path: 'test-file',
-        originalname: 'test.txt',
-        fieldname: 'outOfBoundFilename',
-        mimetype: 'application/pdf',
-        size: 100,
-      } as Express.Multer.File
-
-      req = {
-        params: {
-          licenceId: '1',
-          conditionId: '1',
-        },
-        file: uploadFile,
-        query: {},
-        body: { outOfBoundFilename: 'test.txt' },
-      } as unknown as Request
-
-      licenceService.uploadExclusionZoneFile = jest.fn()
-      licenceService.updateAdditionalConditionData = jest.fn()
-
-      res.locals.licence = {
-        additionalLicenceConditions: [
-          {
-            id: 1,
-            code: 'outOfBoundsRegion',
-            expandedText: 'expanded text',
-          },
-        ],
-      } as Licence
-    })
-
-    it('should recognise a file upload', async () => {
-      await handler.POST(req, res)
-      expect(licenceService.uploadExclusionZoneFile).toHaveBeenCalledWith('1', '1', req.file, { username: 'joebloggs' })
-      expect(licenceService.updateAdditionalConditionData).toHaveBeenCalledWith(
-        '1',
-        { code: 'outOfBoundsRegion', id: 1, expandedText: 'expanded text' },
-        { outOfBoundFilename: 'test.txt' },
-        { username: 'joebloggs' }
-      )
-    })
-
-    it('should ignore file uploads with for conditions other than out of bounds', async () => {
-      req.file = { ...req.file, fieldname: 'WRONG' }
-      await handler.POST(req, res)
-      expect(licenceService.updateAdditionalConditionData).toHaveBeenCalledWith(
-        '1',
-        { code: 'outOfBoundsRegion', id: 1, expandedText: 'expanded text' },
-        { outOfBoundFilename: 'test.txt' },
-        { username: 'joebloggs' }
-      )
-      expect(licenceService.uploadExclusionZoneFile).not.toHaveBeenCalled()
-    })
-  })
-
   describe('DELETE', () => {
     beforeEach(() => {
       licenceService.updateAdditionalConditions = jest.fn()

--- a/server/routes/manageConditions/handlers/additionalLicenceConditionInput.ts
+++ b/server/routes/manageConditions/handlers/additionalLicenceConditionInput.ts
@@ -42,20 +42,9 @@ export default class AdditionalLicenceConditionInputRoutes {
     const { licenceId } = req.params
     const { conditionId } = req.params
     const { user, licence } = res.locals
-    const isFileUploadRequest = req.file && req.file.fieldname === 'outOfBoundFilename'
 
-    const { code } = licence.additionalLicenceConditions.find(c => c.id === parseInt(conditionId, 10))
-
-    // if the update involves a file or updating a data element for exclusion zone name outOfBoundArea
     let redirect
-    if (isFileUploadRequest || 'outOfBoundArea' in req.body) {
-      redirect = `/licence/create/id/${licenceId}/additional-licence-conditions/condition/${code}/file-uploads`
-      if (req.query?.fromPolicyReview) {
-        redirect += '?fromPolicyReview=true'
-      } else if (req.query?.fromReview) {
-        redirect += '?fromReview=true'
-      }
-    } else if (req.query?.fromPolicyReview) {
+    if (req.query?.fromPolicyReview) {
       redirect = `/licence/vary/id/${licenceId}/policy-changes/input/callback/${
         +req.session.changedConditionsInputsCounter + 1
       }`
@@ -63,11 +52,6 @@ export default class AdditionalLicenceConditionInputRoutes {
       redirect = `/licence/create/id/${licenceId}/additional-licence-conditions/callback${
         req.query?.fromReview ? '?fromReview=true' : ''
       }`
-    }
-
-    // Check for file uploads on specific forms
-    if (isFileUploadRequest) {
-      await this.licenceService.uploadExclusionZoneFile(licenceId, conditionId, req.file, user)
     }
 
     const condition = licence.additionalLicenceConditions.find(c => c.id === +conditionId)
@@ -81,13 +65,8 @@ export default class AdditionalLicenceConditionInputRoutes {
     const { conditionId } = req.params
     const { user } = res.locals
 
-    const condition = licence.additionalLicenceConditions.find(c => c.id === parseInt(conditionId, 10))
-
-    // if the exclusion zone name outOfBoundArea is present, redirect to file uploads dialog
     let redirect
-    if (condition.expandedText.indexOf('{outOfBoundArea}') > 1) {
-      redirect = `/licence/create/id/${licence.id}/additional-licence-conditions/condition/${condition.code}/file-uploads`
-    } else if (req.query?.fromPolicyReview) {
+    if (req.query?.fromPolicyReview) {
       redirect = `/licence/vary/id/${licence.id}/policy-changes/input/callback/${
         +req.session.changedConditionsInputsCounter + 1
       }`

--- a/server/routes/manageConditions/handlers/additionalLicenceConditionUploadInput.test.ts
+++ b/server/routes/manageConditions/handlers/additionalLicenceConditionUploadInput.test.ts
@@ -1,0 +1,160 @@
+import { Request, Response } from 'express'
+
+import AdditionalLicenceConditionUploadInputRoutes from './additionalLicenceConditionUploadInput'
+import LicenceService from '../../../services/licenceService'
+import type { Licence } from '../../../@types/licenceApiClientTypes'
+
+jest.mock('../../../services/licenceService')
+
+const licenceService = new LicenceService(null, null, null, null) as jest.Mocked<LicenceService>
+
+describe('Route Handlers - Create Licence - Additional Licence Condition Input for upload areas', () => {
+  const handler = new AdditionalLicenceConditionUploadInputRoutes(licenceService)
+  let req: Request
+  let res: Response
+
+  beforeEach(() => {
+    req = {
+      params: {
+        licenceId: '1',
+        conditionId: '1',
+      },
+      query: {},
+      body: {},
+    } as unknown as Request
+
+    res = {
+      render: jest.fn(),
+      redirect: jest.fn(),
+      status: jest.fn(),
+      locals: {
+        licence: {
+          additionalLicenceConditions: [],
+          version: 'version',
+        },
+        user: {
+          username: 'joebloggs',
+        },
+      },
+    } as unknown as Response
+  })
+
+  describe('POST', () => {
+    beforeEach(() => {
+      licenceService.updateAdditionalConditionData = jest.fn()
+      res.locals.licence = {
+        additionalLicenceConditions: [
+          {
+            id: 1,
+            code: 'code1',
+          },
+        ],
+      } as Licence
+    })
+
+    it('should call licence service to update the additional condition data', async () => {
+      await handler.POST(req, res)
+      expect(licenceService.updateAdditionalConditionData).toHaveBeenCalledWith(
+        '1',
+        { code: 'code1', id: 1 },
+        {},
+        { username: 'joebloggs' }
+      )
+    })
+
+    it('should redirect to the list view', async () => {
+      await handler.POST(req, res)
+      expect(res.redirect).toHaveBeenCalledWith(
+        '/licence/create/id/1/additional-licence-conditions/condition/code1/file-uploads'
+      )
+    })
+
+    it('should redirect to the callback function with query parameter if fromReview flag is true', async () => {
+      req.query.fromReview = 'true'
+      await handler.POST(req, res)
+      expect(res.redirect).toHaveBeenCalledWith(
+        '/licence/create/id/1/additional-licence-conditions/condition/code1/file-uploads?fromReview=true'
+      )
+    })
+  })
+
+  describe('POST with file upload', () => {
+    beforeEach(() => {
+      const uploadFile = {
+        path: 'test-file',
+        originalname: 'test.txt',
+        fieldname: 'outOfBoundFilename',
+        mimetype: 'application/pdf',
+        size: 100,
+      } as Express.Multer.File
+
+      req = {
+        params: {
+          licenceId: '1',
+          conditionId: '1',
+        },
+        file: uploadFile,
+        query: {},
+        body: { outOfBoundFilename: 'test.txt' },
+      } as unknown as Request
+
+      licenceService.uploadExclusionZoneFile = jest.fn()
+      licenceService.updateAdditionalConditionData = jest.fn()
+
+      res.locals.licence = {
+        additionalLicenceConditions: [
+          {
+            id: 1,
+            code: 'outOfBoundsRegion',
+            expandedText: 'expanded text',
+          },
+        ],
+      } as Licence
+    })
+
+    it('should recognise a file upload', async () => {
+      await handler.POST(req, res)
+      expect(licenceService.uploadExclusionZoneFile).toHaveBeenCalledWith('1', '1', req.file, { username: 'joebloggs' })
+      expect(licenceService.updateAdditionalConditionData).toHaveBeenCalledWith(
+        '1',
+        { code: 'outOfBoundsRegion', id: 1, expandedText: 'expanded text' },
+        { outOfBoundFilename: 'test.txt' },
+        { username: 'joebloggs' }
+      )
+    })
+  })
+
+  describe('DELETE', () => {
+    beforeEach(() => {
+      licenceService.updateAdditionalConditions = jest.fn()
+      licenceService.deleteAdditionalCondition = jest.fn()
+      res.locals.licence = {
+        id: 1,
+        additionalLicenceConditions: [
+          {
+            id: 1,
+            code: 'code1',
+            expandedText: 'expanded text',
+          },
+          {
+            id: 2,
+            code: 'code2',
+            expandedText: 'more expanded text',
+          },
+        ],
+      } as Licence
+    })
+
+    it('should call licence service to update the additional conditions with the condition removed', async () => {
+      await handler.DELETE(req, res)
+      expect(licenceService.deleteAdditionalCondition).toHaveBeenCalledWith(1, 1, { username: 'joebloggs' })
+    })
+
+    it('should redirect to the area list view', async () => {
+      await handler.DELETE(req, res)
+      expect(res.redirect).toHaveBeenCalledWith(
+        '/licence/create/id/1/additional-licence-conditions/condition/code1/file-uploads'
+      )
+    })
+  })
+})

--- a/server/routes/manageConditions/handlers/additionalLicenceConditionUploadInput.ts
+++ b/server/routes/manageConditions/handlers/additionalLicenceConditionUploadInput.ts
@@ -1,0 +1,42 @@
+import { Request, Response } from 'express'
+import LicenceService from '../../../services/licenceService'
+
+export default class AdditionalLicenceConditionUploadInputRoutes {
+  constructor(private readonly licenceService: LicenceService) {}
+
+  POST = async (req: Request, res: Response): Promise<void> => {
+    const { licenceId } = req.params
+    const { conditionId } = req.params
+    const { user, licence } = res.locals
+
+    const { code } = licence.additionalLicenceConditions.find(c => c.id === parseInt(conditionId, 10))
+
+    let redirect = `/licence/create/id/${licenceId}/additional-licence-conditions/condition/${code}/file-uploads`
+    if (req.query?.fromPolicyReview) {
+      redirect += '?fromPolicyReview=true'
+    } else if (req.query?.fromReview) {
+      redirect += '?fromReview=true'
+    }
+
+    await this.licenceService.uploadExclusionZoneFile(licenceId, conditionId, req.file, user)
+
+    const condition = licence.additionalLicenceConditions.find(c => c.id === +conditionId)
+    await this.licenceService.updateAdditionalConditionData(licenceId, condition, req.body, user)
+
+    return res.redirect(redirect)
+  }
+
+  DELETE = async (req: Request, res: Response): Promise<void> => {
+    const { licence } = res.locals
+    const { conditionId } = req.params
+    const { user } = res.locals
+
+    const condition = licence.additionalLicenceConditions.find(c => c.id === parseInt(conditionId, 10))
+
+    await this.licenceService.deleteAdditionalCondition(parseInt(conditionId, 10), licence.id, user)
+
+    return res.redirect(
+      `/licence/create/id/${licence.id}/additional-licence-conditions/condition/${condition.code}/file-uploads`
+    )
+  }
+}

--- a/server/routes/manageConditions/index.ts
+++ b/server/routes/manageConditions/index.ts
@@ -13,6 +13,7 @@ import type { Services } from '../../services'
 import AdditionalConditions from './types/additionalConditions'
 import AdditionalLicenceConditionsCallbackRoutes from './handlers/additionalLicenceConditionsCallback'
 import AdditionalLicenceConditionInputRoutes from './handlers/additionalLicenceConditionInput'
+import AdditionalLicenceConditionUploadInputRoutes from './handlers/additionalLicenceConditionUploadInput'
 import AdditionalPssConditionsRoutes from './handlers/additionalPssConditions'
 import AdditionalPssConditionsCallbackRoutes from './handlers/additionalPssConditionsCallback'
 import AdditionalPssConditionInputRoutes from './handlers/additionalPssConditionInput'
@@ -79,6 +80,13 @@ export default function Index({ licenceService, conditionService }: Services): R
     post('/additional-licence-conditions/condition/:conditionCode/file-uploads', controller.POST)
   }
 
+  {
+    // upload/delete files from input page
+    const controller = new AdditionalLicenceConditionUploadInputRoutes(licenceService)
+    postWithFileUpload('/additional-licence-conditions/condition/:conditionId/file-upload-input', controller.POST)
+    get('/additional-licence-conditions/condition/:conditionId/file-upload-delete', controller.DELETE)
+  }
+
   // remove area from map list with confirmation (delete single conditions)
   {
     const controller = new AdditionalLicenceConditionUploadsRemovalRoutes(licenceService)
@@ -90,7 +98,7 @@ export default function Index({ licenceService, conditionService }: Services): R
   {
     const controller = new AdditionalLicenceConditionInputRoutes(licenceService, conditionService)
     get('/additional-licence-conditions/condition/:conditionId', controller.GET)
-    postWithFileUpload('/additional-licence-conditions/condition/:conditionId', controller.POST)
+    post('/additional-licence-conditions/condition/:conditionId', controller.POST)
     get('/additional-licence-conditions/condition/:conditionId/delete', controller.DELETE)
   }
 

--- a/server/utils/conditionRoutes.ts
+++ b/server/utils/conditionRoutes.ts
@@ -22,7 +22,7 @@ const DEFAULT_CONDITION_CONFIG: ConditionConfig = {
 
 const conditions: Record<string, ConditionConfig> = {
   [MEZ_CONDITION_CODE]: {
-    inputTemplate: 'pages/create/additionalLicenceConditionInput',
+    inputTemplate: 'pages/create/additionalLicenceConditionMapInput',
     getEditConditionHref: (args: EditConditionHrefArgs) =>
       `/licence/create/id/${args.licenceId}/additional-licence-conditions/condition/${args.conditionCode}/file-uploads${
         args.fromReview ? '?fromReview=true' : ''

--- a/server/views/pages/create/additionalLicenceConditionMapInput.njk
+++ b/server/views/pages/create/additionalLicenceConditionMapInput.njk
@@ -29,9 +29,15 @@
         </div>
     </div>
 
+
+    {% set fileUploadPresent = additionalCondition.uploadSummary.length > 0 %}
+    
     {# Alter the form encoding to multi-part formdata and supply csrf token in query params for file upload conditions #}
     <div class="govuk-button-group">
-        <form method="POST">
+        <form method="POST"
+            encType="multipart/form-data"
+            action="/licence/create/id/{{licence.id}}/additional-licence-conditions/condition/{{additionalCondition.id}}/file-upload-input?_csrf={{ csrfToken }}{{ fromReviewAppend }}{{ fromPolicyReviewAppend }}">
+
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
             <input type="hidden" name="code" value="{{ config.code }}">
 
@@ -45,6 +51,19 @@
                     {% endif %}
 
                     {{ formBuilder(licence.id, config, additionalCondition, validationErrors, formResponses, csrfToken) }}
+                    {% if not fileUploadPresent %}
+                        <h2 class="govuk-heading-m govuk-!-padding-top-8">Help with this licence condition</h2>
+                        {{ govukDetails({
+                            summaryText: "If you need to add more than one map",
+                            text: "Add your first map on this page. You can add more from the next page.",
+                            classes: 'govuk-!-margin-bottom-3'
+                        }) }}
+                        {{ govukDetails({
+                            summaryText: "If you do not have a map",
+                            html: "You can create one on <a class='govuk-link govuk-link--no-visited-state govuk-!-margin-right-0' href='https://mapmaker.field-dynamics.co.uk/moj/map/default' target='_blank'>Map Maker</a>.",
+                            classes: 'govuk-!-margin-bottom-3'
+                        }) }}
+                    {% endif %}
                     <div class="govuk-button-group">
                         {{ govukButton({
                             text: "Continue",
@@ -53,13 +72,19 @@
                             attributes: { 'data-qa': 'continue' },
                             preventDoubleClick: true
                         }) }}
-                        {{ govukButton({
-                            text: "Delete this condition",
-                            href: "/licence/create/id/" + licence.id + "/additional-licence-conditions/condition/" + additionalCondition.id + "/delete" + fromReview + fromPolicyReviewQuery,
-                            classes: 'govuk-button--secondary',
-                            attributes: { 'data-qa': 'delete' },
-                            preventDoubleClick: true
-                        }) }}
+                        
+                        {% if fileUploadPresent %}
+                            <a class="govuk-link govuk-link--no-visited-state"
+                                href={{ "/licence/create/id/" + licence.id +"/additional-licence-conditions/condition/"+additionalCondition.code+"/file-uploads?fromReview=true" }}>Cancel</a>
+                        {% else %}
+                            {{ govukButton({
+                                text: "Delete this condition",
+                                href: "/licence/create/id/" + licence.id + "/additional-licence-conditions/condition/" + additionalCondition.id + "/file-upload-delete" + fromReview + fromPolicyReviewQuery,
+                                classes: 'govuk-button--secondary',
+                                attributes: { 'data-qa': 'delete' },
+                                preventDoubleClick: true
+                            }) }}
+                        {% endif %}
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Split out the existing routes so MEZ has its own template on
`/additional-licence-conditions/condition/:conditionId`

and then that template posts to its own special handlers for setting data and deletions:
```
/additional-licence-conditions/condition/:conditionId/file-upload-input
/additional-licence-conditions/condition/:conditionId/file-upload-removal
``` 

This reduces complexity in normal condition endpoints and also allows the ability to customize the MEZ journey a bit more freely