### PR TITLE
CVSL-1786 Adding standard parsing methods for dates

### DIFF
--- a/server/listeners/eventHandlers/prisonEvents/datesChangedEventHandler.ts
+++ b/server/listeners/eventHandlers/prisonEvents/datesChangedEventHandler.ts
@@ -1,8 +1,8 @@
-import { format, isAfter, parse } from 'date-fns'
+import { format, isAfter } from 'date-fns'
 import LicenceService from '../../../services/licenceService'
 import PrisonerService from '../../../services/prisonerService'
 import LicenceStatus from '../../../enumeration/licenceStatus'
-import { convertDateFormat } from '../../../utils/utils'
+import { convertDateFormat, parseCvlDate } from '../../../utils/utils'
 import logger from '../../../../logger'
 import { LicenceSummary } from '../../../@types/licenceApiClientTypes'
 import { PrisonEventMessage } from '../../../@types/events'
@@ -51,9 +51,7 @@ export default class DatesChangedEventHandler {
     const ssd = await this.prisonerService.getPrisonerLatestSentenceStartDate(bookingId)
     await Promise.all(
       licences.map(async licence => {
-        const crd = licence.conditionalReleaseDate
-          ? parse(licence.conditionalReleaseDate, 'dd/MM/yyyy', new Date())
-          : null
+        const crd = licence.conditionalReleaseDate ? parseCvlDate(licence.conditionalReleaseDate) : null
 
         if (ssd && crd && isAfter(ssd, crd)) {
           logger.info(

--- a/server/routes/approvingLicences/handlers/approvalCases.ts
+++ b/server/routes/approvingLicences/handlers/approvalCases.ts
@@ -1,8 +1,8 @@
 import { Request, Response } from 'express'
 import _ from 'lodash'
-import { format, getUnixTime, isAfter, isValid, parse, subDays } from 'date-fns'
+import { format, getUnixTime, isAfter, isValid, subDays } from 'date-fns'
 import PrisonerService from '../../../services/prisonerService'
-import { convertToTitleCase, selectReleaseDate } from '../../../utils/utils'
+import { convertToTitleCase, parseCvlDateTime, selectReleaseDate } from '../../../utils/utils'
 import ApproverCaseloadService from '../../../services/approverCaseloadService'
 
 export default class ApprovalCaseRoutes {
@@ -31,7 +31,7 @@ export default class ApprovalCaseRoutes {
         let approvedDate
         if (_.head(c.licences).approvedDate) {
           approvedDate = format(
-            parse(_.head(c.licences).approvedDate, 'dd/MM/yyyy HH:mm:ss', new Date()),
+            parseCvlDateTime(_.head(c.licences).approvedDate, { withSeconds: true }),
             'dd MMMM yyyy'
           )
         }
@@ -41,7 +41,7 @@ export default class ApprovalCaseRoutes {
           prisonerNumber: c.nomisRecord.prisonerNumber,
           probationPractitioner: c.probationPractitioner,
           submittedByFullName: _.head(c.licences).submittedByFullName,
-          releaseDate,
+          releaseDate: releaseDate ? format(releaseDate, 'dd MMM yyyy') : 'not found',
           urgentApproval,
           approvedBy: _.head(c.licences).approvedBy,
           approvedOn: approvedDate,
@@ -73,8 +73,7 @@ export default class ApprovalCaseRoutes {
     })
   }
 
-  isUrgentApproval = (releaseDateString: string): boolean => {
-    const releaseDate = parse(releaseDateString, 'dd MMM yyyy', new Date())
+  isUrgentApproval = (releaseDate: Date): boolean => {
     const isValidDate = isValid(releaseDate)
     return isValidDate && isAfter(new Date(), subDays(releaseDate, 2))
   }

--- a/server/routes/approvingVariations/handlers/varyApproveList.ts
+++ b/server/routes/approvingVariations/handlers/varyApproveList.ts
@@ -1,9 +1,9 @@
 import { Request, Response } from 'express'
 import moment from 'moment'
 import _ from 'lodash'
-import { format, parse } from 'date-fns'
+import { format } from 'date-fns'
 import CaseloadService from '../../../services/caseloadService'
-import { convertToTitleCase } from '../../../utils/utils'
+import { convertToTitleCase, parseCvlDateTime, parseIsoDate } from '../../../utils/utils'
 
 export default class VaryApproveListRoutes {
   constructor(private readonly caseloadService: CaseloadService) {}
@@ -22,11 +22,11 @@ export default class VaryApproveListRoutes {
         const licence = _.head(c.licences)
 
         const releaseDate = c.nomisRecord.releaseDate
-          ? format(parse(c.nomisRecord.releaseDate, 'yyyy-MM-dd', new Date()), 'dd MMM yyyy')
+          ? format(parseIsoDate(c.nomisRecord.releaseDate), 'dd MMM yyyy')
           : null
 
         const variationRequestDate = licence.dateCreated
-          ? format(parse(licence.dateCreated, 'dd/MM/yyyy HH:mm', new Date()), 'dd MMMM yyyy')
+          ? format(parseCvlDateTime(licence.dateCreated, { withSeconds: false }), 'dd MMMM yyyy')
           : null
 
         return {

--- a/server/routes/viewingLicences/handlers/viewCases.ts
+++ b/server/routes/viewingLicences/handlers/viewCases.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express'
-import { getUnixTime } from 'date-fns'
+import { format, getUnixTime } from 'date-fns'
 import _ from 'lodash'
 import statusConfig from '../../../licences/licenceStatus'
 import CaseloadService from '../../../services/caseloadService'
@@ -44,7 +44,7 @@ export default class ViewAndPrintCaseRoutes {
           name: convertToTitleCase(`${c.nomisRecord.firstName} ${c.nomisRecord.lastName}`.trim()),
           prisonerNumber: c.nomisRecord.prisonerNumber,
           probationPractitioner: c.probationPractitioner,
-          releaseDate,
+          releaseDate: releaseDate ? format(releaseDate, 'dd MMM yyyy') : 'not found',
           releaseDateLabel: c.nomisRecord.confirmedReleaseDate ? 'Confirmed release date' : 'CRD',
           licenceStatus: latestLicence.status,
           tabType,

--- a/server/routes/viewingLicences/handlers/viewLicence.ts
+++ b/server/routes/viewingLicences/handlers/viewLicence.ts
@@ -1,8 +1,8 @@
 import type { Request, Response } from 'express'
-import { format, parse } from 'date-fns'
+import { format } from 'date-fns'
 import LicenceStatus from '../../../enumeration/licenceStatus'
 import type LicenceService from '../../../services/licenceService'
-import { groupingBy, isInHardStopPeriod } from '../../../utils/utils'
+import { groupingBy, isInHardStopPeriod, parseCvlDateTime } from '../../../utils/utils'
 import { Licence } from '../../../@types/licenceApiClientTypes'
 import CommunityService from '../../../services/communityService'
 
@@ -98,6 +98,6 @@ export default class ViewAndPrintLicenceRoutes {
         licenceDate = licence.dateLastUpdated
         break
     }
-    return licenceDate ? format(parse(licenceDate, 'dd/MM/yyyy HH:mm:ss', new Date()), 'd LLLL yyyy') : null
+    return licenceDate ? format(parseCvlDateTime(licenceDate, { withSeconds: true }), 'd LLLL yyyy') : null
   }
 }

--- a/server/routes/views/CaseloadViewModel.test.ts
+++ b/server/routes/views/CaseloadViewModel.test.ts
@@ -1,5 +1,5 @@
 import moment from 'moment'
-import { addDays, parse, subDays } from 'date-fns'
+import { addDays, subDays } from 'date-fns'
 import { DeliusRecord, Licence, ManagedCase, ProbationPractitioner } from '../../@types/managedCase'
 import { Prisoner } from '../../@types/prisonerSearchApiClientTypes'
 import LicenceKind from '../../enumeration/LicenceKind'
@@ -7,6 +7,7 @@ import LicenceStatus from '../../enumeration/licenceStatus'
 import LicenceType from '../../enumeration/licenceType'
 import createCaseloadViewModel from './CaseloadViewModel'
 import config from '../../config'
+import { parseIsoDate } from '../../utils/utils'
 
 describe('CaseloadViewModel', () => {
   let nomisRecord: Prisoner
@@ -103,7 +104,7 @@ describe('CaseloadViewModel', () => {
     })
 
     it('sets showHardStopWarning to true if the release date is between the warning and cutoff dates', () => {
-      const releaseDate = parse(nomisRecord.releaseDate, 'yyyy-MM-dd', new Date())
+      const releaseDate = parseIsoDate(nomisRecord.releaseDate)
       hardStopDates = { hardStopWarningDate: addDays(releaseDate, 1), hardStopCutoffDate: subDays(releaseDate, 1) }
 
       expect(
@@ -116,7 +117,7 @@ describe('CaseloadViewModel', () => {
     })
 
     it('sets showHardStopWarning to true if the release date is equal to the warning date', () => {
-      const releaseDate = parse(nomisRecord.releaseDate, 'yyyy-MM-dd', new Date())
+      const releaseDate = parseIsoDate(nomisRecord.releaseDate)
       hardStopDates = { hardStopWarningDate: releaseDate, hardStopCutoffDate: subDays(releaseDate, 2) }
 
       expect(
@@ -129,7 +130,7 @@ describe('CaseloadViewModel', () => {
     })
 
     it('sets showHardStopWarning to false if the release date is equal to the cutoff date', () => {
-      const releaseDate = parse(nomisRecord.releaseDate, 'yyyy-MM-dd', new Date())
+      const releaseDate = parseIsoDate(nomisRecord.releaseDate)
       hardStopDates = { hardStopWarningDate: addDays(releaseDate, 2), hardStopCutoffDate: releaseDate }
 
       expect(
@@ -153,7 +154,7 @@ describe('CaseloadViewModel', () => {
 
     it('sets showHardStopWarning to false if hardStopEnabled is false', () => {
       config.hardStopEnabled = false
-      const releaseDate = parse(nomisRecord.releaseDate, 'yyyy-MM-dd', new Date())
+      const releaseDate = parseIsoDate(nomisRecord.releaseDate)
       hardStopDates = { hardStopWarningDate: subDays(releaseDate, 1), hardStopCutoffDate: addDays(releaseDate, 1) }
 
       expect(

--- a/server/services/licenceService.test.ts
+++ b/server/services/licenceService.test.ts
@@ -1,5 +1,5 @@
 import { Readable } from 'stream'
-import { format, parse } from 'date-fns'
+import { format } from 'date-fns'
 import { User } from '../@types/CvlUserDetails'
 import LicenceApiClient from '../data/licenceApiClient'
 import LicenceService from './licenceService'
@@ -665,9 +665,9 @@ describe('Licence Service', () => {
   })
 
   describe('Audit events', () => {
-    const eventTime = parse('13/01/2022 11:00:00', 'dd/MM/yyyy HH:mm:ss', new Date())
-    const eventStart = parse('12/01/2022 10:45:00', 'dd/MM/yyyy HH:mm:ss', new Date())
-    const eventEnd = parse('13/01/2022 10:45:00', 'dd/MM/yyyy HH:mm:ss', new Date())
+    const eventTime = utils.parseCvlDateTime('13/01/2022 11:00:00', { withSeconds: true })
+    const eventStart = utils.parseCvlDateTime('12/01/2022 10:45:00', { withSeconds: true })
+    const eventEnd = utils.parseCvlDateTime('13/01/2022 10:45:00', { withSeconds: true })
 
     it('will record a new audit event', async () => {
       await licenceService.recordAuditEvent('Summary', 'Detail', 1, eventTime, user)

--- a/server/services/prisonerService.ts
+++ b/server/services/prisonerService.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'stream'
 import fs from 'fs'
 import _ from 'lodash'
-import { format, parse } from 'date-fns'
+import { format } from 'date-fns'
 import PrisonApiClient from '../data/prisonApiClient'
 import PrisonerSearchApiClient from '../data/prisonerSearchApiClient'
 import {
@@ -14,6 +14,7 @@ import { Prisoner, PrisonerSearchCriteria } from '../@types/prisonerSearchApiCli
 import logger from '../../logger'
 import HdcStatus from '../@types/HdcStatus'
 import { User } from '../@types/CvlUserDetails'
+import { parseIsoDate } from '../utils/utils'
 
 export default class PrisonerService {
   constructor(
@@ -53,9 +54,7 @@ export default class PrisonerService {
       bookingId,
       user
     )
-    const sentenceStartDates: Date[] = sentenceAndOffenceDetails.map(details =>
-      parse(details.sentenceDate, 'yyyy-MM-dd', new Date())
-    )
+    const sentenceStartDates: Date[] = sentenceAndOffenceDetails.map(details => parseIsoDate(details.sentenceDate))
     return new Date(Math.max(...sentenceStartDates.map(date => date.getTime())))
   }
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -9,12 +9,13 @@ import { FieldValidationError } from '../middleware/validationMiddleware'
 import config from '../config'
 import type { ApplicationInfo } from '../applicationInfo'
 import {
+  ComCreateCaseTab,
   formatAddress,
   jsonDtTo12HourTime,
   jsonDtToDate,
   jsonDtToDateShort,
   jsonDtToDateWithDay,
-  toDate,
+  parseCvlDate,
 } from './utils'
 import { AdditionalCondition, AdditionalConditionData, Licence } from '../@types/licenceApiClientTypes'
 import SimpleTime from '../routes/creatingLicences/types/time'
@@ -119,12 +120,8 @@ export function registerNunjucks(app?: express.Express): Environment {
     return appointmentTimeType[type]
   })
 
-  njkEnv.addFilter(
-    'tabType',
-    (
-      licences: Record<string, unknown>[],
-      type: 'releasesInNextTwoWorkingDays' | 'futureReleases' | 'attentionNeeded'
-    ) => licences.filter(c => c.tabType === type)
+  njkEnv.addFilter('filterByTabType', (licences: Record<string, unknown>[], type: ComCreateCaseTab) =>
+    licences.filter(c => c.tabType === type)
   )
 
   njkEnv.addFilter('fillFormResponse', (defaultValue: unknown, overrideValue: unknown) => {
@@ -302,9 +299,9 @@ export function registerNunjucks(app?: express.Express): Environment {
 
   njkEnv.addFilter('dateToDisplay', (licence: Licence) => {
     const licenceType = licence.typeCode
-    const led = licence.licenceExpiryDate ? toDate(licence.licenceExpiryDate) : null
-    const tussd = licence.topupSupervisionStartDate ? toDate(licence.topupSupervisionStartDate) : null
-    const tused = licence.topupSupervisionExpiryDate ? toDate(licence.topupSupervisionExpiryDate) : null
+    const led = licence.licenceExpiryDate ? parseCvlDate(licence.licenceExpiryDate) : null
+    const tussd = licence.topupSupervisionStartDate ? parseCvlDate(licence.topupSupervisionStartDate) : null
+    const tused = licence.topupSupervisionExpiryDate ? parseCvlDate(licence.topupSupervisionExpiryDate) : null
 
     let dateToDisplay: Date
     let textToDisplay = ''

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,5 +1,5 @@
 import { isDefined } from 'class-validator'
-import { addDays, format } from 'date-fns'
+import { format, isValid } from 'date-fns'
 import {
   addressObjectToString,
   convertDateFormat,
@@ -10,7 +10,6 @@ import {
   stringToAddressObject,
   jsonDtTo12HourTime,
   jsonDtToDate,
-  toDate,
   removeDuplicates,
   filterCentralCaseload,
   jsonDtToDateWithDay,
@@ -18,19 +17,21 @@ import {
   hasAuthSource,
   licenceIsTwoDaysToRelease,
   selectReleaseDate,
-  isPassedArdOrCrd,
   groupingBy,
   isReleaseDateOnOrBeforeCutOffDate,
   isAttentionNeeded,
   determineComCreateCasesTab,
   isInHardStopPeriod,
+  parseIsoDate,
+  parseCvlDate,
+  parseCvlDateTime,
 } from './utils'
 import AuthRole from '../enumeration/authRole'
 import SimpleTime, { AmPm } from '../routes/creatingLicences/types/time'
 import SimpleDate from '../routes/creatingLicences/types/date'
 import SimpleDateTime from '../routes/creatingLicences/types/simpleDateTime'
 import Address from '../routes/initialAppointment/types/address'
-import { Licence, LicenceSummary } from '../@types/licenceApiClientTypes'
+import { Licence } from '../@types/licenceApiClientTypes'
 import LicenceStatus from '../enumeration/licenceStatus'
 import { Prisoner } from '../@types/prisonerSearchApiClientTypes'
 import config from '../config'
@@ -160,13 +161,6 @@ describe('Convert date format', () => {
   })
 })
 
-describe('Create date from string', () => {
-  it('should return date object', () => {
-    const dateString = '25/12/2022'
-    expect(toDate(dateString)).toStrictEqual(new Date('2022-12-25'))
-  })
-})
-
 test.each`
   jsonDateTime          | day       | month     | year      | hour      | min       | ampm
   ${'12/12/2021 23:15'} | ${'12'}   | ${'12'}   | ${'2021'} | ${'11'}   | ${'15'}   | ${'pm'}
@@ -267,6 +261,99 @@ test.each`
   }
 })
 
+describe('parseIsoDate', () => {
+  it('ignores null', () => {
+    expect(parseIsoDate(null)).toEqual(null)
+  })
+  it('ignores empty string', () => {
+    expect(parseIsoDate('')).toEqual(null)
+  })
+  it('parses valid date', () => {
+    expect(format(parseIsoDate('2023-01-23'), 'yyyy-MM-yy')).toEqual('2023-01-23')
+  })
+  it('fails to parse invalid date format', () => {
+    const date = parseIsoDate('23/01/2023')
+    expect(isValid(date)).toEqual(false)
+  })
+  it('fails to parse invalid date', () => {
+    const date = parseIsoDate('invalid date')
+    expect(isValid(date)).toEqual(false)
+  })
+})
+
+describe('parseCvlDate', () => {
+  it('ignores null', () => {
+    expect(parseCvlDate(null)).toEqual(null)
+  })
+  it('ignores empty string', () => {
+    expect(parseCvlDate('')).toEqual(null)
+  })
+  it('parses valid date', () => {
+    expect(format(parseCvlDate('23/01/2023'), 'yyyy-MM-yy')).toEqual('2023-01-23')
+  })
+  it('fails to parse invalid date format', () => {
+    const date = parseCvlDate('2023-01-23')
+    expect(isValid(date)).toEqual(false)
+  })
+  it('fails to parse invalid date', () => {
+    const date = parseCvlDate('invalid date')
+    expect(isValid(date)).toEqual(false)
+  })
+})
+
+describe('parseCvlDateTime', () => {
+  it('ignores null', () => {
+    expect(parseCvlDateTime(null, { withSeconds: true })).toEqual(null)
+    expect(parseCvlDateTime(null, { withSeconds: false })).toEqual(null)
+  })
+  it('ignores empty string', () => {
+    expect(parseCvlDateTime('', { withSeconds: true })).toEqual(null)
+    expect(parseCvlDateTime('', { withSeconds: false })).toEqual(null)
+  })
+  it('parses valid date time', () => {
+    {
+      const dateTime = parseCvlDateTime('23/01/2023 10:30:45', { withSeconds: true })
+      const formatted = format(dateTime, 'yyyy-MM-yy hh:mm:ss')
+      expect(formatted).toEqual('2023-01-23 10:30:45')
+    }
+    {
+      const dateTime = parseCvlDateTime('23/01/2023 10:30', { withSeconds: false })
+      const formatted = format(dateTime, 'yyyy-MM-yy hh:mm')
+      expect(formatted).toEqual('2023-01-23 10:30')
+    }
+  })
+  it('fails to parse invalid date time', () => {
+    {
+      const date = parseCvlDateTime('2023-01-23', { withSeconds: true })
+      expect(isValid(date)).toEqual(false)
+    }
+    {
+      const date = parseCvlDateTime('2023-01-23', { withSeconds: false })
+      expect(isValid(date)).toEqual(false)
+    }
+  })
+  it('fails to parse date time with invalid withSeconds spec', () => {
+    {
+      const dateTime = parseCvlDateTime('23/01/2023 10:30:45', { withSeconds: false })
+      expect(isValid(dateTime)).toEqual(false)
+    }
+    {
+      const dateTime = parseCvlDateTime('23/01/2023 10:30', { withSeconds: true })
+      expect(isValid(dateTime)).toEqual(false)
+    }
+  })
+  it('fails to parse invalid date', () => {
+    {
+      const dateTime = parseCvlDateTime('invalid date time', { withSeconds: false })
+      expect(isValid(dateTime)).toEqual(false)
+    }
+    {
+      const dateTime = parseCvlDateTime('invalid date time', { withSeconds: true })
+      expect(isValid(dateTime)).toEqual(false)
+    }
+  })
+})
+
 describe('Remove duplicates', () => {
   it('should remove duplicates from a list of strings', () => {
     const listWithDuplicates = ['A', 'B', 'C', 'C', 'C']
@@ -355,7 +442,7 @@ describe('Get prisoner release date from Nomis', () => {
       conditionalReleaseDate: null,
     } as Prisoner
 
-    expect(selectReleaseDate(nomisRecord)).toBe('not found')
+    expect(selectReleaseDate(nomisRecord)).toStrictEqual(null)
   })
 
   it('Release date should be Conditional Release Date 22 Nov 2035', () => {
@@ -363,7 +450,7 @@ describe('Get prisoner release date from Nomis', () => {
       conditionalReleaseDate: '2035-11-22',
     } as Prisoner
 
-    expect(selectReleaseDate(nomisRecord)).toBe('22 Nov 2035')
+    expect(selectReleaseDate(nomisRecord)).toStrictEqual(parseIsoDate('2035-11-22'))
   })
 
   it('Release date should be Confirmed Release Date 22 Oct 2035', () => {
@@ -372,7 +459,7 @@ describe('Get prisoner release date from Nomis', () => {
       confirmedReleaseDate: '2035-10-22',
     } as Prisoner
 
-    expect(selectReleaseDate(nomisRecord)).toBe('22 Oct 2035')
+    expect(selectReleaseDate(nomisRecord)).toStrictEqual(parseIsoDate('2035-10-22'))
   })
 
   it('Release date should be Conditional Release Override Date 22 Nov 2036', () => {
@@ -381,105 +468,15 @@ describe('Get prisoner release date from Nomis', () => {
       conditionalReleaseOverrideDate: '2036-11-22',
     } as Prisoner
 
-    expect(selectReleaseDate(nomisRecord)).toBe('22 Nov 2036')
+    expect(selectReleaseDate(nomisRecord)).toStrictEqual(parseIsoDate('2036-11-22'))
   })
 
-  it('Returns malformed date as is', () => {
+  it('Filters out malformed date', () => {
     const nomisRecord = {
       conditionalReleaseDate: 'aaa2036-11-01',
     } as Prisoner
 
-    expect(selectReleaseDate(nomisRecord)).toBe('aaa2036-11-01')
-  })
-
-  describe('isPassedArdOrCrd', () => {
-    it('Should return true when legal status is NOT immigration and actualReleaseDate is yesterday', () => {
-      const licence = {
-        actualReleaseDate: format(addDays(new Date(), -1), 'dd/MM/yyyy'),
-        conditionalReleaseDate: format(addDays(new Date(), 5), 'dd/MM/yyyy'),
-      } as LicenceSummary
-
-      const prisoner = { legalStatus: 'SENTENCED' } as Prisoner
-
-      expect(isPassedArdOrCrd(licence, prisoner)).toBe(true)
-    })
-
-    it('Should return true when legal status is NOT immigration and actualReleaseDate is today', () => {
-      const licence = {
-        actualReleaseDate: format(new Date(), 'dd/MM/yyyy'),
-        conditionalReleaseDate: format(addDays(new Date(), 5), 'dd/MM/yyyy'),
-      } as LicenceSummary
-
-      const prisoner = { legalStatus: 'SENTENCED' } as Prisoner
-
-      expect(isPassedArdOrCrd(licence, prisoner)).toBe(true)
-    })
-
-    it('Should return false when legal status is NOT immigration and actualReleaseDate is tomorrow', () => {
-      const licence = {
-        actualReleaseDate: format(addDays(new Date(), 1), 'dd/MM/yyyy'),
-        conditionalReleaseDate: format(addDays(new Date(), 5), 'dd/MM/yyyy'),
-      } as LicenceSummary
-
-      const prisoner = { legalStatus: 'SENTENCED' } as Prisoner
-
-      expect(isPassedArdOrCrd(licence, prisoner)).toBe(false)
-    })
-
-    it('Should return true when legal status is immigration and conditionalReleaseDate is today', () => {
-      const licence = {
-        actualReleaseDate: undefined,
-        conditionalReleaseDate: format(new Date(), 'dd/MM/yyyy'),
-      } as LicenceSummary
-
-      const prisoner = { legalStatus: 'IMMIGRATION_DETAINEE' } as Prisoner
-
-      expect(isPassedArdOrCrd(licence, prisoner)).toBe(true)
-    })
-
-    it('Should return false when legal status is immigration and conditionalReleaseDate is tomorrow', () => {
-      const licence = {
-        actualReleaseDate: undefined,
-        conditionalReleaseDate: format(addDays(new Date(), 1), 'dd/MM/yyyy'),
-      } as LicenceSummary
-
-      const prisoner = { legalStatus: 'IMMIGRATION_DETAINEE' } as Prisoner
-
-      expect(isPassedArdOrCrd(licence, prisoner)).toBe(false)
-    })
-
-    it('Should return true when legal status is immigration and actualReleaseDate is present and in the past', () => {
-      const licence = {
-        actualReleaseDate: format(new Date(), 'dd/MM/yyyy'),
-        conditionalReleaseDate: format(addDays(new Date(), 1), 'dd/MM/yyyy'),
-      } as LicenceSummary
-
-      const prisoner = { legalStatus: 'IMMIGRATION_DETAINEE' } as Prisoner
-
-      expect(isPassedArdOrCrd(licence, prisoner)).toBe(true)
-    })
-
-    it('Should return false when legal status is immigration and actualReleaseDate is present and in the future', () => {
-      const licence = {
-        actualReleaseDate: format(addDays(new Date(), 1), 'dd/MM/yyyy'),
-        conditionalReleaseDate: format(new Date(), 'dd/MM/yyyy'),
-      } as LicenceSummary
-
-      const prisoner = { legalStatus: 'IMMIGRATION_DETAINEE' } as Prisoner
-
-      expect(isPassedArdOrCrd(licence, prisoner)).toBe(false)
-    })
-
-    it('Should return false when legal status is immigration and no dates are present', () => {
-      const licence = {
-        actualReleaseDate: undefined,
-        conditionalReleaseDate: undefined,
-      } as LicenceSummary
-
-      const prisoner = { legalStatus: 'IMMIGRATION_DETAINEE' } as Prisoner
-
-      expect(isPassedArdOrCrd(licence, prisoner)).toBe(false)
-    })
+    expect(selectReleaseDate(nomisRecord)).toStrictEqual(null)
   })
 
   describe('groupingBy', () => {
@@ -520,15 +517,15 @@ describe('Get prisoner release date from Nomis', () => {
 
 describe('Check if release date before cutoff date', () => {
   it('should return true if release date is before cutoff date', () => {
-    expect(isReleaseDateOnOrBeforeCutOffDate('04/12/2023', '03/12/2023')).toBeTruthy()
+    expect(isReleaseDateOnOrBeforeCutOffDate(parseCvlDate('04/12/2023'), parseCvlDate('03/12/2023'))).toBeTruthy()
   })
 
   it('should return false if release date is after cutoff date', () => {
-    expect(isReleaseDateOnOrBeforeCutOffDate('04/12/2023', '05/12/2023')).toBeFalsy()
+    expect(isReleaseDateOnOrBeforeCutOffDate(parseCvlDate('04/12/2023'), parseCvlDate('05/12/2023'))).toBeFalsy()
   })
 
   it('should return true if release date is equal to cutoff date', () => {
-    expect(isReleaseDateOnOrBeforeCutOffDate('04/12/2023', '04/12/2023')).toBeTruthy()
+    expect(isReleaseDateOnOrBeforeCutOffDate(parseCvlDate('04/12/2023'), parseCvlDate('04/12/2023'))).toBeTruthy()
   })
 })
 

--- a/server/views/pages/view/cases.njk
+++ b/server/views/pages/view/cases.njk
@@ -148,11 +148,11 @@
                                 Future releases
                             </a>
                     </li>
-                    {% if (cases | tabType('attentionNeeded')).length %}
+                    {% if (cases | filterByTabType('attentionNeeded')).length %}
                         <li class="govuk-tabs__list-item" data-qa="attention-needed-view-link" role="presentation">
                             <a class="govuk-tabs__tab" href="#attention-needed" id="tab_attention-needed" role="tab" aria-controls="attention-needed" aria-selected="false" tabindex="-2">
                                     Attention needed
-                                    <span id="attention-needed-count" class="moj-notification-badge">{{ (cases | tabType('attentionNeeded')).length  }}</span>
+                                    <span id="attention-needed-count" class="moj-notification-badge">{{ (cases | filterByTabType('attentionNeeded')).length  }}</span>
                                 </a>
                         </li>
                     {% endif %}
@@ -174,7 +174,7 @@
                     {{ viewCases({ cases: cases, tabType: 'futureReleases', config: statusConfig}) }}
                 </div>
 
-                {% if (cases | tabType('attentionNeeded')).length %}
+                {% if (cases | filterByTabType('attentionNeeded')).length %}
                     <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="attention-needed" role="tabpanel" aria-labelledby="tab_attention-needed">
                         <h2 class="govuk-heading-l">Attention needed</h2>
                             {{ attentionNeededTabDescription() }}

--- a/server/views/partials/viewCases.njk
+++ b/server/views/partials/viewCases.njk
@@ -92,7 +92,7 @@
 {% endmacro %}
 
 {% macro viewCases(params) %}
-    {% set cases = params.cases | tabType(params.tabType) %}
+    {% set cases = params.cases | filterByTabType(params.tabType) %}
     {% set licences = [] %}
     {% set caseData = [] %}
 


### PR DESCRIPTION
Added 3 helper functions for parsing dates and moved over existing code to use them:
* `parseIsoDate` => `2023-01-23`
* `parseCvlDate` => `23/01/2023`
* `parseCvlDateTime` 
  * `{ withSeconds: true }`  => `23/01/2023 13:45:50`
  * `{ withSeconds: false }`  => `23/01/2023 13:45`
  