### PR TITLE
CVSL-2336 add logic to change confirmation message based on kind

### DIFF
--- a/server/routes/creatingLicences/handlers/confirmation.ts
+++ b/server/routes/creatingLicences/handlers/confirmation.ts
@@ -8,6 +8,7 @@ export default class ConfirmationRoutes {
     let titleText
     let confirmationMessage
     const backLink = req.session.returnToCase || '/licence/create/caseload'
+    const { kind } = licence
 
     switch (licence.typeCode) {
       case LicenceType.AP_PSS:
@@ -27,6 +28,6 @@ export default class ConfirmationRoutes {
       }
     }
 
-    res.render('pages/create/confirmation', { titleText, confirmationMessage, backLink })
+    res.render('pages/create/confirmation', { titleText, confirmationMessage, backLink, kind })
   }
 }

--- a/server/views/pages/create/confirmation.njk
+++ b/server/views/pages/create/confirmation.njk
@@ -23,11 +23,20 @@
             </p>
 
             <h2 class="govuk-heading-m">If you need to make any changes</h2>
-            <p class="govuk-body">
-                You can do so up to 2 days before a standard release. From this point, you can only ask the prison to change the initial appointment details. Other changes must be made after release.
-                <br>
-                You can continue to work on licences for people being released early after the 2-day point. 
-            </p>
+            {% if kind == "HDC" %}
+                <p class="govuk-body" id="message">
+                    You can make changes to reporting instructions through the Create and vary a licence service. These changes do not need to be reapproved by the prison, but a case administrator may need to reprint the licence.
+                <p>
+                <p class="govuk-body" id="change-message">
+                    To change the curfew address, curfew hours or first night curfew hours email createandvaryalicence@digital.justice.gov.uk.
+                </p>
+            {% else %}    
+                <p class="govuk-body" id="message">
+                    You can do so up to 2 days before a standard release. From this point, you can only ask the prison to change the initial appointment details. Other changes must be made after release.
+                    <br>
+                    You can continue to work on licences for people being released early after the 2-day point. 
+                </p>
+            {% endif %}
 
             <h2 class="govuk-heading-m">Give us your feedback</h2>
             <p class="govuk-body">

--- a/server/views/pages/create/confirmation.test.ts
+++ b/server/views/pages/create/confirmation.test.ts
@@ -1,0 +1,44 @@
+import fs from 'fs'
+import { templateRenderer } from '../../../utils/__testutils/templateTestUtils'
+
+const render = templateRenderer(fs.readFileSync('server/views/pages/create/confirmation.njk').toString())
+
+describe('Hdc Confirmation', () => {
+  it('should show correct message when kind is HDC', () => {
+    const $ = render({
+      kind: 'HDC',
+    })
+    expect($('#message').text().trim().toString()).toContain(
+      'You can make changes to reporting instructions through the Create and vary a licence service. These changes do not need to be reapproved by the prison, but a case administrator may need to reprint the licence.',
+    )
+
+    expect($('#change-message').text().toString()).toContain(
+      'To change the curfew address, curfew hours or first night curfew hours email createandvaryalicence@digital.justice.gov.uk.',
+    )
+
+    expect($('#message').text().trim().toString()).not.toContain(
+      'You can do so up to 2 days before a standard release. From this point, you can only ask the prison to change the initial appointment details. Other changes must be made after release.',
+    )
+
+    expect($('#message').text().trim().toString()).not.toContain(
+      'You can continue to work on licences for people being released early after the 2-day point.',
+    )
+  })
+
+  it('should show correct message when kind is not HDC', () => {
+    const $ = render({
+      kind: 'CRD',
+    })
+    expect($('#message').text().trim().toString()).toContain(
+      'You can do so up to 2 days before a standard release. From this point, you can only ask the prison to change the initial appointment details. Other changes must be made after release.',
+    )
+
+    expect($('#message').text().trim().toString()).toContain(
+      'You can continue to work on licences for people being released early after the 2-day point.',
+    )
+
+    expect($('#message').text()).not.toContain(
+      'You can make changes to reporting instructions through the Create and vary a licence service. These changes do not need to be reapproved by the prison, but a case administrator may need to reprint the licence.',
+    )
+  })
+})


### PR DESCRIPTION
This PR is content change for the confirmation page based on the licence kind being HDC.

![Screenshot 2025-01-17 at 12 30 17](https://github.com/user-attachments/assets/1f5c9859-7853-4f52-b76f-5f620233ca8b)
