### PR TITLE
CVSL-2084 Preventing policy upgrade notice page from appearing when there are zero changes to review

### DIFF
--- a/server/routes/varyingLicences/handlers/policyChangesNotice.test.ts
+++ b/server/routes/varyingLicences/handlers/policyChangesNotice.test.ts
@@ -41,8 +41,6 @@ describe('Route handlers', () => {
     suggestions: [{ code: 'code 6', currentText: 'Condition 6' }],
   } as LicenceConditionChange
 
-  licenceService.getPolicyChanges.mockResolvedValue([condition1, condition2, condition3])
-
   beforeEach(() => {
     req = {
       params: {
@@ -63,6 +61,8 @@ describe('Route handlers', () => {
         },
       },
     } as unknown as Response
+
+    licenceService.getPolicyChanges.mockResolvedValue([condition1, condition2, condition3])
   })
 
   describe('GET', () => {
@@ -79,6 +79,13 @@ describe('Route handlers', () => {
       expect(res.render).toHaveBeenCalledWith('pages/vary/policyChanges', {
         numberOfChanges: 'Three',
       })
+    })
+
+    it('redirects to check-your-answers if all policy changes have been reviewed already', async () => {
+      licenceService.getPolicyChanges.mockResolvedValue([])
+
+      await handler.GET(req, res)
+      expect(res.redirect).toHaveBeenCalledWith('/licence/create/id/1/check-your-answers')
     })
   })
 

--- a/server/routes/varyingLicences/handlers/policyChangesNotice.ts
+++ b/server/routes/varyingLicences/handlers/policyChangesNotice.ts
@@ -11,6 +11,12 @@ export default class PolicyChangesNoticeRoutes {
     const { licenceId } = req.params
 
     const changedConditions = await this.licenceService.getPolicyChanges(licenceId)
+
+    // If policy changes have all already been reviewed, no need to render the notice page
+    if (changedConditions.length < 1) {
+      return res.redirect(`/licence/create/id/${licenceId}/check-your-answers`)
+    }
+
     const numberOfChanges = convertToTitleCase(Converter.toWords(changedConditions.length))
 
     req.session.changedConditions = changedConditions.sort((a: LicenceConditionChange, b: LicenceConditionChange) => {
@@ -21,7 +27,7 @@ export default class PolicyChangesNoticeRoutes {
     })
     req.session.changedConditionsCounter = 0
 
-    res.render('pages/vary/policyChanges', { numberOfChanges })
+    return res.render('pages/vary/policyChanges', { numberOfChanges })
   }
 
   POST = async (req: Request, res: Response): Promise<void> => {


### PR DESCRIPTION
Fixing a small bug that's been around for a while.
When a user has already reviewed all policy changes, they still meet the criteria of being a `VARIATION_IN_PROGRESS` with a parent on an older version. If the user doesn't submit the variation immediately, every time they go to edit the variation, they are presented with a screen telling them that there are "Zero policy changes to review"
This screen is redundant for these users, so should just be skipped.