### PR TITLE
CVSL-2346 add HDC release marker for PP search

### DIFF
--- a/server/views/pages/search/probationSearch/probationSearch.njk
+++ b/server/views/pages/search/probationSearch/probationSearch.njk
@@ -127,6 +127,9 @@
         {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort + '</span><span class="urgent-highlight urgent-highlight-message">Early release</span>' %}
     {% elseif offender | shouldShowHardStopWarning %}
         {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Submit licence by ' + offender.hardStopDate | cvlDateToDateShort  +'</span>' %}
+    {% elseif offender.kind === "HDC" %}
+        {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort
+            + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
     {% else %}
         {% set releaseDate = '<p>' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort + '</p>' %}
     {% endif %}

--- a/server/views/pages/search/probationSearch/probationSearch.test.ts
+++ b/server/views/pages/search/probationSearch/probationSearch.test.ts
@@ -470,4 +470,82 @@ describe('View Probation Search Results', () => {
     })
     expect($('#name-button-1').attr('href')).toBe('/licence/create/id/3/check-your-answers')
   })
+
+  it('should highlight a HDC licence with a HDC release warning label in the people in prison tab', () => {
+    const $ = render({
+      statusConfig,
+      searchResponse: {
+        results: [
+          {
+            name: 'Test Person',
+            crn: 'A123456',
+            nomisId: 'A1234BC',
+            comName: 'Test Staff',
+            comStaffCode: '3000',
+            teamName: 'Test Team',
+            releaseDate: '20/12/2025',
+            licenceId: 1,
+            licenceType: 'AP',
+            licenceStatus: LicenceStatus.IN_PROGRESS,
+            isOnProbation: false,
+            isDueForEarlyRelease: false,
+            releaseDateLabel: 'HDCAD',
+            kind: LicenceKind.HDC,
+          },
+        ],
+        inPrisonCount: 1,
+        onProbationCount: 0,
+      },
+      tabParameters: {
+        activeTab: '#people-in-prison',
+        prisonTabId: 'tab-heading-prison',
+        probationTabId: 'tab-heading-probation',
+      },
+      queryTerm: 'Test',
+    })
+
+    expect($('tbody .govuk-table__row').length).toBe(1)
+    expect($('#licence-status-1 > .status-badge').text().trim()).toBe('In progress')
+    expect($('#release-date-1').text()).toBe('HDCAD: 20 Dec 2025HDC release')
+    expect($('.urgent-highlight-message').text().toString()).toEqual('HDC release')
+  })
+
+  it('should highlight a HDC licence with a HDC release warning label in the people on probation tab', () => {
+    const $ = render({
+      statusConfig,
+      searchResponse: {
+        results: [
+          {
+            name: 'Test Person',
+            crn: 'A123456',
+            nomisId: 'A1234BC',
+            comName: 'Test Staff',
+            comStaffCode: '3000',
+            teamName: 'Test Team',
+            releaseDate: '20/12/2025',
+            licenceId: 1,
+            licenceType: 'AP',
+            licenceStatus: LicenceStatus.ACTIVE,
+            isOnProbation: true,
+            isDueForEarlyRelease: false,
+            releaseDateLabel: 'HDCAD',
+            kind: LicenceKind.HDC,
+          },
+        ],
+        inPrisonCount: 0,
+        onProbationCount: 1,
+      },
+      tabParameters: {
+        activeTab: '#people-on-probation',
+        prisonTabId: 'tab-heading-prison',
+        probationTabId: 'tab-heading-probation',
+      },
+      queryTerm: 'Test',
+    })
+
+    expect($('tbody .govuk-table__row').length).toBe(1)
+    expect($('#licence-status-1 > .status-badge').text().trim()).toBe('Active')
+    expect($('#release-date-1').text()).toBe('HDCAD: 20 Dec 2025HDC release')
+    expect($('.urgent-highlight-message').text().toString()).toEqual('HDC release')
+  })
 })


### PR DESCRIPTION
This follow on PR adds the HDC release marker for search, both on the people in prison and people on probation tabs. 

![Screenshot 2025-02-07 at 11 08 48](https://github.com/user-attachments/assets/71a7f196-d287-4773-9b18-cddc4ae24826)

![Screenshot 2025-02-07 at 11 11 01](https://github.com/user-attachments/assets/0d335216-3d86-4395-884e-e3d64647b015)
