### PR TITLE
CVSL-1587 Adding initial appointment editing without reapproval

### DIFF
--- a/server/routes/creatingLicences/handlers/checkAnswers.ts
+++ b/server/routes/creatingLicences/handlers/checkAnswers.ts
@@ -8,6 +8,8 @@ import { FieldValidationError } from '../../../middleware/validationMiddleware'
 import LicenceType from '../../../enumeration/licenceType'
 import ConditionService from '../../../services/conditionService'
 import { groupingBy } from '../../../utils/utils'
+import config from '../../../config'
+import LicenceKind from '../../../enumeration/LicenceKind'
 
 export default class CheckAnswersRoutes {
   constructor(
@@ -38,6 +40,9 @@ export default class CheckAnswersRoutes {
       additionalConditions: groupingBy(conditionsToDisplay, 'code'),
       bespokeConditionsToDisplay,
       backLink,
+      initialApptUpdatedMessage: req.flash('initialApptUpdated')?.[0],
+      canEditInitialAppt:
+        licence.kind !== LicenceKind.VARIATION && !(config.hardStopEnabled && licence.isInHardStopPeriod),
     })
   }
 

--- a/server/routes/initialAppointment/handlers/initialMeetingContact.test.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingContact.test.ts
@@ -4,6 +4,9 @@ import InitialMeetingContactRoutes from './initialMeetingContact'
 import LicenceService from '../../../services/licenceService'
 import Telephone from '../types/telephone'
 import UserType from '../../../enumeration/userType'
+import flashInitialApptUpdatedMessage from './initialMeetingUpdatedFlashMessage'
+
+jest.mock('./initialMeetingUpdatedFlashMessage')
 
 const licenceService = new LicenceService(null, null) as jest.Mocked<LicenceService>
 
@@ -71,6 +74,11 @@ describe('Route Handlers - Create Licence - Initial Meeting Contact', () => {
         await handler.POST(req, res)
         expect(res.redirect).toHaveBeenCalledWith('/licence/create/id/1/check-your-answers')
       })
+
+      it('should call to generate a flash message', async () => {
+        await handler.POST(req, res)
+        expect(flashInitialApptUpdatedMessage).toHaveBeenCalledWith(req, res.locals.licence, UserType.PROBATION)
+      })
     })
   })
 
@@ -95,6 +103,11 @@ describe('Route Handlers - Create Licence - Initial Meeting Contact', () => {
           { username: 'joebloggs' }
         )
         expect(res.redirect).toHaveBeenCalledWith('/licence/view/id/1/show')
+      })
+
+      it('should call to generate a flash message', async () => {
+        await handler.POST(req, res)
+        expect(flashInitialApptUpdatedMessage).toHaveBeenCalledWith(req, res.locals.licence, UserType.PRISON)
       })
     })
   })

--- a/server/routes/initialAppointment/handlers/initialMeetingContact.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingContact.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import LicenceService from '../../../services/licenceService'
 import UserType from '../../../enumeration/userType'
+import flashInitialApptUpdatedMessage from './initialMeetingUpdatedFlashMessage'
 
 export default class InitialMeetingContactRoutes {
   constructor(
@@ -18,8 +19,10 @@ export default class InitialMeetingContactRoutes {
 
   POST = async (req: Request, res: Response): Promise<void> => {
     const { licenceId } = req.params
-    const { user } = res.locals
+    const { user, licence } = res.locals
     await this.licenceService.updateContactNumber(licenceId, req.body, user)
+
+    flashInitialApptUpdatedMessage(req, licence, this.userType)
 
     if (this.userType === UserType.PRISON) {
       res.redirect(`/licence/view/id/${licenceId}/show`)

--- a/server/routes/initialAppointment/handlers/initialMeetingName.test.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingName.test.ts
@@ -3,6 +3,9 @@ import { Request, Response } from 'express'
 import InitialMeetingNameRoutes from './initialMeetingName'
 import LicenceService from '../../../services/licenceService'
 import UserType from '../../../enumeration/userType'
+import flashInitialApptUpdatedMessage from './initialMeetingUpdatedFlashMessage'
+
+jest.mock('./initialMeetingUpdatedFlashMessage')
 
 const licenceService = new LicenceService(null, null) as jest.Mocked<LicenceService>
 
@@ -60,6 +63,11 @@ describe('Route Handlers - Create Licence - Initial Meeting Name - Probation use
         await handler.POST(req, res)
         expect(res.redirect).toHaveBeenCalledWith('/licence/create/id/1/check-your-answers')
       })
+
+      it('should call to generate a flash message', async () => {
+        await handler.POST(req, res)
+        expect(flashInitialApptUpdatedMessage).toHaveBeenCalledWith(req, res.locals.licence, UserType.PROBATION)
+      })
     })
   })
 
