### PR TITLE
CVSL-2337 add HDC highlight for cases in the people in prison tab

### DIFF
--- a/server/routes/viewingLicences/handlers/viewCases.test.ts
+++ b/server/routes/viewingLicences/handlers/viewCases.test.ts
@@ -227,6 +227,7 @@ describe('Route handlers - View and print case list', () => {
             nomisLegalStatus: 'SENTENCED',
             lastWorkedOnBy: 'Test Updater',
             isDueForEarlyRelease: false,
+            kind: LicenceKind.CRD,
           },
           {
             link: '/licence/view/id/2/show',
@@ -243,6 +244,7 @@ describe('Route handlers - View and print case list', () => {
             lastWorkedOnBy: 'Test Updater',
             releaseDateLabel: 'Confirmed release date',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
           {
             link: null,
@@ -259,6 +261,7 @@ describe('Route handlers - View and print case list', () => {
             nomisLegalStatus: 'SENTENCED',
             isDueForEarlyRelease: false,
             lastWorkedOnBy: 'Test Updater',
+            kind: LicenceKind.CRD,
           },
           {
             link: '/licence/view/id/4/show',
@@ -275,6 +278,7 @@ describe('Route handlers - View and print case list', () => {
             nomisLegalStatus: 'SENTENCED',
             isDueForEarlyRelease: true,
             lastWorkedOnBy: 'Test Updater',
+            kind: LicenceKind.CRD,
           },
         ],
         CaViewCasesTab,
@@ -315,6 +319,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '01 Jul 2022',
             releaseDateLabel: 'Confirmed release date',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
           {
             isDueForEarlyRelease: true,
@@ -339,6 +344,7 @@ describe('Route handlers - View and print case list', () => {
             },
             releaseDate: '01 May 2022',
             releaseDateLabel: 'Confirmed release date',
+            kind: LicenceKind.HARD_STOP,
           },
           {
             isDueForEarlyRelease: false,
@@ -391,6 +397,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '01 May 2022',
             releaseDateLabel: 'Confirmed release date',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
           {
             isDueForEarlyRelease: false,
@@ -407,6 +414,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '10 Jun 2022',
             releaseDateLabel: 'Confirmed release date',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
           {
             isDueForEarlyRelease: false,
@@ -423,6 +431,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '01 May 2022',
             releaseDateLabel: 'Confirmed release date',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
           {
             isDueForEarlyRelease: true,
@@ -439,6 +448,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '01 May 2022',
             releaseDateLabel: 'CRD',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
         ],
         CaViewCasesTab,
@@ -479,6 +489,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '01 Jul 2022',
             releaseDateLabel: 'Confirmed release date',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
           {
             isDueForEarlyRelease: true,
@@ -503,6 +514,7 @@ describe('Route handlers - View and print case list', () => {
             },
             releaseDate: '01 May 2022',
             releaseDateLabel: 'Confirmed release date',
+            kind: LicenceKind.HARD_STOP,
           },
           {
             isDueForEarlyRelease: false,
@@ -587,6 +599,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '01 May 2022',
             releaseDateLabel: 'Confirmed release date',
             isDueForEarlyRelease: true,
+            kind: LicenceKind.HARD_STOP,
           },
         ],
         CaViewCasesTab,
@@ -627,6 +640,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '01 Jul 2022',
             releaseDateLabel: 'Confirmed release date',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
           {
             isDueForEarlyRelease: true,
@@ -651,6 +665,7 @@ describe('Route handlers - View and print case list', () => {
             },
             releaseDate: '01 May 2022',
             releaseDateLabel: 'Confirmed release date',
+            kind: LicenceKind.HARD_STOP,
           },
           {
             isDueForEarlyRelease: false,
@@ -703,6 +718,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '01 May 2022',
             releaseDateLabel: 'Confirmed release date',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
           {
             isDueForEarlyRelease: false,
@@ -719,6 +735,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '10 Jun 2022',
             releaseDateLabel: 'Confirmed release date',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
           {
             isDueForEarlyRelease: false,
@@ -735,6 +752,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '01 May 2022',
             releaseDateLabel: 'Confirmed release date',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
           {
             isDueForEarlyRelease: true,
@@ -751,6 +769,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '01 May 2022',
             releaseDateLabel: 'CRD',
             tabType: 'releasesInNextTwoWorkingDays',
+            kind: LicenceKind.CRD,
           },
         ],
         CaViewCasesTab,
@@ -793,6 +812,7 @@ describe('Route handlers - View and print case list', () => {
             releaseDate: '01 May 2022',
             releaseDateLabel: 'Confirmed release date',
             tabType: 'attentionNeeded',
+            kind: LicenceKind.CRD,
           },
         ],
         CaViewCasesTab,

--- a/server/routes/viewingLicences/handlers/viewCases.ts
+++ b/server/routes/viewingLicences/handlers/viewCases.ts
@@ -60,6 +60,7 @@ export default class ViewAndPrintCaseRoutes {
           isDueForEarlyRelease: c.isDueForEarlyRelease,
           link,
           licenceStatus,
+          kind: c.kind,
         }
       }),
       CaViewCasesTab,

--- a/server/views/pages/view/cases.test.ts
+++ b/server/views/pages/view/cases.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import { templateRenderer } from '../../../utils/__testutils/templateTestUtils'
 import statusConfig from '../../../licences/licenceStatus'
 import { CaViewCasesTab } from '../../../utils/utils'
+import LicenceKind from '../../../enumeration/LicenceKind'
 
 const render = templateRenderer(fs.readFileSync('server/views/pages/view/cases.njk').toString())
 
@@ -198,5 +199,61 @@ describe('View and print a licence - case list', () => {
     expect($('.govuk-tabs__list a').text()).toContain('Releases in next 2 working days (0 results)')
     expect($('.govuk-tabs__list a').text()).toContain('Future releases (1 result)')
     expect($('.govuk-tabs__list a').text()).toContain('Attention needed (1 result)')
+  })
+
+  it('should highlight a HDC licence with a HDC release warning label in prison view', () => {
+    const search = ''
+    const prisonsToDisplay = ''
+    const probationView = false
+    const $ = render({
+      cases: [
+        {
+          name: 'Adam Balasaravika',
+          prisonerNumber: 'A1234AA',
+          releaseDate: '3 Aug 2022',
+          releaseDateLabel: 'HDCAD',
+          tabType: 'releasesInNextTwoWorkingDays',
+          kind: LicenceKind.HDC,
+        },
+      ],
+      showAttentionNeededTab: false,
+      CaViewCasesTab,
+      statusConfig,
+      search,
+      prisonsToDisplay,
+      probationView,
+    })
+    expect($('tbody .govuk-table__row').length).toBe(1)
+    expect($('#name-1 > div > span').text()).toBe('Adam Balasaravika')
+    expect($('#nomis-id-1').text()).toBe('A1234AA')
+    expect($('#release-date-1').text()).toBe('HDCAD: 3 Aug 2022HDC release')
+  })
+
+  it('should highlight a HDC licence with a HDC release warning label in prison view for the attention needed tab', () => {
+    const search = ''
+    const prisonsToDisplay = ''
+    const probationView = false
+    const $ = render({
+      cases: [
+        {
+          name: 'Adam Balasaravika',
+          prisonerNumber: 'A1234AA',
+          releaseDate: '3 Aug 2022',
+          releaseDateLabel: 'HDCAD',
+          tabType: 'releasesInNextTwoWorkingDays',
+          kind: LicenceKind.HDC,
+        },
+      ],
+      showAttentionNeededTab: true,
+      CaViewCasesTab,
+      statusConfig,
+      search,
+      prisonsToDisplay,
+      probationView,
+    })
+    expect($('tbody .govuk-table__row').length).toBe(1)
+    expect($('#name-1 > div > span').text()).toBe('Adam Balasaravika')
+    expect($('#nomis-id-1').text()).toBe('A1234AA')
+    expect($('#release-date-1').text()).toBe('HDCAD: 3 Aug 2022HDC release')
   })
 })

--- a/server/views/partials/viewCases.njk
+++ b/server/views/partials/viewCases.njk
@@ -117,6 +117,8 @@
 
         {% if case.isDueForEarlyRelease %}
             {% set releaseDate = '<span class="urgent-highlight">' + case.releaseDateLabel + ': <br>' + case.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Early release</span>' %}
+        {% elseif case.kind == 'HDC' %}
+            {% set releaseDate = '<span class="urgent-highlight">' + case.releaseDateLabel + ': <br>' + case.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
         {% else %}
             {% set releaseDate = '<p>' + case.releaseDateLabel + ': <br>' + case.releaseDate + '</p>' %}
         {% endif %}


### PR DESCRIPTION
This PR is to add the HDC release label to relevant cases in the CA view. This is currently for the tabs under the `People in Prison` tab only - another PR will follow for the `People on Probation` tab. 

<details>
<summary>Release in 2 days</summary>
![Screenshot 2025-01-30 at 11 56 14](https://github.com/user-attachments/assets/0ae4296b-0a8c-4159-8978-941c14a8b78c)
</details>

<details>
<summary>Future release</summary>
![Screenshot 2025-01-30 at 11 54 57](https://github.com/user-attachments/assets/461c5a02-bee0-49cf-be8a-3ef914aa0830)
</details>

<details>
<summary>Attention needed</summary>
![Screenshot 2025-01-30 at 11 47 03](https://github.com/user-attachments/assets/026b4875-3356-4f32-ae7a-215bdc220437)
</details>