### PR TITLE
CVSL-2346 add HDC release marker for vary caseload

### DIFF
--- a/server/routes/varyingLicences/handlers/caseload.test.ts
+++ b/server/routes/varyingLicences/handlers/caseload.test.ts
@@ -154,7 +154,7 @@ describe('Route Handlers - Vary Licence - Caseload', () => {
               name: 'Walter White',
             },
             isDueForEarlyRelease: false,
-            kind: 'CRD',
+            kind: LicenceKind.CRD,
             isReviewNeeded: true,
           },
           {
@@ -169,7 +169,7 @@ describe('Route Handlers - Vary Licence - Caseload', () => {
               name: 'Walter White',
             },
             isDueForEarlyRelease: false,
-            kind: 'CRD',
+            kind: LicenceKind.CRD,
             isReviewNeeded: false,
           },
         ],

--- a/server/routes/varyingLicences/handlers/caseload.ts
+++ b/server/routes/varyingLicences/handlers/caseload.ts
@@ -25,6 +25,7 @@ export default class CaseloadRoutes {
         ...comCase,
         releaseDate,
         licenceStatus: comCase.isReviewNeeded ? LicenceStatus.REVIEW_NEEDED : comCase.licenceStatus,
+        kind: comCase.kind,
       }
     })
 

--- a/server/views/pages/vary/caseload.njk
+++ b/server/views/pages/vary/caseload.njk
@@ -22,6 +22,9 @@
 {% for offender in caseload %}
     {% if offender.licenceStatus === "REVIEW_NEEDED" %}
         {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Timed out</span>' %}
+    {% elseif offender.kind === 'HDC' %}
+        {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate
+            + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
     {% else %}
         {% set releaseDate = offender.releaseDate %}
     {% endif %}

--- a/server/views/pages/vary/caseload.test.ts
+++ b/server/views/pages/vary/caseload.test.ts
@@ -99,4 +99,37 @@ describe('Caseload', () => {
     expect($('.status-badge').text().toString()).toContain('Review needed')
     expect($('.urgent-highlight-message').text().toString()).toEqual('Timed out')
   })
+
+  it('should highlight a HDC licence with a HDC release warning label', () => {
+    const $ = render({
+      caseload: [
+        {
+          licenceId: 3,
+          name: 'Biydaav Griya',
+          crnNumber: 'Z882661',
+          licenceType: 'AP',
+          releaseDate: '13 Feb 2023',
+          licenceStatus: 'ACTIVE',
+          probationPractitioner: { staffCode: 'X12342', name: 'CVL COM' },
+          kind: 'HDC',
+        },
+      ],
+      statusConfig: {
+        ACTIVE: {
+          label: 'Active',
+          description: 'Approved by the prison and is now the currently active licence',
+          colour: 'turquoise',
+        },
+        VARIATION_IN_PROGRESS: {
+          label: 'Variation in progress',
+          description: 'Variation in progress',
+          colour: 'blue',
+        },
+      },
+    })
+    expect($('tbody .govuk-table__row').length).toBe(1)
+    expect($('.status-badge').text().toString()).toContain('Active')
+    expect($('#release-date-1').text()).toBe('13 Feb 2023HDC release')
+    expect($('.urgent-highlight-message').text().toString()).toEqual('HDC release')
+  })
 })


### PR DESCRIPTION
This PR is to add a HDC marker to HDC licences in the vary caseload view. 

![Screenshot 2025-02-06 at 12 34 50](https://github.com/user-attachments/assets/f3fdec69-7b12-49cf-82b6-b015e0e45fda)
