### PR TITLE
CVSL-2729 adjust ordering of marker display

### DIFF
--- a/server/views/pages/approve/cases.njk
+++ b/server/views/pages/approve/cases.njk
@@ -14,12 +14,12 @@
     {% if case.urgentApproval and approvalNeededView %}
         {% set releaseDate = '<span class="urgent-highlight">' + case.releaseDate
             + '</span><span class="urgent-highlight urgent-highlight-message">Urgent approval required for<br>upcoming release</span>' %}
-    {% elseif case.isDueForEarlyRelease and approvalNeededView %}
-        {% set releaseDate = '<span class="urgent-highlight">' + case.releaseDate
-            + '</span><span class="urgent-highlight urgent-highlight-message">Early release</span>' %}
     {% elseif case.kind == 'HDC' %}
         {% set releaseDate = '<span class="urgent-highlight">' + case.releaseDate
             + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
+    {% elseif case.isDueForEarlyRelease and approvalNeededView %}
+        {% set releaseDate = '<span class="urgent-highlight">' + case.releaseDate
+            + '</span><span class="urgent-highlight urgent-highlight-message">Early release</span>' %}
     {% else %}
         {% set releaseDate = case.releaseDate %}
     {% endif %}

--- a/server/views/pages/approve/keyDates.njk
+++ b/server/views/pages/approve/keyDates.njk
@@ -2,9 +2,11 @@
 
 {% macro keyDates(licence, isDueForEarlyRelease) %}
 
-    {% set releaseDate = '<span class="urgent-highlight">' + licence.homeDetentionCurfewActualDate | datetimeToDateShort + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' if licence.kind === 'HDC' else licence.licenceStartDate | datetimeToDateShort %}
+    {% set releaseDate = licence.licenceStartDate | datetimeToDateShort %}
 
-    {% if isDueForEarlyRelease %}
+    {% if licence.kind === 'HDC' %}
+        {% set releaseDateHtml = '<span class="urgent-highlight">' + releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
+    {% elseif isDueForEarlyRelease %}
         {% set releaseDateHtml = '<span class="urgent-highlight">' + releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Early release</span>' %}
     {% else %}
         {% set releaseDateHtml = '<p>' + releaseDate + '</p>' %}

--- a/server/views/pages/create/caseload.njk
+++ b/server/views/pages/create/caseload.njk
@@ -31,13 +31,13 @@
         {% set comDetailsHtml = 'Unallocated' %}
     {% endif %}
 
-    {% if offender.isDueForEarlyRelease %}
+    {% if offender.kind === "HDC" %}
+        {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate
+            + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
+    {% elseif offender.isDueForEarlyRelease %}
         {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Early release</span>' %}
     {% elseif offender | shouldShowHardStopWarning %}
         {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Submit licence by ' + offender.hardStopDate | cvlDateToDateShort  +'</span>' %}
-    {% elseif offender.kind === "HDC" %}
-        {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate
-            + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
     {% else %}
         {% set releaseDate = offender.releaseDate %}
     {% endif %}

--- a/server/views/pages/search/probationSearch/probationSearch.njk
+++ b/server/views/pages/search/probationSearch/probationSearch.njk
@@ -123,13 +123,13 @@
         {% set comDetailsHtml = 'Unallocated' %}
     {% endif %}
 
-    {% if offender.isDueForEarlyRelease %}
+    {% if offender.kind === "HDC" %}
+        {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort
+            + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
+    {% elseif offender.isDueForEarlyRelease %}
         {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort + '</span><span class="urgent-highlight urgent-highlight-message">Early release</span>' %}
     {% elseif offender | shouldShowHardStopWarning %}
         {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Submit licence by ' + offender.hardStopDate | cvlDateToDateShort  +'</span>' %}
-    {% elseif offender.kind === "HDC" %}
-        {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort
-            + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
     {% else %}
         {% set releaseDate = '<p>' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort + '</p>' %}
     {% endif %}

--- a/server/views/pages/vary/caseload.njk
+++ b/server/views/pages/vary/caseload.njk
@@ -20,11 +20,11 @@
 {% set licences = [] %}
 
 {% for offender in caseload %}
-    {% if offender.licenceStatus === "REVIEW_NEEDED" %}
-        {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Timed out</span>' %}
-    {% elseif offender.kind === 'HDC' %}
+    {% if offender.kind === 'HDC' %}
         {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate
             + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
+    {% elseif offender.licenceStatus === "REVIEW_NEEDED" %}
+        {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Timed out</span>' %}
     {% else %}
         {% set releaseDate = offender.releaseDate %}
     {% endif %}

--- a/server/views/partials/viewCases.njk
+++ b/server/views/partials/viewCases.njk
@@ -115,10 +115,10 @@
             %}
         {% endif %}
 
-        {% if case.isDueForEarlyRelease %}
-            {% set releaseDate = '<span class="urgent-highlight">' + case.releaseDateLabel + ': <br>' + case.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Early release</span>' %}
-        {% elseif case.kind == 'HDC' %}
+        {% if case.kind == 'HDC' %}
             {% set releaseDate = '<span class="urgent-highlight">' + case.releaseDateLabel + ': <br>' + case.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
+        {% elseif case.isDueForEarlyRelease %}
+            {% set releaseDate = '<span class="urgent-highlight">' + case.releaseDateLabel + ': <br>' + case.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Early release</span>' %}
         {% else %}
             {% set releaseDate = '<p>' + case.releaseDateLabel + ': <br>' + case.releaseDate + '</p>' %}
         {% endif %}


### PR DESCRIPTION
This PR is to fix a bug where the Early marker was being shown instead of the HDC marker. Adjusted now the HDC marker takes precedence. 