### PR TITLE
CVSL-2113 add self report url to error pages

### DIFF
--- a/helm_deploy/create-and-vary-a-licence/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence/values.yaml
@@ -60,7 +60,7 @@ generic-service:
     TOKEN_VERIFICATION_ENABLED: "true"
     COMMON_COMPONENTS_ENABLED: "true"
     SHOW_WHATS_NEW_BANNER: "true"
-    SERVICENOW_URL: 'https://mojprod.service-now.com/moj_sp?id%3Dsc_cat_item%26table%3Dsc_cat_item%26sys_id%3De389e8931b8bc65025dc6351f54bcb82%26recordUrl%3Dcom.glideapp.servicecatalog_cat_item_view.do%253Fv%253D1%26sysparm_id%3De389e8931b8bc65025dc6351f54bcb82&sa=D&source=docs&ust=1725979019789136&usg=AOvVaw2zJZYv1yliAZ94XL7--OPq'
+    SERVICE_NOW_URL: 'https://mojprod.service-now.com/moj_sp?id%3Dsc_cat_item%26table%3Dsc_cat_item%26sys_id%3De389e8931b8bc65025dc6351f54bcb82%26recordUrl%3Dcom.glideapp.servicecatalog_cat_item_view.do%253Fv%253D1%26sysparm_id%3De389e8931b8bc65025dc6351f54bcb82&sa=D&source=docs&ust=1725979019789136&usg=AOvVaw2zJZYv1yliAZ94XL7--OPq'
 
     # HDC
     MONITORING_SUPPLIER_TELEPHONE: "0800 137 291"

--- a/helm_deploy/create-and-vary-a-licence/values.yaml
+++ b/helm_deploy/create-and-vary-a-licence/values.yaml
@@ -60,6 +60,7 @@ generic-service:
     TOKEN_VERIFICATION_ENABLED: "true"
     COMMON_COMPONENTS_ENABLED: "true"
     SHOW_WHATS_NEW_BANNER: "true"
+    SERVICENOW_URL: 'https://mojprod.service-now.com/moj_sp?id%3Dsc_cat_item%26table%3Dsc_cat_item%26sys_id%3De389e8931b8bc65025dc6351f54bcb82%26recordUrl%3Dcom.glideapp.servicecatalog_cat_item_view.do%253Fv%253D1%26sysparm_id%3De389e8931b8bc65025dc6351f54bcb82&sa=D&source=docs&ust=1725979019789136&usg=AOvVaw2zJZYv1yliAZ94XL7--OPq'
 
     # HDC
     MONITORING_SUPPLIER_TELEPHONE: "0800 137 291"

