### PR TITLE
CVSL-1514 Moving cronjob values to new pattern and enabling in preprod and prod

### DIFF
--- a/helm_deploy/create-and-vary-a-licence/templates/expire-active-licences-cronjob.yaml
+++ b/helm_deploy/create-and-vary-a-licence/templates/expire-active-licences-cronjob.yaml
@@ -1,10 +1,10 @@
-{{- if .Values.EXPIRE_LICENCES_JOB_ENABLED -}}
+{{- if .Values.cronjobs.expire_licences.enabled -}}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: expire-licences
 spec:
-  schedule: {{ .Values.cronjobs.expire_active_licences }}
+  schedule: {{ .Values.cronjobs.expire_licences.schedule }}
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 43200

--- a/helm_deploy/create-and-vary-a-licence/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence/values.yaml
@@ -2,12 +2,14 @@
 cronjobs:
   activate_licences: "0 3,9,12,15,18 * * *" # 3am, 9am, 12pm, 3pm, and 6pm every day
   email_probation_practioner: "0 2 * * *" # 2am every day
-  expire_active_licences: "0 4 * * *" # 4am every day
   prompt_licence_creation: "0 7 * * 1" # 7am UTC every monday
   remove_expired_conditions: "0 3 * * *" # 3am every day
   time_out_licences:
     enabled: false
     schedule: "30 1 * * 1-5" # 1:30am UTC Monday - Friday
+  expire_licences:
+    enabled: true
+    schedule: "0 4 * * *" # 4am every day
 
 generic-service:
   nameOverride: create-and-vary-a-licence
@@ -50,7 +52,6 @@ generic-service:
     COMMON_COMPONENTS_ENABLED: 'true'
     MANAGE_USERS_API_URL: 'https://manage-users-api-dev.hmpps.service.justice.gov.uk'
     FRIDAY_RELEASE_POLICY: 'https://www.gov.uk/government/publications/discretionary-fridaypre-bank-holiday-release-scheme-policy-framework'
-    EXPIRE_LICENCES_JOB_ENABLED: "false"
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -2,12 +2,14 @@
 cronjobs:
   activate_licences: "0 9,12,15,18 * * 1-5" # 9am, 12pm, 3pm, and 6pm UTC, Monday - Friday
   email_probation_practioner: "0 11 * * 1-5" # 11am UTC, Monday - Friday
-  expire_active_licences: "0 10 * * 1-5" # 10am UTC, Monday - Friday
   prompt_licence_creation: "0 8 * * 1" # 8am UTC, every monday
   remove_expired_conditions: "0 7 * * 1-5" # 7am UTC, Monday - Friday
   time_out_licences:
     enabled: true
     schedule: "30 1 * * 1-5" # 1:30am UTC Monday - Friday
+  expire_licences:
+    enabled: false
+    schedule: "0 10 * * 1-5" # 10am UTC, Monday - Friday
 
 generic-service:
   replicaCount: 2

--- a/helm_deploy/values-test1.yaml
+++ b/helm_deploy/values-test1.yaml
@@ -2,9 +2,11 @@
 cronjobs:
   activate_licences: "0 9,12,15,18 * * 1-5" # 9am, 12pm, 3pm, and 6pm UTC, Monday - Friday
   email_probation_practioner: "0 11 * * 1-5" # 11am UTC, Monday - Friday
-  expire_active_licences: "0 10 * * 1-5" # 10am UTC, Monday - Friday
   prompt_licence_creation: "0 8 * * 1" # 8am UTC, every monday
   remove_expired_conditions: "0 7 * * 1-5" # 7am UTC, Monday - Friday
+  expire_licences:
+    enabled: false
+    schedule: "0 10 * * 1-5" # 10am UTC, Monday - Friday
 
 generic-service:
   replicaCount: 2

--- a/helm_deploy/values-test2.yaml
+++ b/helm_deploy/values-test2.yaml
@@ -2,9 +2,11 @@
 cronjobs:
   activate_licences: "0 9,12,15,18 * * 1-5" # 9am, 12pm, 3pm, and 6pm UTC, Monday - Friday
   email_probation_practioner: "0 11 * * 1-5" # 11am UTC, Monday - Friday
-  expire_active_licences: "0 10 * * 1-5" # 10am UTC, Monday - Friday
   prompt_licence_creation: "0 8 * * 1" # 8am UTC, every monday
   remove_expired_conditions: "0 7 * * 1-5" # 7am UTC, Monday - Friday
+  expire_licences:
+    enabled: false
+    schedule: "0 10 * * 1-5" # 10am UTC, Monday - Friday
 
 generic-service:
   replicaCount: 2


### PR DESCRIPTION
Disabled in dev and test environments because the dates of these cases are often unreliable, so could lead to mass-deactivation of useful test cases.