### PR TITLE
CVSL-1513: Adding unique name for session cookie

### DIFF
--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -13,6 +13,7 @@ export default function setUpWebSession(): Router {
   const router = express.Router()
   router.use(
     session({
+      name: 'create-and-vary-a-licence.session',
       store: new RedisStore({ client }),
       cookie: { secure: config.https, sameSite: 'lax', maxAge: config.session.expiryMinutes * 60 * 1000 },
       secret: config.session.secret,


### PR DESCRIPTION
This is to help counter any issues with other cookies on the domain overriding our sessions