### PR TITLE
CVSL-2337 add HDC highlight for cases in the people on probation tab

### DIFF
--- a/server/views/pages/view/cases.njk
+++ b/server/views/pages/view/cases.njk
@@ -53,6 +53,12 @@
         }, statusConfig) %}
     {% endif %}
 
+    {% if case.kind == 'HDC' %}
+        {% set releaseDateHtml = '<span class="urgent-highlight">' + case.releaseDateLabel + ': <br>' + case.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
+    {% else %}
+        {% set releaseDateHtml = '<p>' + (case.releaseDateLabel + ': <br>' if not probationView) + case.releaseDate + '</p>' %}
+    {% endif %}
+
     {% set licences = (licences.push([
         {
             attributes: {
@@ -83,7 +89,7 @@
                 id: 'release-date-' + loop.index,
                 "data-sort-value": case.releaseDate | dateToUnix
             },
-            html: '<p>' + (case.releaseDateLabel + ': <br>' if not probationView)  + case.releaseDate + '</p>' 
+            html: releaseDateHtml 
         },
         {
             attributes: {

--- a/server/views/pages/view/cases.test.ts
+++ b/server/views/pages/view/cases.test.ts
@@ -256,4 +256,32 @@ describe('View and print a licence - case list', () => {
     expect($('#nomis-id-1').text()).toBe('A1234AA')
     expect($('#release-date-1').text()).toBe('HDCAD: 3 Aug 2022HDC release')
   })
+
+  it('should highlight a HDC licence with a HDC release warning label in probation view', () => {
+    const search = ''
+    const prisonsToDisplay = ''
+    const probationView = true
+    const $ = render({
+      cases: [
+        {
+          name: 'Adam Balasaravika',
+          prisonerNumber: 'A1234AA',
+          releaseDate: '3 Aug 2022',
+          releaseDateLabel: 'HDCAD',
+          tabType: 'releasesInNextTwoWorkingDays',
+          kind: LicenceKind.HDC,
+        },
+      ],
+      showAttentionNeededTab: false,
+      CaViewCasesTab,
+      statusConfig,
+      search,
+      prisonsToDisplay,
+      probationView,
+    })
+    expect($('tbody .govuk-table__row').length).toBe(1)
+    expect($('#name-1 > div > span').text()).toBe('Adam Balasaravika')
+    expect($('#nomis-id-1').text()).toBe('A1234AA')
+    expect($('#release-date-1').text()).toBe('HDCAD: 3 Aug 2022HDC release')
+  })
 })


### PR DESCRIPTION
This follow on PR adds the HDC release label to cases in the CA view, where the person is on probation. 

![Screenshot 2025-01-30 at 15 16 57](https://github.com/user-attachments/assets/05d9f96e-40d4-4522-9538-c388181c126a)
