### PR TITLE
CVSL-2338 add HDC licence data summary when viewing or printing a licence in CA view

### DIFF
--- a/server/routes/initialAppointment/handlers/hardStop/index.ts
+++ b/server/routes/initialAppointment/handlers/hardStop/index.ts
@@ -17,7 +17,7 @@ import ViewAndPrintLicenceRoutes from '../../../viewingLicences/handlers/viewLic
 import ConfirmationRoutes from '../../../creatingLicences/handlers/hardStop/confirmation'
 import PathType from '../../../../enumeration/pathType'
 
-export default function Index({ licenceService, conditionService }: Services): Router {
+export default function Index({ licenceService, conditionService, hdcService }: Services): Router {
   const router = Router()
 
   const routePrefix = (path: string) => `/licence/hard-stop${path}`
@@ -85,7 +85,7 @@ export default function Index({ licenceService, conditionService }: Services): R
     post('/edit/id/:licenceId/initial-meeting-time', controller.POST, DateTime)
   }
   {
-    const controller = new ViewAndPrintLicenceRoutes(licenceService)
+    const controller = new ViewAndPrintLicenceRoutes(licenceService, hdcService)
     get('/id/:licenceId/check-your-answers', controller.GET)
     post('/id/:licenceId/check-your-answers', controller.POST)
   }

--- a/server/routes/viewingLicences/index.ts
+++ b/server/routes/viewingLicences/index.ts
@@ -29,7 +29,7 @@ export default function Index({
     )
 
   const viewCasesHandler = new ViewAndPrintCaseRoutes(caCaseloadService, prisonerService)
-  const viewLicenceHandler = new ViewAndPrintLicenceRoutes(licenceService)
+  const viewLicenceHandler = new ViewAndPrintLicenceRoutes(licenceService, hdcService)
   const printHandler = new PrintLicenceRoutes(prisonerService, qrCodeService, licenceService, hdcService)
   const comDetailsHandler = new ComDetailsRoutes(probationService)
 

--- a/server/views/pages/view/view.njk
+++ b/server/views/pages/view/view.njk
@@ -9,6 +9,8 @@
 {% from "partials/bespokeConditionsSummary.njk" import bespokeConditions %}
 {% from "moj/components/banner/macro.njk" import mojBanner %}
 {% from "pages/immediateReleaseConditions.njk" import immediateReleaseConditions %}
+{% from "pages/licence/partials/hdcCurfewTimes.njk" import hdcCurfewTimes %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% if licence.statusCode === "APPROVED" or licence.statusCode === "ACTIVE" %}
   {% set actionWord = "Print" %}
@@ -61,6 +63,15 @@
                     {{ hardStopInductionMeetingDetails(licence, isEditableByPrison, validationErrors, null, isPrisonUser) }}
                 {% else %}
                     {{ inductionMeetingDetails(licence, isEditableByPrison, [], null, isPrisonUser) }}
+                {% endif %}
+
+                {% if licence.kind === 'HDC' %}
+                    <h2 class="govuk-!-margin-bottom-3 govuk-!-margin-top-3 govuk-heading-m">HDC curfew details</h2>
+                    {{ hdcCurfewTimes(hdcLicenceData) }}
+                    {{ govukDetails({
+                        summaryText: "How do I change the HDC curfew details?",
+                        html: "Email createandvaryalicence@digital.justice.gov.uk to change the HDC curfew details."
+                    }) }}
                 {% endif %}
 
                 {% if licence.kind === 'HARD_STOP' %}

--- a/server/views/pages/view/view.test.ts
+++ b/server/views/pages/view/view.test.ts
@@ -192,6 +192,34 @@ describe('View and print - single licence view', () => {
 
     expect($('h1').text()).toContain('Print post sentence supervision order for John Smith')
   })
+
+  it('should render the HDC curfew details if the licence kind is HDC', () => {
+    const $ = render({
+      licence: { ...licence, kind: 'HDC' },
+    })
+
+    expect($('[data-qa=hdc-curfew-details]').length).toBe(1)
+  })
+
+  it('should render the curfew time summary if all the curfew times are equal', () => {
+    const $ = render({
+      licence: { ...licence, kind: 'HDC' },
+      hdcLicenceData: { allCurfewTimesEqual: true },
+    })
+
+    expect($('[data-qa=hdc-curfew-details]').length).toBe(1)
+    expect($('.all-curfew-times-equal').length).toBe(1)
+  })
+
+  it('should render the individual curfew times if any of the curfew times are different', () => {
+    const $ = render({
+      licence: { ...licence, kind: 'HDC' },
+      hdcLicenceData: { allCurfewTimesEqual: false },
+    })
+
+    expect($('[data-qa=hdc-curfew-details]').length).toBe(1)
+    expect($('[data-qa=curfew-times-not-equal]').length).toBe(1)
+  })
 })
 
 describe('View and print - single standard licence view', () => {


### PR DESCRIPTION
This PR is to add the HDC licence data summary to the CA view. This adds details on curfew address, first night curfew details and curfew hours where a HDC licence has been submitted or approved. 

Submitted - CA - View the licence:
![Screenshot 2025-02-04 at 15 21 31](https://github.com/user-attachments/assets/6df9c1a4-5756-4a47-ae95-1e9f42fb4417)


Approved - CA - Print the licence:
![Screenshot 2025-02-04 at 15 22 12](https://github.com/user-attachments/assets/54734bc2-57be-4d0a-a1f5-3ef5d275a931)
