### PR TITLE
CVSL-2591 remove check for null booking ID as not sent back from resp…

### DIFF
--- a/server/services/prisonerService.test.ts
+++ b/server/services/prisonerService.test.ts
@@ -213,20 +213,6 @@ describe('Prisoner Service', () => {
       expect(prisonApiClient.getLatestHdcStatus).toHaveBeenCalledWith('123')
     })
 
-    it('Should return NULL if no bookingId is found', async () => {
-      prisonApiClient.getLatestHdcStatus.mockResolvedValue({
-        bookingId: null,
-        approvalStatus: 'PASSED',
-        passed: true,
-      } as HomeDetentionCurfew)
-
-      const actualResult = await prisonerService.getActiveHdcStatus('123')
-
-      expect(actualResult).toBeNull()
-
-      expect(prisonApiClient.getLatestHdcStatus).toHaveBeenCalledWith('123')
-    })
-
     it('Should return PASSED approval status', async () => {
       prisonApiClient.getLatestHdcStatus.mockResolvedValue({
         bookingId: 123,

--- a/server/services/prisonerService.ts
+++ b/server/services/prisonerService.ts
@@ -80,14 +80,11 @@ export default class PrisonerService {
 
   async getActiveHdcStatus(bookingId: string): Promise<HdcStatus | null> {
     const hdcLicence = await this.prisonApiClient.getLatestHdcStatus(bookingId)
-    if (!hdcLicence || !hdcLicence.bookingId) return null
-
-    const hdcBookingId = hdcLicence.bookingId.toString()
-
+    if (!hdcLicence) return null
     return {
       approvalStatus: hdcLicence.approvalStatus,
       checksPassed: hdcLicence?.passed,
-      bookingId: hdcBookingId,
+      bookingId,
     }
   }
 


### PR DESCRIPTION
…onse

This PR is to remove returning a null when the latest HDC status is returned where bookingId is not present in the response. 