@@ -80,6 +88,11 @@ describe('Route Handlers - Create Licence - Initial Meeting Name - Probation use
         await handler.POST(req, res)
         expect(licenceService.updateAppointmentPerson).toHaveBeenCalledWith('1', {}, { username: 'joebloggs' })
         expect(res.redirect).toHaveBeenCalledWith('/licence/view/id/1/show')
+      })
+
+      it('should call to generate a flash message', async () => {
+        await handler.POST(req, res)
+        expect(flashInitialApptUpdatedMessage).toHaveBeenCalledWith(req, res.locals.licence, UserType.PRISON)
       })
     })
   })

--- a/server/routes/initialAppointment/handlers/initialMeetingName.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingName.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import LicenceService from '../../../services/licenceService'
 import UserType from '../../../enumeration/userType'
+import flashInitialApptUpdatedMessage from './initialMeetingUpdatedFlashMessage'
 
 export default class InitialMeetingNameRoutes {
   constructor(
@@ -18,8 +19,10 @@ export default class InitialMeetingNameRoutes {
 
   POST = async (req: Request, res: Response): Promise<void> => {
     const { licenceId } = req.params
-    const { user } = res.locals
+    const { user, licence } = res.locals
     await this.licenceService.updateAppointmentPerson(licenceId, req.body, user)
+
+    flashInitialApptUpdatedMessage(req, licence, this.userType)
 
     if (this.userType === UserType.PRISON) {
       res.redirect(`/licence/view/id/${licenceId}/show`)

--- a/server/routes/initialAppointment/handlers/initialMeetingPlace.test.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingPlace.test.ts
@@ -4,6 +4,9 @@ import InitialMeetingPlaceRoutes from './initialMeetingPlace'
 import LicenceService from '../../../services/licenceService'
 import Address from '../types/address'
 import UserType from '../../../enumeration/userType'
+import flashInitialApptUpdatedMessage from './initialMeetingUpdatedFlashMessage'
+
+jest.mock('./initialMeetingUpdatedFlashMessage')
 
 const licenceService = new LicenceService(null, null) as jest.Mocked<LicenceService>
 
@@ -73,6 +76,11 @@ describe('Route Handlers - Create Licence - Initial Meeting Place', () => {
         await handler.POST(req, res)
         expect(res.redirect).toHaveBeenCalledWith('/licence/create/id/1/check-your-answers')
       })
+
+      it('should call to generate a flash message', async () => {
+        await handler.POST(req, res)
+        expect(flashInitialApptUpdatedMessage).toHaveBeenCalledWith(req, res.locals.licence, UserType.PROBATION)
+      })
     })
   })
 
@@ -94,6 +102,11 @@ describe('Route Handlers - Create Licence - Initial Meeting Place', () => {
         await handler.POST(req, res)
         expect(licenceService.updateAppointmentAddress).toHaveBeenCalledWith(1, formAddress, { username: 'joebloggs' })
         expect(res.redirect).toHaveBeenCalledWith('/licence/view/id/1/show')
+      })
+
+      it('should call to generate a flash message', async () => {
+        await handler.POST(req, res)
+        expect(flashInitialApptUpdatedMessage).toHaveBeenCalledWith(req, res.locals.licence, UserType.PRISON)
       })
     })
   })

