### PR TITLE
CVSL-2329 combine time and date into a single fieldset

### DIFF
--- a/server/views/partials/hdc/hdcInitialMeetingTimeInputs.njk
+++ b/server/views/partials/hdc/hdcInitialMeetingTimeInputs.njk
@@ -8,9 +8,9 @@
 
     {% call govukFieldset({
         legend: {
-            text: "Date",
-            classes: "govuk-visually-hidden",
-            isPageHeading: false}
+            text: "Appointment date and time",
+            classes: "govuk-visually-hidden"
+        }
         }) %}
 
         {{ govukRadios({
@@ -38,15 +38,6 @@
             classes: 'hmpps-datepicker--fixed-width',
             value: formResponses.date.calendarDate or formDate.date.calendarDate
         }) }}
-    {% endcall %}
-    {% call govukFieldset({
-        classes:"govuk-!-margin-top-2",
-
-        legend: {
-            text: "Time",
-            classes: "govuk-visually-hidden",
-            isPageHeading: false}
-        }) %}
 
         {{ timePicker({
             id: "time",

--- a/server/views/partials/initialMeetingTimeInputs.njk
+++ b/server/views/partials/initialMeetingTimeInputs.njk
@@ -9,9 +9,9 @@
     {% set dateTimeHtml %}
         {% call govukFieldset({
             legend: {
-                text: "Date",
-                classes: "govuk-visually-hidden",
-                isPageHeading: false}
+                text: "Appointment date and time",
+                classes: "govuk-visually-hidden"
+            }
             }) %}
 
             {{ hmppsDatePicker({
@@ -28,16 +28,7 @@
                 classes: 'hmpps-datepicker--fixed-width',
                 value: formResponses.date.calendarDate or formDate.date.calendarDate
             }) }}
-        {% endcall %}
-        {% call govukFieldset({
-            classes:"govuk-!-margin-top-7",
-
-            legend: {
-                text: "Time",
-                classes: "govuk-visually-hidden",
-                isPageHeading: false}
-            }) %}
-        
+            
             {{ timePicker({
                 id: "time",
                 label: {
@@ -50,6 +41,7 @@
                 errorMessage: validationErrors | findError('time'),
                 formResponses: formResponses.time or formDate.time
             }) }}
+            
         {% endcall %}
     {% endset %}
 


### PR DESCRIPTION
This follow on PR is based on demo feedback to combine the fields into a single fields for date and time instead of having two separate fieldsets.