### PR TITLE
CVSL-1767 Allow prison users to not have email

### DIFF
--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -170,7 +170,7 @@ describe('populateCurrentUser', () => {
     expect(next).toHaveBeenCalled()
   })
 
-  it('should throw error and not call updatePrisonUserDetails when email of a nomis user is not found', async () => {
+  it('should call updatePrisonUserDetails when email of a nomis user is not found or is unverified', async () => {
     res.locals.user.authSource = 'nomis'
     req.user.userRoles = [AuthRole.CASE_ADMIN]
 
@@ -198,7 +198,12 @@ describe('populateCurrentUser', () => {
 
     await middleware(req, res, next)
 
-    expect(licenceServiceMock.updatePrisonUserDetails).not.toHaveBeenCalled()
+    expect(licenceServiceMock.updatePrisonUserDetails).toHaveBeenCalledWith({
+      staffUsername: 'joebloggs',
+      staffEmail: undefined,
+      firstName: 'Joe',
+      lastName: 'Bloggs',
+    })
     expect(next).toHaveBeenCalled()
   })
 

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -51,7 +51,6 @@ export default function populateCurrentUser(userService: UserService, licenceSer
             )
 
             const { email } = await userService.getUserEmail(user)
-            if (!email) throw new Error(`Failed to get email for: ${user.username}`)
             await licenceService.updatePrisonUserDetails({
               staffUsername: prisonUser.username,
               staffEmail: email,


### PR DESCRIPTION
This provides access to the serviceto people who have unverified email addresses. Reasoning that it's better to not store an unverified email address