### PR TITLE
CVSL-2345 add HDC curfew summary when viewing a licence in the vary journey

### DIFF
--- a/server/routes/varyingLicences/handlers/viewActiveLicence.test.ts
+++ b/server/routes/varyingLicences/handlers/viewActiveLicence.test.ts
@@ -3,15 +3,19 @@ import LicenceStatus from '../../../enumeration/licenceStatus'
 import { Licence } from '../../../@types/licenceApiClientTypes'
 import ConditionService from '../../../services/conditionService'
 import ViewActiveLicenceRoutes from './viewActiveLicence'
+import HdcService, { CvlHdcLicenceData } from '../../../services/hdcService'
+import LicenceKind from '../../../enumeration/LicenceKind'
 
 const conditionService = new ConditionService(null) as jest.Mocked<ConditionService>
+const hdcService = new HdcService(null) as jest.Mocked<HdcService>
 
 jest.mock('../../../services/conditionService')
+jest.mock('../../../services/hdcService')
 
 describe('Route Handlers - Vary Licence - View active licence', () => {
   let req: Request
   let res: Response
-  const handler = new ViewActiveLicenceRoutes(conditionService)
+  const handler = new ViewActiveLicenceRoutes(conditionService, hdcService)
   const licence = {
     id: 1,
     surname: 'Bobson',
@@ -22,6 +26,36 @@ describe('Route Handlers - Vary Licence - View active licence', () => {
     additionalPssConditions: [],
     bespokeConditions: [],
   } as Licence
+
+  const exampleHdcLicenceData = {
+    curfewAddress: {
+      addressLine1: 'addressLineOne',
+      addressLine2: 'addressLineTwo',
+      addressTown: 'addressTownOrCity',
+      postCode: 'addressPostcode',
+    },
+    firstNightCurfewHours: {
+      firstNightFrom: '09:00',
+      firstNightUntil: '17:00',
+    },
+    curfewTimes: [
+      {
+        curfewTimesSequence: 1,
+        fromDay: 'MONDAY',
+        fromTime: '17:00:00',
+        untilDay: 'TUESDAY',
+        untilTime: '09:00:00',
+      },
+      {
+        curfewTimesSequence: 2,
+        fromDay: 'TUESDAY',
+        fromTime: '17:00:00',
+        untilDay: 'WEDNESDAY',
+        untilTime: '09:00:00',
+      },
+    ],
+    allCurfewTimesEqual: true,
+  } as CvlHdcLicenceData
 
   afterEach(() => {
     jest.resetAllMocks()
@@ -47,6 +81,7 @@ describe('Route Handlers - Vary Licence - View active licence', () => {
     } as unknown as Response
     const condition = { code: 'code5', text: 'Conditon 5', category: 'group1', requiresInput: false }
     conditionService.getAdditionalConditionByCode.mockResolvedValue(condition)
+    hdcService.getHdcLicenceData.mockResolvedValue(exampleHdcLicenceData)
   })
 
   describe('GET', () => {
@@ -74,6 +109,7 @@ describe('Route Handlers - Vary Licence - View active licence', () => {
             },
           ],
         ],
+        hdcLicenceData: null,
       })
     })
 
@@ -92,6 +128,46 @@ describe('Route Handlers - Vary Licence - View active licence', () => {
       await handler.GET(req, res)
 
       expect(res.redirect).toHaveBeenCalledWith(`/licence/vary/id/${licence.id}/timeline`)
+    })
+
+    it('should pass through the HDC licence data when it is a HDC licence', async () => {
+      res = {
+        render: jest.fn(),
+        redirect: jest.fn(),
+        locals: {
+          ...res.locals,
+          licence: {
+            ...licence,
+            kind: LicenceKind.HDC,
+          },
+        },
+      } as unknown as Response
+
+      conditionService.getAdditionalAPConditionsForSummaryAndPdf.mockResolvedValue([
+        {
+          text: 'Condition 1',
+          code: 'CON1',
+          data: [],
+          uploadSummary: [],
+        },
+      ])
+
+      await handler.GET(req, res)
+
+      expect(res.render).toHaveBeenCalledWith('pages/vary/viewActive', {
+        callToActions: { shouldShowVaryButton: true },
+        additionalConditions: [
+          [
+            {
+              text: 'Condition 1',
+              code: 'CON1',
+              data: [],
+              uploadSummary: [],
+            },
+          ],
+        ],
+        hdcLicenceData: exampleHdcLicenceData,
+      })
     })
   })
 })

--- a/server/routes/varyingLicences/handlers/viewActiveLicence.ts
+++ b/server/routes/varyingLicences/handlers/viewActiveLicence.ts
@@ -2,9 +2,14 @@ import { Request, Response } from 'express'
 import LicenceStatus from '../../../enumeration/licenceStatus'
 import ConditionService from '../../../services/conditionService'
 import { groupingBy } from '../../../utils/utils'