--- a/server/routes/initialAppointment/handlers/initialMeetingPlace.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingPlace.ts
@@ -2,6 +2,7 @@ import { Request, Response } from 'express'
 import { stringToAddressObject } from '../../../utils/utils'
 import LicenceService from '../../../services/licenceService'
 import UserType from '../../../enumeration/userType'
+import flashInitialApptUpdatedMessage from './initialMeetingUpdatedFlashMessage'
 
 export default class InitialMeetingPlaceRoutes {
   constructor(
@@ -21,8 +22,10 @@ export default class InitialMeetingPlaceRoutes {
 
   POST = async (req: Request, res: Response): Promise<void> => {
     const { licenceId } = req.params
-    const { user } = res.locals
+    const { user, licence } = res.locals
     await this.licenceService.updateAppointmentAddress(licenceId, req.body, user)
+
+    flashInitialApptUpdatedMessage(req, licence, this.userType)
 
     if (this.userType === UserType.PRISON) {
       res.redirect(`/licence/view/id/${licenceId}/show`)

--- a/server/routes/initialAppointment/handlers/initialMeetingTime.test.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingTime.test.ts
@@ -5,6 +5,9 @@ import LicenceService from '../../../services/licenceService'
 import DateTime from '../types/dateTime'
 import UserType from '../../../enumeration/userType'
 import AppointmentTimeType from '../../../enumeration/appointmentTimeType'
+import flashInitialApptUpdatedMessage from './initialMeetingUpdatedFlashMessage'
+
+jest.mock('./initialMeetingUpdatedFlashMessage')
 
 const licenceService = new LicenceService(null, null) as jest.Mocked<LicenceService>
 
@@ -93,6 +96,11 @@ describe('Route - create licence - initial meeting date and time', () => {
         await handler.POST(req, res)
         expect(res.redirect).toHaveBeenCalledWith('/licence/create/id/1/additional-pss-conditions-question')
       })
+
+      it('should call to generate a flash message', async () => {
+        await handler.POST(req, res)
+        expect(flashInitialApptUpdatedMessage).toHaveBeenCalledWith(req, res.locals.licence, UserType.PROBATION)
+      })
     })
 
     describe('getNextPage', () => {
@@ -147,6 +155,11 @@ describe('Route - create licence - initial meeting date and time', () => {
         await handler.POST(req, res)
         expect(licenceService.updateAppointmentTime).toHaveBeenCalledWith(1, formDate, { username: 'joebloggs' })
         expect(res.redirect).toHaveBeenCalledWith('/licence/view/id/1/show')
+      })
+
+      it('should call to generate a flash message', async () => {
+        await handler.POST(req, res)
+        expect(flashInitialApptUpdatedMessage).toHaveBeenCalledWith(req, res.locals.licence, UserType.PRISON)
       })
     })
 

--- a/server/routes/initialAppointment/handlers/initialMeetingTime.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingTime.ts
@@ -27,9 +27,10 @@ export default class InitialMeetingTimeRoutes {
 
   POST = async (req: Request, res: Response): Promise<void> => {
     const { licenceId } = req.params
-    const { licence } = res.locals
-    const { user } = res.locals
+    const { user, licence } = res.locals
     await this.licenceService.updateAppointmentTime(licenceId, req.body, user)
+
+    flashInitialApptUpdatedMessage(req, licence, this.userType)
 
     return res.redirect(this.getNextPage(licenceId, licence.typeCode, req))
   }

--- a/server/routes/initialAppointment/handlers/initialMeetingTime.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingTime.ts
@@ -4,6 +4,7 @@ import DateTime from '../types/dateTime'
 import LicenceType from '../../../enumeration/licenceType'
 import UserType from '../../../enumeration/userType'
 import AppointmentTimeType from '../../../enumeration/appointmentTimeType'
+import flashInitialApptUpdatedMessage from './initialMeetingUpdatedFlashMessage'
 
 export default class InitialMeetingTimeRoutes {
   constructor(

--- a/server/routes/initialAppointment/handlers/initialMeetingUpdatedFlashMessage.test.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingUpdatedFlashMessage.test.ts
@@ -1,0 +1,70 @@
+import { Request } from 'express'
+import { Licence } from '../../../@types/licenceApiClientTypes'
+import LicenceStatus from '../../../enumeration/licenceStatus'
+import flashInitialApptUpdatedMessage from './initialMeetingUpdatedFlashMessage'
+import UserType from '../../../enumeration/userType'
+
+describe('Initial appointment updated flash message', () => {
+  let req: Request
+  let licence: Licence
+  beforeEach(() => {
+    req = {
+      flash: jest.fn(),
+    } as unknown as Request
+    licence = {
+      id: 1,
+      statusCode: LicenceStatus.APPROVED,
+    } as Licence
+  })
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  const messageKey = 'initialApptUpdated'
+
+  it('does not generate a message for any licence statuses other than SUBMITTED or APPROVED', () => {
+    Object.keys(LicenceStatus).forEach(key => {
+      flashInitialApptUpdatedMessage(req, { ...licence, statusCode: LicenceStatus[key] }, UserType.PROBATION)
+    })
+
+    expect(req.flash).toHaveBeenCalledTimes(2)
+  })
+
+  describe('for prison users', () => {
+    const userType = UserType.PRISON
+    it('sends the expected message for SUBMITTED licences', () => {
+      licence.statusCode = LicenceStatus.SUBMITTED
+      const expectedMessage = 'Initial appointment details updated. You must now tell the community probation team.'
+      flashInitialApptUpdatedMessage(req, licence, userType)
+
+      expect(req.flash).toHaveBeenCalledWith(messageKey, expectedMessage)
+    })
+
+    it('sends the expected message for APPROVED licences', () => {
+      const expectedMessage = `Initial appointment details updated. You must now tell the community probation team. <a target="_blank" href='/licence/view/id/1/pdf-print>View and print new licence PDF</a>`
+      flashInitialApptUpdatedMessage(req, licence, userType)
+
+      expect(req.flash).toHaveBeenCalledWith(messageKey, expectedMessage)
+    })
+  })
+
+  describe('for probation users', () => {
+    const userType = UserType.PROBATION
+    it('sends the expected message for SUBMITTED licences', () => {
+      licence.statusCode = LicenceStatus.SUBMITTED
+      const expectedMessage = 'Initial appointment details updated.'
+      flashInitialApptUpdatedMessage(req, licence, userType)
+
+      expect(req.flash).toHaveBeenCalledWith(messageKey, expectedMessage)
+    })
+
+    it('sends the expected message for APPROVED licences', () => {
+      const expectedMessage =
+        'Initial appointment details updated. You must now notify the prison so they can print the licence again.'
+      flashInitialApptUpdatedMessage(req, licence, userType)
+
+      expect(req.flash).toHaveBeenCalledWith(messageKey, expectedMessage)
+    })
+  })
+})

--- a/server/routes/initialAppointment/handlers/initialMeetingUpdatedFlashMessage.test.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingUpdatedFlashMessage.test.ts
@@ -42,7 +42,7 @@ describe('Initial appointment updated flash message', () => {
     })
 
     it('sends the expected message for APPROVED licences', () => {
-      const expectedMessage = `Initial appointment details updated. You must now tell the community probation team. <a target="_blank" href='/licence/view/id/1/pdf-print>View and print new licence PDF</a>`
+      const expectedMessage = `Initial appointment details updated. You must now tell the community probation team. <a target="_blank" href='/licence/view/id/1/pdf-print'>View and print new licence PDF</a>`
       flashInitialApptUpdatedMessage(req, licence, userType)
 
       expect(req.flash).toHaveBeenCalledWith(messageKey, expectedMessage)

--- a/server/routes/initialAppointment/handlers/initialMeetingUpdatedFlashMessage.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingUpdatedFlashMessage.ts
@@ -12,7 +12,7 @@ const flashInitialApptUpdatedMessage = (req: Request, licence: Licence, userType
   if (userType === UserType.PRISON) {
     updateMessage += ' You must now tell the community probation team.'
     if (licence.statusCode === LicenceStatus.APPROVED) {
-      updateMessage += ` <a target="_blank" href='/licence/view/id/${licence.id}/pdf-print>View and print new licence PDF</a>`
+      updateMessage += ` <a target="_blank" href='/licence/view/id/${licence.id}/pdf-print'>View and print new licence PDF</a>`
     }
   } else if (userType === UserType.PROBATION && licence.statusCode === LicenceStatus.APPROVED) {
     updateMessage += ' You must now notify the prison so they can print the licence again.'

--- a/server/routes/initialAppointment/handlers/initialMeetingUpdatedFlashMessage.ts
+++ b/server/routes/initialAppointment/handlers/initialMeetingUpdatedFlashMessage.ts
@@ -1,0 +1,23 @@
+import { Request } from 'express'
+import UserType from '../../../enumeration/userType'
+import LicenceStatus from '../../../enumeration/licenceStatus'
+import { Licence } from '../../../@types/licenceApiClientTypes'
+
+const flashInitialApptUpdatedMessage = (req: Request, licence: Licence, userType: UserType) => {
+  if (licence.statusCode !== LicenceStatus.SUBMITTED && licence.statusCode !== LicenceStatus.APPROVED) {
+    return
+  }
+
+  let updateMessage = 'Initial appointment details updated.'
+  if (userType === UserType.PRISON) {
+    updateMessage += ' You must now tell the community probation team.'
+    if (licence.statusCode === LicenceStatus.APPROVED) {
+      updateMessage += ` <a target="_blank" href='/licence/view/id/${licence.id}/pdf-print>View and print new licence PDF</a>`
+    }
+  } else if (userType === UserType.PROBATION && licence.statusCode === LicenceStatus.APPROVED) {
+    updateMessage += ' You must now notify the prison so they can print the licence again.'
+  }
+  req.flash('initialApptUpdated', updateMessage)
+}
+
+export default flashInitialApptUpdatedMessage

--- a/server/routes/viewingLicences/handlers/viewLicence.test.ts
+++ b/server/routes/viewingLicences/handlers/viewLicence.test.ts
@@ -41,6 +41,7 @@ describe('Route - view and approve a licence', () => {
         licenceId: '1',
       },
       query: {},
+      flash: jest.fn(),
     } as unknown as Request
     licenceService.recordAuditEvent = jest.fn()
   })
@@ -165,6 +166,21 @@ describe('Route - view and approve a licence', () => {
           'You can also view and print the last approved version of this licence</a>.',
       })
       expect(licenceService.recordAuditEvent).not.toHaveBeenCalled()
+    })
+
+    it('should read flash message for initial appointment updates', async () => {
+      res = {
+        render: jest.fn(),
+        redirect: jest.fn(),
+        locals: {
+          user,
+          licence,
+        },
+      } as unknown as Response
+
+      await handler.GET(req, res)
+
+      expect(req.flash).toHaveBeenCalledWith('initialApptUpdated')
     })
 
     describe('when hard stop is enabled', () => {

--- a/server/routes/viewingLicences/handlers/viewLicence.ts
+++ b/server/routes/viewingLicences/handlers/viewLicence.ts
@@ -63,8 +63,9 @@ export default class ViewAndPrintLicenceRoutes {
         additionalConditions: groupingBy(licence.additionalLicenceConditions, 'code'),
         warningMessage,
         isEditableByPrison:
-          config.hardStopEnabled && licence.kind !== LicenceKind.VARIATION && licence.isInHardStopPeriod,
+          licence.kind !== LicenceKind.VARIATION && config.hardStopEnabled && licence.isInHardStopPeriod,
         isPrisonUser: user.authSource === 'nomis',
+        initialApptUpdatedMessage: req.flash('initialApptUpdated')?.[0],
       })
     } else {
       res.redirect(`/licence/view/cases`)

--- a/server/utils/urlAccessByStatus.test.ts
+++ b/server/utils/urlAccessByStatus.test.ts
@@ -42,9 +42,9 @@ describe('URL access checks for licence statuses', () => {
       expect(getUrlAccessByStatus(path, 1, 'SUBMITTED', username)).toEqual(true)
     })
 
-    it('should deny access to creation forms', () => {
+    it('should allow access to editing initial appointment information', () => {
       path = '/licence/create/id/1/initial-meeting-name'
-      expect(getUrlAccessByStatus(path, 1, 'SUBMITTED', username)).toEqual(false)
+      expect(getUrlAccessByStatus(path, 1, 'SUBMITTED', username)).toEqual(true)
     })
 
     it('should deny access to pdf print', () => {
@@ -59,8 +59,13 @@ describe('URL access checks for licence statuses', () => {
       expect(getUrlAccessByStatus(path, 1, 'APPROVED', username)).toEqual(true)
     })
 
-    it('should deny access to other creation forms', () => {
+    it('should allow access to editing initial appointment information', () => {
       path = '/licence/create/id/1/initial-meeting-name'
+      expect(getUrlAccessByStatus(path, 1, 'APPROVED', username)).toEqual(true)
+    })
+
+    it('should deny access to other creation forms', () => {
+      path = '/licence/create/id/1//additional-licence-conditions-question'
       expect(getUrlAccessByStatus(path, 1, 'APPROVED', username)).toEqual(false)
     })
 

--- a/server/utils/urlAccessByStatus.ts
+++ b/server/utils/urlAccessByStatus.ts
@@ -18,6 +18,7 @@ const allowedPaths = [
       '/licence/create/id/(\\d)*/check-your-answers.*',
       '/licence/create/id/(\\d)*/edit.*',
       '/licence/create/id/(\\d)*/confirmation.*',
+      '/licence/create/id/(\\d)*/initial-meeting.*',
       '/licence/view/id/(\\d)*/.*',
       '/licence/approve/id/(\\d)*/.*',
     ],
@@ -28,6 +29,7 @@ const allowedPaths = [
     allowed: [
       '/licence/create/id/(\\d)*/check-your-answers.*',
       '/licence/create/id/(\\d)*/edit.*',
+      '/licence/create/id/(\\d)*/initial-meeting.*',
       '/licence/approve/id/(\\d)*/confirm-approved.*',
       '/licence/view/id/(\\d)*/.*',
       '/licence/approve/id/(\\d)*/probation-practitioner.*',

--- a/server/views/pages/create/checkAnswers.njk
+++ b/server/views/pages/create/checkAnswers.njk
@@ -6,6 +6,7 @@
 {% from "partials/additionalPssConditionsSummary.njk" import additionalPssConditions %}
 {% from "partials/bespokeConditionsSummary.njk" import bespokeConditions %}
 {% from "partials/variationSummary.njk" import variationSummary %}
+{% from "moj/components/banner/macro.njk" import mojBanner %}
 
 {% set pageTitle = applicationName + " - Create a licence - Check your answers" %}
 {% set pageId = "check-answers-page" %}
@@ -24,6 +25,13 @@
 {% endif %}
 
 {% block content %}
+    {% if initialApptUpdatedMessage | length > 0%}
+        {{ mojBanner({
+            type: 'success',
+            text: initialApptUpdatedMessage,
+            iconFallbackText: 'Success'
+        }) }}
+    {% endif %}  
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             {% if licence.kind === 'VARIATION' %}
@@ -77,7 +85,7 @@
             {% if licence.kind === 'VARIATION' %}
                 {{ variationSummary(licence, isInProgress) }}
             {% else %}
-                {{ inductionMeetingDetails(licence, isInProgress, validationErrors) }}
+                {{ inductionMeetingDetails(licence, canEditInitialAppt, validationErrors) }}
             {% endif %}
 
 

--- a/server/views/pages/create/checkAnswers.test.ts
+++ b/server/views/pages/create/checkAnswers.test.ts
@@ -240,7 +240,7 @@ describe('Create a Licence Views - Check Answers', () => {
     )
   })
 
-  it('should show change links and submit button when licence status is IN_PROGRESS', () => {
+  it('should show change links and submit button when licence status is IN_PROGRESS and canEditInitialAppt is true', () => {
     const $ = render({
       licence: { ...licence, statusCode: 'IN_PROGRESS' },
       additionalConditions: [
@@ -285,6 +285,7 @@ describe('Create a Licence Views - Check Answers', () => {
           },
         ],
       ],
+      canEditInitialAppt: true,
     })
 
     expect($('.govuk-summary-list__actions').length).toBe(11)
@@ -334,10 +335,62 @@ describe('Create a Licence Views - Check Answers', () => {
           },
         ],
       ],
+      canEditInitialAppt: true,
     })
 
     expect($2('.govuk-summary-list__actions').length).toBe(10)
     expect($2('[data-qa="send-licence-conditions"]').length).toBe(1)
+  })
+
+  it('should hide edit initial appointment buttons when canEditInitialAppt is false', () => {
+    const $ = render({
+      licence: { ...licence, statusCode: 'IN_PROGRESS' },
+      additionalConditions: [
+        [
+          {
+            code: 'condition1',
+            category: 'Category 1',
+            expandedText: 'Template 1',
+            uploadSummary: [],
+            data: [
+              {
+                field: 'field1',
+                value: 'Data 1',
+                contributesToLicence: true,
+              },
+            ],
+          },
+        ],
+        [
+          {
+            code: 'condition2',
+            category: 'Category 2',
+            expandedText: 'Template 2',
+            uploadSummary: [],
+            data: [
+              {
+                field: 'field2',
+                value: 'Data 2A',
+                contributesToLicence: true,
+              },
+              {
+                field: 'field2',
+                value: 'Data 2B',
+                contributesToLicence: true,
+              },
+              {
+                field: 'field3',
+                value: 'Data 2C',
+                contributesToLicence: true,
+              },
+            ],
+          },
+        ],
+      ],
+      canEditInitialAppt: false,
+    })
+
+    expect($('.govuk-summary-list__actions').length).toBe(6)
   })
 
   it('should hide edit licence button when status is IN_PROGRESS', () => {

--- a/server/views/pages/view/view.njk
+++ b/server/views/pages/view/view.njk
@@ -6,6 +6,7 @@
 {% from "partials/additionalLicenceConditionsSummary.njk" import additionalLicenceConditions %}
 {% from "partials/additionalPssConditionsSummary.njk" import additionalPssConditions %}
 {% from "partials/bespokeConditionsSummary.njk" import bespokeConditions %}
+{% from "moj/components/banner/macro.njk" import mojBanner %}
 
 {% if licence.statusCode === "APPROVED" or licence.statusCode === "ACTIVE" %}
   {% set actionWord = "Print" %}
@@ -20,6 +21,14 @@
 {% set backLinkHref = "/licence/view/cases" %}
 
 {% block content %}
+    {% if initialApptUpdatedMessage | length > 0%}
+        {{ mojBanner({
+            type: 'success',
+            html: initialApptUpdatedMessage,
+            iconFallbackText: 'Success'
+        }) }}
+    {% endif %}  
+    
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             {% if licence.typeCode === 'AP' %}


### PR DESCRIPTION
Also adds flash messages to initial appointment updates for SUBMITTED and APPROVED licences