### PR TITLE
CVSL-2344 content changes to the vary view for HDC licences

### DIFF
--- a/server/routes/varyingLicences/handlers/timeline.test.ts
+++ b/server/routes/varyingLicences/handlers/timeline.test.ts
@@ -5,6 +5,7 @@ import TimelineRoutes from './timeline'
 import LicenceStatus from '../../../enumeration/licenceStatus'
 import TimelineEvent from '../../../@types/TimelineEvent'
 import TimelineService from '../../../services/timelineService'
+import LicenceKind from '../../../enumeration/LicenceKind'
 
 jest.mock('../../../services/licenceService')
 jest.mock('../../../services/timelineService')
@@ -224,6 +225,7 @@ describe('Route Handlers - Timeline', () => {
             id: 1,
             statusCode: LicenceStatus.ACTIVE,
             isReviewNeeded: false,
+            kind: LicenceKind.CRD,
           },
           user: commonUser,
         },
@@ -245,13 +247,53 @@ describe('Route Handlers - Timeline', () => {
       await handler.GET(req, res)
 
       expect(timelineService.getTimelineEvents).toHaveBeenCalledWith(
-        { id: 1, statusCode: LicenceStatus.ACTIVE, isReviewNeeded: false },
+        { id: 1, statusCode: LicenceStatus.ACTIVE, isReviewNeeded: false, kind: LicenceKind.CRD },
         { username: 'joebloggs' },
       )
 
       expect(res.render).toHaveBeenCalledWith('pages/vary/timeline', {
         timelineEvents,
         callToAction: 'VIEW_OR_VARY',
+      })
+    })
+
+    it('should render view call to action', async () => {
+      res = {
+        ...commonRes,
+        locals: {
+          licence: {
+            id: 1,
+            kind: LicenceKind.HDC,
+            statusCode: LicenceStatus.ACTIVE,
+            isReviewNeeded: false,
+          },
+          user: commonUser,
+        },
+      } as unknown as Response
+
+      const timelineEvents = [
+        {
+          eventType: 'CREATION',
+          title: 'Licence created',
+          statusCode: 'ACTIVE',
+          createdBy: 'X Y',
+          licenceId: 1,
+          lastUpdate: '12/11/2022 10:04:00',
+        },
+      ] as unknown as TimelineEvent[]
+
+      timelineService.getTimelineEvents.mockResolvedValue(timelineEvents)
+
+      await handler.GET(req, res)
+
+      expect(timelineService.getTimelineEvents).toHaveBeenCalledWith(
+        { id: 1, statusCode: LicenceStatus.ACTIVE, isReviewNeeded: false, kind: LicenceKind.HDC },
+        { username: 'joebloggs' },
+      )
+
+      expect(res.render).toHaveBeenCalledWith('pages/vary/timeline', {
+        timelineEvents,
+        callToAction: 'VIEW',
       })
     })
   })

--- a/server/routes/varyingLicences/handlers/timeline.ts
+++ b/server/routes/varyingLicences/handlers/timeline.ts
@@ -3,16 +3,18 @@ import LicenceStatus from '../../../enumeration/licenceStatus'
 import TimelineService from '../../../services/timelineService'
 import LicenceService from '../../../services/licenceService'
 import type { Licence } from '../../../@types/licenceApiClientTypes'
+import LicenceKind from '../../../enumeration/LicenceKind'
 
 enum CallToActionType {
   PRINT_TO_ACTIVATE = 'PRINT_TO_ACTIVATE',
   EDIT = 'EDIT',
   REVIEW = 'REVIEW',
   VIEW_OR_VARY = 'VIEW_OR_VARY',
+  VIEW = 'VIEW',
 }
 
 const { VARIATION_APPROVED, ACTIVE, VARIATION_IN_PROGRESS, VARIATION_REJECTED, VARIATION_SUBMITTED } = LicenceStatus
-const { PRINT_TO_ACTIVATE, EDIT, VIEW_OR_VARY, REVIEW } = CallToActionType
+const { PRINT_TO_ACTIVATE, EDIT, VIEW_OR_VARY, REVIEW, VIEW } = CallToActionType
 
 export default class TimelineRoutes {
   constructor(
@@ -24,8 +26,12 @@ export default class TimelineRoutes {
     if (licence.statusCode === VARIATION_APPROVED) {
       return PRINT_TO_ACTIVATE
     }
-    if (licence.statusCode === ACTIVE && !licence.isReviewNeeded) {
+    if (licence.statusCode === ACTIVE && !licence.isReviewNeeded && licence.kind !== LicenceKind.HDC) {
       return VIEW_OR_VARY
+    }
+
+    if (licence.statusCode === ACTIVE && !licence.isReviewNeeded && licence.kind === LicenceKind.HDC) {
+      return VIEW
     }
 
     if ([VARIATION_IN_PROGRESS, VARIATION_SUBMITTED, VARIATION_REJECTED].includes(<LicenceStatus>licence.statusCode)) {

--- a/server/views/pages/vary/timeline.njk
+++ b/server/views/pages/vary/timeline.njk
@@ -5,6 +5,7 @@
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% from "partials/varyCallToActions.njk" import timelineCta %}
 {% from "moj/components/timeline/macro.njk" import mojTimeline %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% set pageTitle = applicationName + " - Vary a licence - licence history" %}
 {% set pageId = "view-timeline-page" %}
@@ -22,6 +23,13 @@
             <input type="hidden" name="_csrf" value="{{ csrfToken }}">
             {{ timelineCta(callToAction, licence) }}
             {{ currentLicenceEvents(timelineEvents) }}
+            {% if licence.kind === 'HDC' %}
+                {{ govukDetails({
+                    summaryText: "How do I vary this licence?",
+                    html: "Email createandvaryalicence@digital.justice.gov.uk to vary this licence.",
+                    attributes: { 'data-qa': 'hdc-vary-licence' }
+                }) }}
+            {% endif %}
         </form>
     {% endset -%}
 

--- a/server/views/pages/vary/timeline.test.ts
+++ b/server/views/pages/vary/timeline.test.ts
@@ -1,6 +1,7 @@
 import fs from 'fs'
 
 import { templateRenderer } from '../../../utils/__testutils/templateTestUtils'
+import LicenceKind from '../../../enumeration/LicenceKind'
 
 const render = templateRenderer(fs.readFileSync('server/views/pages/vary/timeline.njk').toString())
 
@@ -43,5 +44,26 @@ describe('Timeline', () => {
     })
     expect($('[data-qa=date]').text()).not.toContain('Release date: ')
     expect($('[data-qa=date]').text()).toContain('Licence end date:')
+  })
+
+  it('should display the View licence button for HDC licences', () => {
+    const $ = render({
+      timelineEvents: [],
+      callToAction: 'VIEW',
+    })
+    expect($('[data-qa=view-licence]').length).toBe(1)
+    expect($('[data-qa=view-licence]').text().trim()).toContain('View licence')
+  })
+
+  it('should display the How do I vary the licence component for HDC licences', () => {
+    const $ = render({
+      licence: { kind: LicenceKind.HDC },
+      timelineEvents: [],
+      callToAction: 'VIEW',
+    })
+    expect($('[data-qa=hdc-vary-licence]').text().trim()).toContain('How do I vary this licence?')
+    expect($('[data-qa=hdc-vary-licence]').text().trim()).toContain(
+      'Email createandvaryalicence@digital.justice.gov.uk to vary this licence.',
+    )
   })
 })

