### PR TITLE
CVSL-2591 add pre licence creation middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then:
 There is a single integration test to verify that the Gotenberg container can support the
 conversion of HTML to PDF documents. To run this, follow these instructions:
 
-`$ docker-compose up -d`
+`$ docker compose up -d`
 
 This runs local redis and gotenberg containers.
 
@@ -63,9 +63,9 @@ NOTE: This test is not currently run in CI.
 
 Pull images and start dependent services:
 
-`$ docker-compose -f docker-compose-test.yml pull`
+`$ docker compose -f docker-compose-test.yml pull`
 
-`$ docker-compose -f docker-compose-test.yml up -d`
+`$ docker compose -f docker-compose-test.yml up -d`
 
 In a different terminal:
 

--- a/integration_tests/integration/createHdcLicence.cy.ts
+++ b/integration_tests/integration/createHdcLicence.cy.ts
@@ -12,6 +12,7 @@ context('Create an HDC licence', () => {
     cy.task('stubGetHdcCaseloadItem')
     cy.task('stubGetHdcLicence')
     cy.task('stubGetProbationer')
+    cy.task('stubGetResponsibleCommunityManager')
     cy.task('stubUpdateStandardConditions')
     cy.task('stubRecordAuditEvent')
     cy.task('stubGetLicencePolicyConditions')

--- a/server/middleware/preLicenceCreationMiddleware.test.ts
+++ b/server/middleware/preLicenceCreationMiddleware.test.ts
@@ -1,0 +1,136 @@
+import { Request, Response } from 'express'
+import ProbationService from '../services/probationService'
+import preLicenceCreationMiddleware from './preLicenceCreationMiddleware'
+import { OffenderDetail } from '../@types/probationSearchApiClientTypes'
+import { DeliusManager } from '../@types/deliusClientTypes'
+
+jest.mock('../services/probationService')
+
+const req = {
+  path: '/licence/create/nomisId/A1234BC/confirm',
+} as Request
+const next = jest.fn()
+
+const res = {
+  locals: {
+    user: {
+      username: 'YY',
+      deliusStaffIdentifier: 123,
+      probationAreaCode: 'N55',
+      probationTeamCodes: ['Team2'],
+      userRoles: ['ROLE_LICENCE_RO'],
+    },
+    licence: undefined,
+  },
+  redirect: jest.fn(),
+} as unknown as Response
+
+const probationService = new ProbationService(null, null) as jest.Mocked<ProbationService>
+
+const middleware = preLicenceCreationMiddleware(probationService)
+
+beforeEach(() => {
+  req.params = { nomisId: 'A1234BC' }
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('preLicenceCreationMiddleware', () => {
+  it('should not run pre licence creation check if nomisId is not populated', async () => {
+    req.params = {}
+    await middleware(req, res, next)
+    expect(probationService.getProbationer).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('should populate delius record from probation service', async () => {
+    await middleware(req, res, next)
+    expect(probationService.getProbationer).toHaveBeenCalledTimes(1)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('should handle error from probation service', async () => {
+    probationService.getProbationer.mockRejectedValue('Error')
+    await middleware(req, res, next)
+    expect(next).toHaveBeenCalledWith('Error')
+  })
+
+  it('should allow access for a probation user based on teams', async () => {
+    probationService.getProbationer.mockResolvedValue({
+      otherIds: {
+        crn: 'X12345',
+      },
+    } as OffenderDetail)
+    probationService.getResponsibleCommunityManager.mockResolvedValue({
+      code: 'X12345',
+      id: 2000,
+      username: 'joebloggs',
+      email: 'joebloggs@probation.gov.uk',
+      name: {
+        forename: 'Joe',
+        surname: 'Bloggs',
+      },
+      provider: {
+        code: 'N02',
+        description: 'N02 Region',
+      },
+      team: {
+        code: 'Team2',
+        description: 'Team2 Description',
+        borough: {
+          code: 'PDU2',
+          description: 'PDU2 Description',
+        },
+        district: {
+          code: 'LAU2',
+          description: 'LAU2 Description',
+        },
+      },
+    } as DeliusManager)
+    await middleware(req, res, next)
+    expect(probationService.getProbationer).toHaveBeenCalledTimes(1)
+    expect(probationService.getResponsibleCommunityManager).toHaveBeenCalledTimes(1)
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it('should deny access for a probation user based on teams', async () => {
+    probationService.getProbationer.mockResolvedValue({
+      otherIds: {
+        crn: 'X12345',
+      },
+    } as OffenderDetail)
+    probationService.getResponsibleCommunityManager.mockResolvedValue({
+      code: 'X12345',
+      id: 2000,
+      username: 'joebloggs',
+      email: 'joebloggs@probation.gov.uk',
+      name: {
+        forename: 'Joe',
+        surname: 'Bloggs',
+      },
+      provider: {
+        code: 'N02',
+        description: 'N02 Region',
+      },
+      team: {
+        code: 'Team3',
+        description: 'Team3 Description',
+        borough: {
+          code: 'PDU2',
+          description: 'PDU2 Description',
+        },
+        district: {
+          code: 'LAU2',
+          description: 'LAU2 Description',
+        },
+      },
+    } as DeliusManager)
+    await middleware(req, res, next)
+    expect(probationService.getProbationer).toHaveBeenCalledTimes(1)
+    expect(probationService.getResponsibleCommunityManager).toHaveBeenCalledTimes(1)
+    expect(res.redirect).toHaveBeenCalledWith('/access-denied')
+    expect(next).not.toHaveBeenCalled()
+  })
+})

--- a/server/middleware/preLicenceCreationMiddleware.test.ts
+++ b/server/middleware/preLicenceCreationMiddleware.test.ts
@@ -6,35 +6,36 @@ import { DeliusManager } from '../@types/deliusClientTypes'
 
 jest.mock('../services/probationService')
 
-const req = {
-  path: '/licence/create/nomisId/A1234BC/confirm',
-} as Request
+let req: Request
+let res: Response
 const next = jest.fn()
-
-const res = {
-  locals: {
-    user: {
-      username: 'YY',
-      deliusStaffIdentifier: 123,
-      probationAreaCode: 'N55',
-      probationTeamCodes: ['Team2'],
-      userRoles: ['ROLE_LICENCE_RO'],
-    },
-    licence: undefined,
-  },
-  redirect: jest.fn(),
-} as unknown as Response
 
 const probationService = new ProbationService(null, null) as jest.Mocked<ProbationService>
 
 const middleware = preLicenceCreationMiddleware(probationService)
 
 beforeEach(() => {
-  req.params = { nomisId: 'A1234BC' }
-})
-
-afterEach(() => {
   jest.resetAllMocks()
+  req = {
+    params: {
+      nomisId: 'A1234BC',
+    },
+    path: '/licence/create/nomisId/A1234BC/confirm',
+  } as unknown as Request
+
+  res = {
+    locals: {
+      user: {
+        username: 'YY',
+        deliusStaffIdentifier: 123,
+        probationAreaCode: 'N55',
+        probationTeamCodes: ['Team2'],
+        userRoles: ['ROLE_LICENCE_RO'],
+      },
+      licence: undefined,
+    },
+    redirect: jest.fn(),
+  } as unknown as Response
 })
 
 describe('preLicenceCreationMiddleware', () => {
@@ -44,7 +45,7 @@ describe('preLicenceCreationMiddleware', () => {
   })
 
   it('should return early if there is no delius staff identifier', async () => {
-    probationService.getProbationer.mockResolvedValue(null)
+    probationService.getProbationer.mockResolvedValue(undefined)
     await middleware(req, res, next)
     expect(probationService.getProbationer).toHaveBeenCalledTimes(1)
     expect(probationService.getResponsibleCommunityManager).toHaveBeenCalledTimes(0)
@@ -52,7 +53,7 @@ describe('preLicenceCreationMiddleware', () => {
   })
 
   it('should return early if there is no delius record', async () => {
-    res.locals.user.deliusStaffIdentifier = null
+    res.locals.user.deliusStaffIdentifier = undefined
     await middleware(req, res, next)
     expect(probationService.getProbationer).toHaveBeenCalledTimes(1)
     expect(probationService.getResponsibleCommunityManager).toHaveBeenCalledTimes(0)

--- a/server/middleware/preLicenceCreationMiddleware.ts
+++ b/server/middleware/preLicenceCreationMiddleware.ts
@@ -1,31 +1,32 @@
 import { RequestHandler } from 'express'
+import assert from 'assert'
 import logger from '../../logger'
 import ProbationService from '../services/probationService'
 
 export default function preLicenceCreationMiddleware(probationService: ProbationService): RequestHandler {
   return async (req, res, next) => {
-    if (req.params.nomisId) {
-      try {
-        const { user } = res.locals
-        const { nomisId } = req.params
+    assert(req.params.nomisId, 'No nomisId has been provided')
 
-        const deliusRecord = await probationService.getProbationer({ nomsNumber: nomisId })
-        if (deliusRecord) {
-          const responsibleCom = await probationService.getResponsibleCommunityManager(deliusRecord.otherIds.crn)
-          if (responsibleCom) {
-            if (user?.deliusStaffIdentifier && !user.probationTeamCodes?.includes(responsibleCom.team.code)) {
-              logger.info(
-                `Access denied to create licence for ${nomisId} as ${responsibleCom.team.code} team not present in user probation teams ${user?.probationTeamCodes}`,
-              )
+    try {
+      const { user } = res.locals
+      const { nomisId } = req.params
 
-              return res.redirect('/access-denied')
-            }
-          }
-        }
-      } catch (error) {
-        logger.error(error, `Failed to check pre licence creation rules for: ${req.params.nomisId}`)
-        return next(error)
+      const deliusRecord = await probationService.getProbationer({ nomsNumber: nomisId })
+
+      if (!deliusRecord || !user?.deliusStaffIdentifier) {
+        logger.info(`Access denied to create licence for ${nomisId}`)
+        return res.redirect('/authError')
       }
+      const responsibleCom = await probationService.getResponsibleCommunityManager(deliusRecord.otherIds.crn)
+      if (!user.probationTeamCodes?.includes(responsibleCom.team.code)) {
+        logger.info(
+          `Access denied to create licence for ${nomisId} as ${responsibleCom.team.code} team not present in user probation teams ${user?.probationTeamCodes}`,
+        )
+        return res.redirect('/access-denied')
+      }
+    } catch (error) {
+      logger.error(error, `Failed to check pre licence creation rules for: ${req.params.nomisId}`)
+      return next(error)
     }
 
     return next()

--- a/server/middleware/preLicenceCreationMiddleware.ts
+++ b/server/middleware/preLicenceCreationMiddleware.ts
@@ -1,0 +1,33 @@
+import { RequestHandler } from 'express'
+import logger from '../../logger'
+import ProbationService from '../services/probationService'
+
+export default function preLicenceCreationMiddleware(probationService: ProbationService): RequestHandler {
+  return async (req, res, next) => {
+    if (req.params.nomisId) {
+      try {
+        const { user } = res.locals
+        const { nomisId } = req.params
+
+        const deliusRecord = await probationService.getProbationer({ nomsNumber: nomisId })
+        if (deliusRecord) {
+          const responsibleCom = await probationService.getResponsibleCommunityManager(deliusRecord.otherIds.crn)
+          if (responsibleCom) {
+            if (user?.deliusStaffIdentifier && !user.probationTeamCodes?.includes(responsibleCom.team.code)) {
+              logger.info(
+                `Access denied to create licence for ${nomisId} as ${responsibleCom.team.code} team not present in user probation teams ${user?.probationTeamCodes}`,
+              )
+
+              return res.redirect('/access-denied')
+            }
+          }
+        }
+      } catch (error) {
+        logger.error(error, `Failed to check pre licence creation rules for: ${req.params.nomisId}`)
+        return next(error)
+      }
+    }
+
+    return next()
+  }
+}

--- a/server/routes/creatingLicences/crdLicenceInHardStop.test.ts
+++ b/server/routes/creatingLicences/crdLicenceInHardStop.test.ts
@@ -7,6 +7,9 @@ import ProbationService from '../../services/probationService'
 import ConditionService from '../../services/conditionService'
 import { AdditionalConditionAp } from '../../@types/LicencePolicy'
 import UkBankHolidayFeedService, { BankHolidayRetriever } from '../../services/ukBankHolidayFeedService'
+import { OffenderDetail } from '../../@types/probationSearchApiClientTypes'
+import { DeliusManager } from '../../@types/deliusClientTypes'
+import { User } from '../../@types/CvlUserDetails'
 
 let app: Express
 
@@ -29,9 +32,17 @@ const licence = {
   version: '3.0',
 } as Licence
 
+const user = {
+  username: 'joebloggs',
+  deliusStaffIdentifier: 2000,
+  probationTeamCodes: ['ABC123'],
+  userRoles: ['ROLE_LICENCE_RO'],
+} as User
+
 beforeEach(() => {
   app = appWithAllRoutes({
     services: { licenceService, conditionService, ukBankHolidayFeedService, probationService },
+    userSupplier: () => user,
   })
   licenceService.getOmuEmail.mockResolvedValue({ email: 'test@test.test' } as OmuContact)
   licenceService.getParentLicenceOrSelf.mockResolvedValue(licence)
@@ -39,6 +50,38 @@ beforeEach(() => {
 
   conditionService.getAdditionalAPConditionsForSummaryAndPdf.mockResolvedValue([])
   conditionService.getAdditionalConditionByCode.mockResolvedValue({ validatorType: null } as AdditionalConditionAp)
+
+  probationService.getProbationer.mockResolvedValue({
+    otherIds: {
+      crn: 'X12345',
+    },
+  } as OffenderDetail)
+  probationService.getResponsibleCommunityManager.mockResolvedValue({
+    code: 'X12345',
+    id: 2000,
+    username: 'joebloggs',
+    email: 'joebloggs@probation.gov.uk',
+    name: {
+      forename: 'Joe',
+      surname: 'Bloggs',
+    },
+    provider: {
+      code: 'N02',
+      description: 'N02 Region',
+    },
+    team: {
+      code: 'ABC123',
+      description: 'Team2 Description',
+      borough: {
+        code: 'PDU2',
+        description: 'PDU2 Description',
+      },
+      district: {
+        code: 'LAU2',
+        description: 'LAU2 Description',
+      },
+    },
+  } as DeliusManager)
 })
 
 afterEach(() => {

--- a/server/routes/creatingLicences/crdLicenceInHardStop.test.ts
+++ b/server/routes/creatingLicences/crdLicenceInHardStop.test.ts
@@ -66,19 +66,19 @@ beforeEach(() => {
       surname: 'Bloggs',
     },
     provider: {
-      code: 'N02',
-      description: 'N02 Region',
+      code: 'N01',
+      description: 'N01 Region',
     },
     team: {
       code: 'ABC123',
-      description: 'Team2 Description',
+      description: 'ABC123 Description',
       borough: {
-        code: 'PDU2',
-        description: 'PDU2 Description',
+        code: 'PDU1',
+        description: 'PDU1 Description',
       },
       district: {
-        code: 'LAU2',
-        description: 'LAU2 Description',
+        code: 'LAU1',
+        description: 'LAU1 Description',
       },
     },
   } as DeliusManager)

--- a/server/routes/creatingLicences/handlers/hdc/index.ts
+++ b/server/routes/creatingLicences/handlers/hdc/index.ts
@@ -8,6 +8,7 @@ import { Services } from '../../../../services'
 
 import YesOrNoQuestion from '../../types/yesOrNo'
 import ConfirmCreateRoutes from './confirmCreate'
+import preLicenceCreationMiddleware from '../../../../middleware/preLicenceCreationMiddleware'
 
 export default function Index({ licenceService, conditionService, probationService }: Services): Router {
   const router = Router()
@@ -25,6 +26,7 @@ export default function Index({ licenceService, conditionService, probationServi
       routePrefix(path),
       roleCheckMiddleware(['ROLE_LICENCE_RO']),
       fetchLicence(licenceService),
+      preLicenceCreationMiddleware(probationService),
       asyncMiddleware(handler),
     )
 

--- a/server/routes/creatingLicences/index.ts
+++ b/server/routes/creatingLicences/index.ts
@@ -24,6 +24,7 @@ import LicenceCreatedByPrisonRoutes from './handlers/licenceCreatedByPrison'
 import LicenceChangesNotApprovedInTimeRoutes from './handlers/licenceChangesNotApprovedInTime'
 import hardStopCheckMiddleware from '../../middleware/hardStopCheckMiddleware'
 import UserType from '../../enumeration/userType'
+import preLicenceCreationMiddleware from '../../middleware/preLicenceCreationMiddleware'
 
 export default function Index({
   licenceService,
@@ -59,6 +60,15 @@ export default function Index({
       asyncMiddleware(handler),
     )
 
+  const getWithPreLicenceCreationCheck = (path: string, handler: RequestHandler) =>
+    router.get(
+      routePrefix(path),
+      roleCheckMiddleware(['ROLE_LICENCE_RO']),
+      fetchLicence(licenceService),
+      preLicenceCreationMiddleware(probationService),
+      asyncMiddleware(handler),
+    )
+
   const post = (path: string, handler: RequestHandler, type?: new () => object) =>
     router.post(
       routePrefix(path),
@@ -90,7 +100,7 @@ export default function Index({
 
   {
     const controller = new ConfirmCreateRoutes(probationService, licenceService)
-    get('/nomisId/:nomisId/confirm', controller.GET)
+    getWithPreLicenceCreationCheck('/nomisId/:nomisId/confirm', controller.GET)
     post('/nomisId/:nomisId/confirm', controller.POST, YesOrNoQuestion)
   }
 


### PR DESCRIPTION
This PR is to address bug found during HDC integration testing. This bug allowed any COM to create a HDC licence for any eligible prisoner. We are now checking whether the COM attempting to create the licence (CRD or HDC) has a relationship to the person the licence is being created for (either as their responsible COM or part of the same team).