### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/helm_deploy/create-and-vary-a-licence/Chart.yaml
+++ b/helm_deploy/create-and-vary-a-licence/Chart.yaml
@@ -5,11 +5,11 @@ name: create-and-vary-a-licence
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: "2.7"
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-service
     alias: gotenberg
-    version: "2.7"
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.1.0

--- a/helm_deploy/create-and-vary-a-licence/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence/values.yaml
@@ -1,4 +1,3 @@
----
 cronjobs:
   activate_licences: "0 3,9,12,15,18 * * *" # 3am, 9am, 12pm, 3pm, and 6pm every day
   email_probation_practioner: "0 2 * * *" # 2am every day
@@ -74,10 +73,8 @@ generic-service:
   allowlist:
     hmp-parc-1: 217.161.76.162/32
     hmp-parc-2: 217.161.76.154/32
-    groups:
-      - internal
-      - prisons
-      - private_prisons
+    undefined: internal,prisons,private_prisons/32
+    groups: []
 
 gotenberg:
   nameOverride: gotenberg


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/create-and-vary-a-licence/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `3 => 3 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
