### PR TITLE
CVSL-2399 enabling scheduled downtime

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -51,6 +51,9 @@ generic-service:
     # To enable common front-end components
     COMPONENT_API_URL: "https://frontend-components-dev.hmpps.service.justice.gov.uk"
     MANAGE_USERS_API_URL: "https://manage-users-api-dev.hmpps.service.justice.gov.uk"
+  
+  scheduledDowntime:
+    enabled: true
 
 gotenberg:
   replicaCount: 1
@@ -59,6 +62,9 @@ gotenberg:
     GOOGLE_CHROME_IGNORE_CERTIFICATE_ERRORS: 1
     DISABLE_UNOCONV: 1
     DEFAULT_WAIT_TIMEOUT: 30
+
+  scheduledDowntime:
+    enabled: true
 
 generic-prometheus-alerts:
   alertSeverity: cvl-alerts-non-prod


### PR DESCRIPTION
This will shut down pods between 10pm - 6:30am UTC on weekdays and all day on weekends. 6:30am was chosen as the RDS startup happens between 6am and 6:30am.