### PR TITLE
CVSL-2536 update content

### DIFF
--- a/server/views/pages/create/confirmation.njk
+++ b/server/views/pages/create/confirmation.njk
@@ -27,9 +27,15 @@
                 <p class="govuk-body" id="message">
                     You can make changes to reporting instructions through the Create and vary a licence service. These changes do not need to be reapproved by the prison, but a case administrator may need to reprint the licence.
                 <p>
-                <p class="govuk-body" id="change-message">
-                    To change the curfew address, curfew hours or first night curfew hours email createandvaryalicence@digital.justice.gov.uk.
-                </p>
+                {% if hdcIntegrationMvp2Enabled %}
+                    <p class="govuk-body" id="change-message">
+                        To request a change to the curfew address or first night curfew hours, email createandvaryalicence@digital.justice.gov.uk.
+                    </p>
+                {% else %}
+                    <p class="govuk-body" id="change-message">
+                        To change the curfew address, curfew hours or first night curfew hours email createandvaryalicence@digital.justice.gov.uk.
+                    </p>
+                {% endif %}
             {% else %}    
                 <p class="govuk-body" id="message">
                     You can do so up to 2 days before a standard release. From this point, you can only ask the prison to change the initial appointment details. Other changes must be made after release.

--- a/server/views/pages/create/confirmation.test.ts
+++ b/server/views/pages/create/confirmation.test.ts
@@ -41,4 +41,14 @@ describe('Hdc Confirmation', () => {
       'You can make changes to reporting instructions through the Create and vary a licence service. These changes do not need to be reapproved by the prison, but a case administrator may need to reprint the licence.',
     )
   })
+
+  it('should show correct message when kind is HDC and hdcIntegrationMvp2Enabled is enabled', () => {
+    const $ = render({
+      kind: 'HDC',
+      hdcIntegrationMvp2Enabled: true,
+    })
+    expect($('#change-message').text().toString()).toContain(
+      'To request a change to the curfew address or first night curfew hours, email createandvaryalicence@digital.justice.gov.uk',
+    )
+  })
 })


### PR DESCRIPTION
This PR is to update content on the confirmation screen once a HDC licence has been created.

**Before**
![Screenshot 2025-03-27 at 15 39 29](https://github.com/user-attachments/assets/05465846-d4fa-435f-9ed9-5adddb4472ac)

**After**
![Screenshot 2025-03-27 at 15 40 30](https://github.com/user-attachments/assets/4edbd194-30cb-47b1-af38-756dea2ca1fd)