--- a/server/views/pages/vary/viewActive.njk
+++ b/server/views/pages/vary/viewActive.njk
@@ -25,7 +25,9 @@
         </div>
     </div>
 
-    {{ activeCta(callToActions, licence) }}
+    {% if licence.kind !== 'HDC' %} 
+        {{ activeCta(callToActions, licence) }}
+    {% endif %}
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
@@ -60,6 +62,8 @@
         </div>
     </div>
 
-    {{ activeCta(callToActions, licence) }}
+    {% if licence.kind !== 'HDC' %} 
+        {{ activeCta(callToActions, licence) }}
+    {% endif %}
 
 {% endblock %}

--- a/server/views/pages/vary/viewActive.test.ts
+++ b/server/views/pages/vary/viewActive.test.ts
@@ -2,6 +2,7 @@ import fs from 'fs'
 import LicenceStatus from '../../../enumeration/licenceStatus'
 import { Licence } from '../../../@types/licenceApiClientTypes'
 import { templateRenderer } from '../../../utils/__testutils/templateTestUtils'
+import LicenceKind from '../../../enumeration/LicenceKind'
 
 const render = templateRenderer(fs.readFileSync('server/views/pages/vary/viewActive.njk').toString())
 
@@ -113,5 +114,19 @@ describe('ViewActive', () => {
       additionalConditions: additionalConditionInputs,
     })
     expect($('#conditions-expired').text()).not.toBe('Conditions from expired licence')
+  })
+
+  it('should not display vary buttons for a HDC licence', () => {
+    const $ = render({
+      licence: {
+        ...licence,
+        typeCode: 'AP',
+        isInPssPeriod: false,
+        isActivatedInPssPeriod: true,
+        statusCode: LicenceStatus.ACTIVE,
+        kind: LicenceKind.HDC,
+      },
+    })
+    expect($('[data-qa="vary-licence"]').length).toBe(0)
   })
 })

--- a/server/views/partials/varyCallToActions.njk
+++ b/server/views/partials/varyCallToActions.njk
@@ -50,10 +50,10 @@
                     preventDoubleClick: true
                 }) }}
                 {{ govukButton ({
-    text: "Return to case list",
-                        classes: "govuk-button--secondary",
-                        href: "/licence/vary/caseload",
-                        attributes: { 'data-qa': 'return-to-caselist' }
+                    text: "Return to case list",
+                    classes: "govuk-button--secondary",
+                    href: "/licence/vary/caseload",
+                    attributes: { 'data-qa': 'return-to-caselist' }
                 }) }}
             
             {% case 'VIEW_OR_VARY' %}
@@ -62,6 +62,20 @@
                     classes: "govuk-button--primary govuk-!-margin-right-1",
                     href: '/licence/vary/id/' + licence.id + '/view-active',
                     attributes: { 'data-qa': 'view-or-vary-licence' }
+                }) }}
+                {{ govukButton ({
+                    text: "Return to case list",
+                    classes: "govuk-button--secondary",
+                    href: "/licence/vary/caseload",
+                    attributes: { 'data-qa': 'return-to-caselist' }
+                }) }}
+
+            {% case 'VIEW' %}
+                {{ govukButton({
+                    text: "View licence",
+                    classes: "govuk-button--primary govuk-!-margin-right-1",
+                    href: '/licence/vary/id/' + licence.id + '/view-active',
+                    attributes: { 'data-qa': 'view-licence' }
                 }) }}
                 {{ govukButton ({
                     text: "Return to case list",


### PR DESCRIPTION
This PR is to make content changes for the vary screens once a HDC licence is active. It includes changes to buttons and removing vary functionality (i.e. the buttons) when a licence is viewed. A new component explaining how to vary a HDC licence is also included. 

![Screenshot 2025-02-04 at 17 32 20](https://github.com/user-attachments/assets/225ee451-028a-4b53-9bed-b049f98b53ce)

![Screenshot 2025-02-04 at 17 32 27](https://github.com/user-attachments/assets/c165b37d-7ac3-49a2-88b6-2208fa604f87)

