### PR TITLE
CVSL-2912 add tabs and empty states for CA search

### DIFF
--- a/integration_tests/integration/caSearch.cy.ts
+++ b/integration_tests/integration/caSearch.cy.ts
@@ -25,11 +25,12 @@ context('Search for a person', () => {
     cy.signIn()
   })
 
-  it('should click through search journey', () => {
+  it('should click through search journey and show empty states where no results are present', () => {
     const indexPage = Page.verifyOnPage(IndexPage)
     const caseloadPage = indexPage.clickViewAndPrintALicence()
     const searchPage = caseloadPage.clickSearch('test')
     searchPage.getSearchHeading().contains('Search results for test')
+    searchPage.getPrisonTabTitle().contains('People in prison (0 results)')
     Page.verifyOnPage(CaSearchPage)
   })
 })

--- a/integration_tests/pages/caSearch.ts
+++ b/integration_tests/pages/caSearch.ts
@@ -3,11 +3,23 @@ import Page from './page'
 export default class SearchPage extends Page {
   private searchHeading = '#ca-search-heading'
 
+  private prisonTabTitle = '#tab-heading-prison'
+
+  private probationTabTitle = '#tab-heading-probation'
+
   constructor() {
     super('ca-search-page')
   }
 
   getSearchHeading = () => {
     return cy.get(this.searchHeading)
+  }
+
+  getPrisonTabTitle = () => {
+    return cy.get(this.prisonTabTitle)
+  }
+
+  getProbationTabTitle = () => {
+    return cy.get(this.probationTabTitle)
   }
 }

--- a/server/routes/search/handlers/caSearch.test.ts
+++ b/server/routes/search/handlers/caSearch.test.ts
@@ -11,6 +11,15 @@ describe('Route Handlers - Search - Ca Search', () => {
   let req: Request
   let res: Response
 
+  const tabParameters = {
+    prison: {
+      tabId: 'tab-heading-prison',
+    },
+    probation: {
+      tabId: 'tab-heading-probation',
+    },
+  }
+
   beforeEach(() => {
     req = {} as Request
 
@@ -39,6 +48,7 @@ describe('Route Handlers - Search - Ca Search', () => {
       expect(res.render).toHaveBeenCalledWith('pages/search/caSearch/caSearch', {
         queryTerm: '',
         backLink: '/licence/view/cases',
+        tabParameters,
       })
     }))
 })

--- a/server/routes/search/handlers/caSearch.ts
+++ b/server/routes/search/handlers/caSearch.ts
@@ -8,9 +8,19 @@ export default class CaSearch {
     const queryTerm = req.query?.queryTerm as string
     const backLink = '/licence/view/cases'
 
+    const tabParameters = {
+      prison: {
+        tabId: 'tab-heading-prison',
+      },
+      probation: {
+        tabId: 'tab-heading-probation',
+      },
+    }
+
     return res.render('pages/search/caSearch/caSearch', {
       queryTerm,
       backLink,
+      tabParameters,
     })
   }
 }

--- a/server/views/pages/search/caSearch/caSearch.njk
+++ b/server/views/pages/search/caSearch/caSearch.njk
@@ -1,8 +1,44 @@
 {% extends "layout.njk" %}
 
+{% from "govuk/components/tabs/macro.njk" import govukTabs %}
+
 {% set pageTitle = applicationName + " - Case Admin - Search" %}
 {% set pageId = "ca-search-page" %}
 {% set backLinkHref = backLink %}