+import HdcService from '../../../services/hdcService'
+import LicenceKind from '../../../enumeration/LicenceKind'
 
 export default class ViewActiveLicenceRoutes {
-  constructor(private readonly conditionService: ConditionService) {}
+  constructor(
+    private readonly conditionService: ConditionService,
+    private readonly hdcService: HdcService,
+  ) {}
 
   GET = async (req: Request, res: Response): Promise<void> => {
     const { licence, user } = res.locals
@@ -20,10 +25,13 @@ export default class ViewActiveLicenceRoutes {
 
     const bespokeConditionsToDisplay = await this.conditionService.getbespokeConditionsForSummaryAndPdf(licence, user)
 
+    const hdcLicenceData = licence.kind === LicenceKind.HDC ? await this.hdcService.getHdcLicenceData(licence.id) : null
+
     return res.render('pages/vary/viewActive', {
       additionalConditions: groupingBy(conditionsToDisplay, 'code'),
       bespokeConditionsToDisplay,
       callToActions: { shouldShowVaryButton },
+      hdcLicenceData,
     })
   }
 }

--- a/server/routes/varyingLicences/index.ts
+++ b/server/routes/varyingLicences/index.ts
@@ -42,6 +42,7 @@ export default function Index({
   probationService,
   conditionService,
   timelineService,
+  hdcService,
 }: Services): Router {
   const router = Router()
 
@@ -75,7 +76,7 @@ export default function Index({
   const comDetailsHandler = new ComDetailsRoutes(probationService)
   const timelineHandler = new TimelineRoutes(licenceService, timelineService)
   const viewLicenceHandler = new ViewVariationRoutes(licenceService, conditionService)
-  const viewActiveLicenceHandler = new ViewActiveLicenceRoutes(conditionService)
+  const viewActiveLicenceHandler = new ViewActiveLicenceRoutes(conditionService, hdcService)
   const confirmVaryActionHandler = new ConfirmVaryActionRoutes(licenceService)
   const spoDiscussionHandler = new SpoDiscussionRoutes(licenceService)
   const vloDiscussionHandler = new VloDiscussionRoutes(licenceService, conditionService)

--- a/server/views/pages/vary/viewActive.njk
+++ b/server/views/pages/vary/viewActive.njk
@@ -5,6 +5,7 @@
 {% from "partials/additionalPssConditionsSummary.njk" import additionalPssConditions %}
 {% from "partials/bespokeConditionsSummary.njk" import bespokeConditions %}
 {% from "partials/varyCallToActions.njk" import activeCta %}
+{% from "pages/licence/partials/hdcCurfewTimes.njk" import hdcCurfewTimes %}
 
 {% set pageTitle = applicationName + " - Vary a licence - Active licence" %}
 {% set isInVariation = licence.statusCode == 'VARIATION_IN_PROGRESS' or licence.statusCode == 'VARIATION_SUBMITTED' 
@@ -27,6 +28,11 @@
 
     {% if licence.kind !== 'HDC' %} 
         {{ activeCta(callToActions, licence) }}
+    {% endif %}
+
+    {% if licence.kind === 'HDC' %}
+        <h2 class="govuk-!-margin-bottom-3 govuk-!-margin-top-3 govuk-heading-m">HDC curfew details</h2>
+        {{ hdcCurfewTimes(hdcLicenceData) }}
     {% endif %}
 
     <div class="govuk-grid-row">

--- a/server/views/pages/vary/viewActive.test.ts
+++ b/server/views/pages/vary/viewActive.test.ts
@@ -116,6 +116,14 @@ describe('ViewActive', () => {
     expect($('#conditions-expired').text()).not.toBe('Conditions from expired licence')
   })
 
+  it('should not render the HDC curfew details for non HDC licences', () => {
+    const $ = render({
+      licence: { ...licence, kind: 'CRD' },
+    })
+
+    expect($('[data-qa=hdc-curfew-details]').length).toBe(0)
+  })
+
   it('should not display vary buttons for a HDC licence', () => {
     const $ = render({
       licence: {
@@ -128,5 +136,33 @@ describe('ViewActive', () => {
       },
     })
     expect($('[data-qa="vary-licence"]').length).toBe(0)
+  })
+
+  it('should render the HDC curfew details if the licence kind is HDC', () => {
+    const $ = render({
+      licence: { ...licence, kind: 'HDC' },
+    })
+
+    expect($('[data-qa=hdc-curfew-details]').length).toBe(1)
+  })
+
+  it('should render the curfew time summary if all the curfew times are equal', () => {
+    const $ = render({
+      licence: { ...licence, kind: 'HDC' },
+      hdcLicenceData: { allCurfewTimesEqual: true },
+    })
+
+    expect($('[data-qa=hdc-curfew-details]').length).toBe(1)
+    expect($('.all-curfew-times-equal').length).toBe(1)
+  })
+
+  it('should render the individual curfew times if any of the curfew times are different', () => {
+    const $ = render({
+      licence: { ...licence, kind: 'HDC' },
+      hdcLicenceData: { allCurfewTimesEqual: false },
+    })
+
+    expect($('[data-qa=hdc-curfew-details]').length).toBe(1)
+    expect($('[data-qa=curfew-times-not-equal]').length).toBe(1)
   })
 })


### PR DESCRIPTION
This PR is to add the HDC curfew summary when a PP is viewing a HDC licence in the vary journey. 

![Screenshot 2025-02-05 at 15 06 58](https://github.com/user-attachments/assets/3530761b-a398-419d-a593-aa5510baa3f8)
