### PR TITLE
CVSL-2596 adjust macro to include county and adjust names of variables

### DIFF
--- a/integration_tests/integration/approveLicence.cy.ts
+++ b/integration_tests/integration/approveLicence.cy.ts
@@ -146,7 +146,7 @@ context('Approve a licence', () => {
     approvalViewPage.getValue(approvalViewPage.accordionSectionHeading).should('contain.text', 'HDC curfew details')
     approvalViewPage
       .getValue(approvalViewPage.curfewAddress)
-      .should('contain.text', '1 The Street, Avenue, Some Town, A1 2BC')
+      .should('contain.text', '1 The Street, Avenue, Some Town, Some County, A1 2BC')
     approvalViewPage.getValue(approvalViewPage.firstNightCurfewHours).should('contain.text', '5pm to 7am')
     approvalViewPage.getValue(approvalViewPage.curfewHours).should('contain.text', 'Monday to Sunday')
     approvalViewPage.getValue(approvalViewPage.curfewHours).should('contain.text', '5pm to 7am')

--- a/integration_tests/mockApis/licence.ts
+++ b/integration_tests/mockApis/licence.ts
@@ -213,8 +213,9 @@ export default {
           curfewAddress: {
             addressLine1: '1 The Street',
             addressLine2: 'Avenue',
-            addressTown: 'Some Town',
-            postCode: 'A1 2BC',
+            townOrCity: 'Some Town',
+            county: 'Some county',
+            postcode: 'A1 2BC',
           },
           firstNightCurfewHours: {
             firstNightFrom: '17:00',

--- a/integration_tests/mockApis/licence.ts
+++ b/integration_tests/mockApis/licence.ts
@@ -214,7 +214,7 @@ export default {
             addressLine1: '1 The Street',
             addressLine2: 'Avenue',
             townOrCity: 'Some Town',
-            county: 'Some county',
+            county: 'Some County',
             postcode: 'A1 2BC',
           },
           firstNightCurfewHours: {

--- a/server/@types/licenceApiImport/index.d.ts
+++ b/server/@types/licenceApiImport/index.d.ts
@@ -4563,8 +4563,9 @@ export interface components {
     CurfewAddress: {
       addressLine1: string
       addressLine2?: string
-      addressTown: string
-      postCode: string
+      townOrCity: string
+      county?: string
+      postcode: string
     }
     FirstNight: {
       /**

--- a/server/routes/approvingLicences/handlers/approvalView.test.ts
+++ b/server/routes/approvingLicences/handlers/approvalView.test.ts
@@ -27,8 +27,9 @@ describe('Route - view and approve a licence', () => {
     curfewAddress: {
       addressLine1: 'addressLineOne',
       addressLine2: 'addressLineTwo',
-      addressTown: 'addressTownOrCity',
-      postCode: 'addressPostcode',
+      townOrCity: 'addressTownOrCity',
+      county: 'county',
+      postcode: 'addressPostcode',
     },
     firstNightCurfewHours: {
       firstNightFrom: '09:00',

--- a/server/routes/creatingLicences/handlers/checkAnswers.test.ts
+++ b/server/routes/creatingLicences/handlers/checkAnswers.test.ts
@@ -24,8 +24,9 @@ describe('Route Handlers - Create Licence - Check Answers', () => {
     curfewAddress: {
       addressLine1: 'addressLineOne',
       addressLine2: 'addressLineTwo',
-      addressTown: 'addressTownOrCity',
-      postCode: 'addressPostcode',
+      townOrCity: 'addressTownOrCity',
+      county: 'county',
+      postcode: 'addressPostcode',
     },
     firstNightCurfewHours: {
       firstNightFrom: '09:00',

--- a/server/routes/varyingLicences/handlers/viewActiveLicence.test.ts
+++ b/server/routes/varyingLicences/handlers/viewActiveLicence.test.ts
@@ -31,8 +31,9 @@ describe('Route Handlers - Vary Licence - View active licence', () => {
     curfewAddress: {
       addressLine1: 'addressLineOne',
       addressLine2: 'addressLineTwo',
-      addressTown: 'addressTownOrCity',
-      postCode: 'addressPostcode',
+      townOrCity: 'addressTownOrCity',
+      county: 'county',
+      postcode: 'addressPostcode',
     },
     firstNightCurfewHours: {
       firstNightFrom: '09:00',

--- a/server/routes/viewingLicences/handlers/printLicence.test.ts
+++ b/server/routes/viewingLicences/handlers/printLicence.test.ts
@@ -23,8 +23,9 @@ describe('Route - print a licence', () => {
     curfewAddress: {
       addressLine1: 'addressLineOne',
       addressLine2: 'addressLineTwo',
-      addressTown: 'addressTownOrCity',
-      postCode: 'addressPostcode',
+      townOrCity: 'addressTownOrCity',
+      county: 'county',
+      postcode: 'addressPostcode',
     },
     firstNightCurfewHours: {
       firstNightFrom: '09:00',

--- a/server/routes/viewingLicences/handlers/viewLicence.test.ts
+++ b/server/routes/viewingLicences/handlers/viewLicence.test.ts
@@ -42,8 +42,9 @@ describe('Route - view and approve a licence', () => {
     curfewAddress: {
       addressLine1: 'addressLineOne',
       addressLine2: 'addressLineTwo',
-      addressTown: 'addressTownOrCity',
-      postCode: 'addressPostcode',
+      townOrCity: 'addressTownOrCity',
+      county: 'county',
+      postcode: 'addressPostcode',
     },
     firstNightCurfewHours: {
       firstNightFrom: '09:00',

--- a/server/services/hdcService.test.ts
+++ b/server/services/hdcService.test.ts
@@ -12,8 +12,9 @@ describe('HDC Service', () => {
     curfewAddress: {
       addressLine1: 'addressLineOne',
       addressLine2: 'addressLineTwo',
-      addressTown: 'addressTownOrCity',
-      postCode: 'addressPostcode',
+      townOrCity: 'addressTownOrCity',
+      county: 'county',
+      postcode: 'addressPostcode',
     },
     firstNightCurfewHours: {
       firstNightFrom: '09:00',

--- a/server/views/pages/licence/HDC_AP.njk
+++ b/server/views/pages/licence/HDC_AP.njk
@@ -85,7 +85,7 @@
          The address(es) to which you are curfewed are:<br>
          <div id="curfewAddressLine1"><span class="bold">{{ hdcLicenceData.curfewAddress.addressLine1 }}</span></div>
          <div id="curfewAddressLine2"><span class="bold">{{ hdcLicenceData.curfewAddress.addressLine2 }}</span></div>
-         <div id="curfewAddressTown"><span class="bold">{{ hdcLicenceData.curfewAddress.townOrCity }}</span></div>
+         <div id="curfewAddressTownOrCity"><span class="bold">{{ hdcLicenceData.curfewAddress.townOrCity }}</span></div>
          <div id="curfewAddressPostCode"><span class="bold">{{ hdcLicenceData.curfewAddress.postcode }}</span></div>
       </p>
    </div>

--- a/server/views/pages/licence/HDC_AP.njk
+++ b/server/views/pages/licence/HDC_AP.njk
@@ -85,8 +85,8 @@
          The address(es) to which you are curfewed are:<br>
          <div id="curfewAddressLine1"><span class="bold">{{ hdcLicenceData.curfewAddress.addressLine1 }}</span></div>
          <div id="curfewAddressLine2"><span class="bold">{{ hdcLicenceData.curfewAddress.addressLine2 }}</span></div>
-         <div id="curfewAddressTown"><span class="bold">{{ hdcLicenceData.curfewAddress.addressTown }}</span></div>
-         <div id="curfewAddressPostCode"><span class="bold">{{ hdcLicenceData.curfewAddress.postCode }}</span></div>
+         <div id="curfewAddressTown"><span class="bold">{{ hdcLicenceData.curfewAddress.townOrCity }}</span></div>
+         <div id="curfewAddressPostCode"><span class="bold">{{ hdcLicenceData.curfewAddress.postcode }}</span></div>
       </p>
    </div>
 

--- a/server/views/pages/licence/HDC_AP_PSS.njk
+++ b/server/views/pages/licence/HDC_AP_PSS.njk
@@ -91,7 +91,7 @@
         The address/es to which you are curfewed are:<br>
         <div id="curfewAddressLine1"><span class="bold">{{ hdcLicenceData.curfewAddress.addressLine1 }}</span></div>
         <div id="curfewAddressLine2"><span class="bold">{{ hdcLicenceData.curfewAddress.addressLine2 }}</span></div>
-        <div id="curfewAddressTown"><span class="bold">{{ hdcLicenceData.curfewAddress.townOrCity }}</span></div>
+        <div id="curfewAddressTownOrCity"><span class="bold">{{ hdcLicenceData.curfewAddress.townOrCity }}</span></div>
         <div id="curfewAddressPostCode"><span class="bold">{{ hdcLicenceData.curfewAddress.postcode }}</span></div>
       </p>
    </div>

--- a/server/views/pages/licence/HDC_AP_PSS.njk
+++ b/server/views/pages/licence/HDC_AP_PSS.njk
@@ -91,8 +91,8 @@
         The address/es to which you are curfewed are:<br>
         <div id="curfewAddressLine1"><span class="bold">{{ hdcLicenceData.curfewAddress.addressLine1 }}</span></div>
         <div id="curfewAddressLine2"><span class="bold">{{ hdcLicenceData.curfewAddress.addressLine2 }}</span></div>
-        <div id="curfewAddressTown"><span class="bold">{{ hdcLicenceData.curfewAddress.addressTown }}</span></div>
-        <div id="curfewAddressPostCode"><span class="bold">{{ hdcLicenceData.curfewAddress.postCode }}</span></div>
+        <div id="curfewAddressTown"><span class="bold">{{ hdcLicenceData.curfewAddress.townOrCity }}</span></div>
+        <div id="curfewAddressPostCode"><span class="bold">{{ hdcLicenceData.curfewAddress.postcode }}</span></div>
       </p>
    </div>
 

--- a/server/views/pages/licence/partials/hdcCurfewTimes.njk
+++ b/server/views/pages/licence/partials/hdcCurfewTimes.njk
@@ -1,7 +1,9 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% macro hdcCurfewTimes(curfewTimes) %}
-    {% set addressLine2Html = curfewTimes.curfewAddress.addressLine2 | escape + ", " if curfewTimes.curfewAddress.addressLine2 | length%}
+{% macro hdcCurfewTimes(hdcLicenceData) %}
+    {% set addressLine2Html = hdcLicenceData.curfewAddress.addressLine2 | escape + ", " if hdcLicenceData.curfewAddress.addressLine2 | length%}
+    {% set countyHtml = hdcLicenceData.curfewAddress.county | escape + ", " if hdcLicenceData.curfewAddress.county | length%}
+
 
     {{ govukSummaryList({
         attributes: {'data-qa': 'hdc-curfew-details'},
@@ -9,17 +11,18 @@
             {
                 key: {text: 'Address'}, 
                 value: {
-                    html: "<p>" + curfewTimes.curfewAddress.addressLine1 | escape + ", " + 
+                    html: "<p>" + hdcLicenceData.curfewAddress.addressLine1 | escape + ", " + 
                           addressLine2Html + 
-                          curfewTimes.curfewAddress.addressTown | escape + ", " + 
-                          curfewTimes.curfewAddress.postCode | escape + "</p>",
+                          hdcLicenceData.curfewAddress.townOrCity | escape + ", " +
+                          countyHtml + 
+                          hdcLicenceData.curfewAddress.postcode | escape + "</p>",
                     classes: "curfew-address"
                 }
             },
             {
                 key: { text: 'First night curfew hours' }, 
                 value: {
-                    text: curfewTimes.firstNightCurfewHours.firstNightFrom | localTimeTo12h + " to " + curfewTimes.firstNightCurfewHours.firstNightUntil | localTimeTo12h,
+                    text: hdcLicenceData.firstNightCurfewHours.firstNightFrom | localTimeTo12h + " to " + hdcLicenceData.firstNightCurfewHours.firstNightUntil | localTimeTo12h,
                     classes: "first-night-curfew-hours"
                 }
             },
@@ -29,17 +32,17 @@
                     text: 'Curfew hours'
                 },
                 value: {
-                    html: curfewTimes.curfewTimes[0].fromDay | titlecase | escape + " to " + curfewTimes.curfewTimes[6].fromDay | titlecase | escape + "<br>" + 
-                          curfewTimes.curfewTimes[0].fromTime  | localTimeTo12h + " to " + curfewTimes.curfewTimes[0].untilTime | localTimeTo12h,
+                    html: hdcLicenceData.curfewTimes[0].fromDay | titlecase | escape + " to " + hdcLicenceData.curfewTimes[6].fromDay | titlecase | escape + "<br>" + 
+                          hdcLicenceData.curfewTimes[0].fromTime  | localTimeTo12h + " to " + hdcLicenceData.curfewTimes[0].untilTime | localTimeTo12h,
                     classes: "curfew-hours"
                 }
-            } if curfewTimes.allCurfewTimesEqual
+            } if hdcLicenceData.allCurfewTimesEqual
         ]
     }) }}
 
-    {% if not curfewTimes.allCurfewTimesEqual %}
+    {% if not hdcLicenceData.allCurfewTimesEqual %}
         {% set curfewRows = []%}
-        {% for curfewTime in curfewTimes.curfewTimes %} 
+        {% for curfewTime in hdcLicenceData.curfewTimes %} 
             {% set curfewRows = (curfewRows.push(
                 {
                     key: {


### PR DESCRIPTION
This PR is to adjust the macro which populates the curfew address having changed the representation of curfew addresses in the backend. This is to match what will be from the HDC API for curfew addresses.