--- a/server/config.ts
+++ b/server/config.ts
@@ -34,6 +34,7 @@ export default {
   productId: get('PRODUCT_ID', 'UNASSIGNED', requiredInProduction),
   gitRef: get('GIT_REF', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),
   dpsUrl: get('DPS_URL', 'http://localhost:3000', requiredInProduction),
+  serviceNowUrl: get('SERVICENOW_URL', 'http://localhost:3000', requiredInProduction),
   serviceName: process.env.SERVICE_NAME,
   phaseName: process.env.SYSTEM_PHASE || 'BETA',
   branchName: get('GIT_BRANCH', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),

--- a/server/config.ts
+++ b/server/config.ts
@@ -34,7 +34,7 @@ export default {
   productId: get('PRODUCT_ID', 'UNASSIGNED', requiredInProduction),
   gitRef: get('GIT_REF', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),
   dpsUrl: get('DPS_URL', 'http://localhost:3000', requiredInProduction),
-  serviceNowUrl: get('SERVICENOW_URL', 'http://localhost:3000', requiredInProduction),
+  serviceNowUrl: get('SERVICE_NOW_URL', 'http://localhost:3000', requiredInProduction),
   serviceName: process.env.SERVICE_NAME,
   phaseName: process.env.SYSTEM_PHASE || 'BETA',
   branchName: get('GIT_BRANCH', 'xxxxxxxxxxxxxxxxxxx', requiredInProduction),

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -407,6 +407,7 @@ export function registerNunjucks(app?: express.Express): Environment {
   )
 
   njkEnv.addGlobal('dpsUrl', config.dpsUrl)
+  njkEnv.addGlobal('serviceNowUrl', config.serviceNowUrl)
   njkEnv.addGlobal('serviceName', config.serviceName)
   njkEnv.addGlobal('showWhatsNewBanner', config.showWhatsNewBanner)
   njkEnv.addGlobal('fridayReleasePolicy', config.fridayReleasePolicy)

--- a/server/views/pages/accessDenied.njk
+++ b/server/views/pages/accessDenied.njk
@@ -40,8 +40,8 @@
             </div>
             <div class="govuk-!-padding-top-7">
                 <h2 class="govuk-heading-l govuk-!-margin-bottom-4">For support</h2>
-                <p class="govuk-body">
-                    Contact the helpdesk by calling 0800 917 5148, or #6598 from inside a prison.
+                <p id="support" class="govuk-body">
+                    You must report your issue to the helpdesk using <a id="serviceNowUrl" class="govuk-link" href="{{serviceNowUrl}}">this form on ServiceNow</a>.
                     <br>
                     <br>
                     {% if user.authSource == 'nomis' %}

--- a/server/views/pages/accessDenied.test.ts
+++ b/server/views/pages/accessDenied.test.ts
@@ -1,0 +1,39 @@
+import fs from 'fs'
+import { templateRenderer } from '../../utils/__testutils/templateTestUtils'
+
+const render = templateRenderer(fs.readFileSync('server/views/pages/accessDenied.njk').toString())
+
+describe('Access Denied', () => {
+  it('should display error page content for a NOMIS user', () => {
+    const $ = render({
+      user: {
+        authSource: 'nomis',
+      },
+      serviceNowUrl: 'http://testurl1.com',
+      dpsUrl: 'http://testurl2.com',
+    })
+    expect($('h1').text()).toContain('You do not have permission to view this')
+
+    expect($('#support').text()).toContain('Go to the Digital Prison Services homepage')
+    expect($('#support').text()).not.toContain('Go to the Digital Services homepage.')
+
+    expect($('#support > .govuk-link:first-child').attr('href')).toBe('http://testurl1.com')
+    expect($('#support .govuk-link:last-child').attr('href')).toBe('http://testurl2.com')
+  })
+
+  it('should display error page content for a Delius user', () => {
+    const $ = render({
+      user: {
+        authSource: 'delius',
+      },
+      serviceNowUrl: 'http://testurl1.com',
+    })
+    expect($('h1').text()).toContain('You do not have permission to view this')
+
+    expect($('#support').text()).toContain('Go to the Digital Services homepage.')
+    expect($('#support').text()).not.toContain('Go to the Digital Prison Services homepage')
+
+    expect($('#support > .govuk-link:first-child').attr('href')).toBe('http://testurl1.com')
+    expect($('#support .govuk-link:last-child').attr('href')).toBe('https://sign-in.hmpps.service.justice.gov.uk/auth')
+  })
+})

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -11,8 +11,8 @@
             <p class="govuk-body">Try again later.</p>
             <div class="govuk-!-padding-top-7">
                 <h2 class="govuk-heading-l govuk-!-margin-bottom-4">For support</h2>
-                <p class="govuk-body">
-                    Contact the helpdesk by calling 0800 917 5148, or #6598 from inside a prison.
+                <p id="support" class="govuk-body">
+                    You must report your issue to the helpdesk using <a class="govuk-link" href="{{serviceNowUrl}}">this form on ServiceNow.
                     <br>
                     <br>
                     {% if user.authSource == 'nomis' %}

--- a/server/views/pages/error.test.ts
+++ b/server/views/pages/error.test.ts
@@ -1,0 +1,39 @@
+import fs from 'fs'
+import { templateRenderer } from '../../utils/__testutils/templateTestUtils'
+
+const render = templateRenderer(fs.readFileSync('server/views/pages/error.njk').toString())
+
+describe('Error', () => {
+  it('should display error page content for a NOMIS user', () => {
+    const $ = render({
+      user: {
+        authSource: 'nomis',
+      },
+      serviceNowUrl: 'http://testurl1.com',
+      dpsUrl: 'http://testurl2.com',
+    })
+    expect($('h1').text()).toContain('Sorry, there is a problem with Create and vary a licence')
+
+    expect($('#support').text()).toContain('Go to the Digital Prison Services homepage')
+    expect($('#support').text()).not.toContain('Go to the Digital Services homepage.')
+
+    expect($('#support > .govuk-link:first-child').attr('href')).toBe('http://testurl1.com')
+    expect($('#support .govuk-link:last-child').attr('href')).toBe('http://testurl2.com')
+  })
+
+  it('should display error page content for a Delius user', () => {
+    const $ = render({
+      user: {
+        authSource: 'delius',
+      },
+      serviceNowUrl: 'http://testurl1.com',
+    })
+    expect($('h1').text()).toContain('Sorry, there is a problem with Create and vary a licence')
+
+    expect($('#support').text()).toContain('Go to the Digital Services homepage.')
+    expect($('#support').text()).not.toContain('Go to the Digital Prison Services homepage')
+
+    expect($('#support > .govuk-link:first-child').attr('href')).toBe('http://testurl1.com')
+    expect($('#support .govuk-link:last-child').attr('href')).toBe('https://sign-in.hmpps.service.justice.gov.uk/auth')
+  })
+})


### PR DESCRIPTION
This PR is to add the self report URL to our error pages which provides a direct link to ServiceNow when a user encounters a 401 or 500 error. 

Delius user with a 500 error:
![delius user 500 error](https://github.com/user-attachments/assets/ec04955c-345d-445f-84fd-afc26800902b)


Nomis user with a 401 error
![nomis user 401 error](https://github.com/user-attachments/assets/bf5a5628-6932-470a-a67f-155cbd0f078f)


