### PR TITLE
CVSL-1842 adjust logic for backlink

### DIFF
--- a/server/routes/creatingLicences/handlers/confirmation.test.ts
+++ b/server/routes/creatingLicences/handlers/confirmation.test.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express'
 
 import ConfirmationRoutes from './confirmation'
 
-describe('Route Handlers - Create Licence - Confirmation', () => {
+describe('Route Handlers - Confirmation', () => {
   const handler = new ConfirmationRoutes()
   let req: Request
   let res: Response
@@ -29,58 +29,85 @@ describe('Route Handlers - Create Licence - Confirmation', () => {
     } as unknown as Response
   })
 
-  describe('GET', () => {
-    it('should render view for AP_PSS licence type', async () => {
-      res.locals.licence.typeCode = 'AP_PSS'
+  describe('Create CRD Licence', () => {
+    describe('GET', () => {
+      it('should render view for AP_PSS licence type', async () => {
+        res.locals.licence.typeCode = 'AP_PSS'
 
-      await handler.GET(req, res)
-      expect(res.render).toHaveBeenCalledWith('pages/create/confirmation', {
-        confirmationMessage:
-          'We have sent the licence and post sentence supervision order to Leeds (HMP) for approval.',
-        titleText: 'Licence and post sentence supervision order for Bobby Zamora sent',
-        backLink: req.session.returnToCase,
+        await handler.GET(req, res)
+        expect(res.render).toHaveBeenCalledWith('pages/create/confirmation', {
+          confirmationMessage:
+            'We have sent the licence and post sentence supervision order to Leeds (HMP) for approval.',
+          titleText: 'Licence and post sentence supervision order for Bobby Zamora sent',
+          backLink: req.session.returnToCase,
+        })
+      })
+
+      it('should render default return to caseload link if no session state', async () => {
+        const reqWithEmptySession = {
+          params: {
+            licenceId: '1',
+          },
+          session: {},
+          flash: jest.fn(),
+        } as unknown as Request
+
+        res.locals.licence.typeCode = 'AP_PSS'
+
+        await handler.GET(reqWithEmptySession, res)
+        expect(res.render).toHaveBeenCalledWith('pages/create/confirmation', {
+          confirmationMessage:
+            'We have sent the licence and post sentence supervision order to Leeds (HMP) for approval.',
+          titleText: 'Licence and post sentence supervision order for Bobby Zamora sent',
+          backLink: '/licence/create/caseload',
+        })
+      })
+
+      it('should render view for AP licence type', async () => {
+        res.locals.licence.typeCode = 'AP'
+
+        await handler.GET(req, res)
+        expect(res.render).toHaveBeenCalledWith('pages/create/confirmation', {
+          confirmationMessage: 'We have sent the licence to Leeds (HMP) for approval.',
+          titleText: 'Licence conditions for Bobby Zamora sent',
+          backLink: req.session.returnToCase,
+        })
+      })
+
+      it('should render view for PSS licence type', async () => {
+        res.locals.licence.typeCode = 'PSS'
+
+        await handler.GET(req, res)
+        expect(res.render).toHaveBeenCalledWith('pages/create/confirmation', {
+          confirmationMessage: 'We have sent the post sentence supervision order to Leeds (HMP) for approval.',
+          titleText: 'Post sentence supervision order for Bobby Zamora sent',
+          backLink: req.session.returnToCase,
+        })
       })
     })
+  })
 
-    it('should render default return to caseload link if no session state', async () => {
-      const reqWithEmptySession = {
-        params: {
-          licenceId: '1',
-        },
-        session: {},
-        flash: jest.fn(),
-      } as unknown as Request
+  describe('Create Hard Stop Licence', () => {
+    describe('GET', () => {
+      it('should render correct return to caseload link for hard stop licence', async () => {
+        res.locals.licence.kind = 'HARD_STOP'
 
-      res.locals.licence.typeCode = 'AP_PSS'
+        const reqWithEmptySession = {
+          params: {
+            licenceId: '1',
+          },
+          session: {},
+          flash: jest.fn(),
+        } as unknown as Request
 
-      await handler.GET(reqWithEmptySession, res)
-      expect(res.render).toHaveBeenCalledWith('pages/create/confirmation', {
-        confirmationMessage:
-          'We have sent the licence and post sentence supervision order to Leeds (HMP) for approval.',
-        titleText: 'Licence and post sentence supervision order for Bobby Zamora sent',
-        backLink: '/licence/create/caseload',
-      })
-    })
+        res.locals.licence.typeCode = 'AP'
 
-    it('should render view for AP licence type', async () => {
-      res.locals.licence.typeCode = 'AP'
-
-      await handler.GET(req, res)
-      expect(res.render).toHaveBeenCalledWith('pages/create/confirmation', {
-        confirmationMessage: 'We have sent the licence to Leeds (HMP) for approval.',
-        titleText: 'Licence conditions for Bobby Zamora sent',
-        backLink: req.session.returnToCase,
-      })
-    })
-
-    it('should render view for PSS licence type', async () => {
-      res.locals.licence.typeCode = 'PSS'
-
-      await handler.GET(req, res)
-      expect(res.render).toHaveBeenCalledWith('pages/create/confirmation', {
-        confirmationMessage: 'We have sent the post sentence supervision order to Leeds (HMP) for approval.',
-        titleText: 'Post sentence supervision order for Bobby Zamora sent',
-        backLink: req.session.returnToCase,
+        await handler.GET(reqWithEmptySession, res)
+        expect(res.render).toHaveBeenCalledWith('pages/create/confirmation', {
+          confirmationMessage: 'We have sent the licence to Leeds (HMP) for approval.',
+          titleText: 'Licence conditions for Bobby Zamora sent',
+          backLink: '/licence/view/cases',
+        })
       })
     })
   })

--- a/server/routes/creatingLicences/handlers/confirmation.ts
+++ b/server/routes/creatingLicences/handlers/confirmation.ts
@@ -1,13 +1,23 @@
 import { Request, Response } from 'express'
 import LicenceType from '../../../enumeration/licenceType'
+import LicenceKind from '../../../enumeration/LicenceKind'
 
 export default class ConfirmationRoutes {
   GET = async (req: Request, res: Response): Promise<void> => {
     const { licence } = res.locals
-    const backLink = req.session.returnToCase || '/licence/create/caseload'
 
     let titleText
     let confirmationMessage
+    let backLink
+
+    switch (licence.kind) {
+      case LicenceKind.HARD_STOP:
+        backLink = '/licence/view/cases'
+        break
+      default:
+        backLink = req.session.returnToCase || '/licence/create/caseload'
+        break
+    }
 
     switch (licence.typeCode) {
       case LicenceType.AP_PSS:


### PR DESCRIPTION
This PR addresses a bug where when a hard stop licence was created, the `Return to caselist` button did not work. This now redirects to the view caseload on clicking of the button rather than the create caseload when a hard stop licence is created and submitted. 