+{% set noJsBackLink = true %}
+
+{% macro displayResults(tabId, countText, setPeopleInPrisonTab) %}
+    <h2 class="govuk-heading-l" id = "{{ tabId }}">{{ countText }}</h2>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            {% if setPeopleInPrisonTab %}
+                <p id="people-in-prison-empty-state-content">You can see licences for people in prison in this service if they:</p>
+                <ul class = "govuk-list govuk-list--bullet">
+                    <li>are within 4 weeks of release or if a probation practitioner has started work on their licence before then</li>
+                    <li>are serving a determinate sentence in a prison you work in</li>
+                    <li>have a release date</li>
+                    <li>have not been approved for Home Detention Curfew</li>
+            {% else %}
+                <p id="people-on-probation-empty-state-content">You can see licences for people on probation in this service if they:</p>
+                <ul class = "govuk-list govuk-list--bullet">
+                    <li>served a determinate sentence in a prison you work in</li>
+                    <li>were not released on Home Detention Curfew</li>
+                    <li>were not released from prison with a licence created using NOMIS</li>
+            {% endif %}
+                    <li>have not been recalled or breached a top up supervision order</li>
+                </ul>
+            <p>If you think someone’s licence is missing, tell us by <a id="serviceNowUrl" class="govuk-link" href="{{serviceNowUrl}}">filling in a support request form.</a></p>
+            <p class="govuk-body">
+                {{ govukButton({
+                    text: "Return to caselist",
+                    classes: "govuk-button--secondary govuk-!-margin-bottom-0 govuk-body",
+                    href: backLink,
+                    attributes: { 'data-qa': 'return-to-caselist' }
+                }) }}
+            </p>
+        </div>
+    </div>
+{% endmacro %}
 
 {% block content %}
     <div class="govuk-grid-row">
@@ -30,6 +66,32 @@
             </form>
         </div>
     </div>
+
+    {% set inPrisonCountText = "People in prison (0 results)" %}
+    {% set onProbationCountText = "People on probation (0 results)" %}
+
+    {% set peopleInPrison = displayResults(tabParameters.prison.tabId, inPrisonCountText, true) %}
+    {% set peopleOnProbation = displayResults(tabParameters.probation.tabId, onProbationCountText, false) %}
+
+
+    {{ govukTabs({
+        items: [
+            {
+                label: "People in prison",
+                id: "people-in-prison",
+                panel: {
+                    html: peopleInPrison
+                }
+            },
+            {
+                label: "People on probation",
+                id: "people-on-probation",
+                panel: {
+                    html: peopleOnProbation
+                }
+            }
+        ]
+    }) }}
 
 {% endblock %}
 

--- a/server/views/pages/search/caSearch/caSearch.test.ts
+++ b/server/views/pages/search/caSearch/caSearch.test.ts
@@ -4,10 +4,28 @@ import { templateRenderer } from '../../../../utils/__testutils/templateTestUtil
 const render = templateRenderer(fs.readFileSync('server/views/pages/search/caSearch/caSearch.njk').toString())
 
 describe('View CA Search Results', () => {
-  it('should display the header correctly', () => {
+  it('should display empty states correctly when no search results are found', () => {
     const $ = render({
       queryTerm: 'Test',
+      tabParameters: {
+        prison: {
+          tabId: 'tab-heading-prison',
+        },
+        probation: {
+          tabId: 'tab-heading-probation',
+        },
+      },
     })
     expect($('#ca-search-heading').text()).toBe('Search results for Test')
+    expect($('.govuk-tabs__list a').text()).toContain('People in prison')
+    expect($('.govuk-tabs__list a').text()).toContain('People on probation')
+    expect($('#tab-heading-prison').text()).toContain('People in prison (0 results)')
+    expect($('#tab-heading-probation').text()).toContain('People on probation (0 results)')
+    expect($('#people-in-prison-empty-state-content').text()).toContain(
+      'You can see licences for people in prison in this service if they:',
+    )
+    expect($('#people-on-probation-empty-state-content').text()).toContain(
+      'You can see licences for people on probation in this service if they:',
+    )
   })
 })


### PR DESCRIPTION
This PR is to introduce the tabs for the CA search so that results can be split into people in prison and people on probation. This PR provides the empty states for both tabs should no search results be returned. 

![Screenshot 2025-06-12 at 14 32 05](https://github.com/user-attachments/assets/5b96f7c4-9abe-47fd-a662-1dec337df58f)

![Screenshot 2025-06-12 at 14 32 11](https://github.com/user-attachments/assets/a4bedb89-51cc-4f4f-bf70-f8e1622fe79f)
