### PR TITLE
CVSL-2969 Removing ability to click into a case that's missing a CRN

### DIFF
--- a/server/routes/support/handlers/offenderSearch.test.ts
+++ b/server/routes/support/handlers/offenderSearch.test.ts
@@ -52,7 +52,9 @@ describe('Route Handlers - Offender search', () => {
 
       await handler.GET(req, res)
       expect(res.render).toHaveBeenCalledWith('pages/support/offenderSearch', {
-        searchResults: [{ crn: 'X1234', name: 'Test Person', nomisId: 'ABC123', prison: 'Pentonville' }],
+        searchResults: [
+          { crn: 'X1234', name: 'Test Person', nomisId: 'ABC123', prison: 'Pentonville', isClickable: true },
+        ],
         searchValues: { crn: 'X1234' },
       })
     })
@@ -81,12 +83,62 @@ describe('Route Handlers - Offender search', () => {
 
       await handler.GET(req, res)
       expect(res.render).toHaveBeenCalledWith('pages/support/offenderSearch', {
-        searchResults: [{ crn: 'X1234', name: 'Test Person', nomisId: 'ABC123', prison: 'Pentonville' }],
+        searchResults: [
+          { crn: 'X1234', name: 'Test Person', nomisId: 'ABC123', prison: 'Pentonville', isClickable: true },
+        ],
         searchValues: {
           firstName: 'Test',
           lastName: 'Person',
           nomisId: 'ABC123',
         },
+      })
+    })
+
+    it('Should set isClickable to false if no Delius record is found', async () => {
+      req.query = {
+        firstName: 'Test',
+        lastName: 'Person',
+        nomisId: 'ABC123',
+      }
+
+      prisonerService.searchPrisoners.mockResolvedValue([
+        {
+          prisonerNumber: 'ABC123',
+          prisonName: 'Pentonville',
+          firstName: 'Test',
+          lastName: 'Person',
+        } as unknown as Prisoner,
+      ])
+      probationService.getProbationers.mockResolvedValue([])
+
+      await handler.GET(req, res)
+      expect(res.render).toHaveBeenCalledWith('pages/support/offenderSearch', {
+        searchResults: [
+          { crn: undefined, name: 'Test Person', nomisId: 'ABC123', prison: 'Pentonville', isClickable: false },
+        ],
+        searchValues: {
+          firstName: 'Test',
+          lastName: 'Person',
+          nomisId: 'ABC123',
+        },
+      })
+    })
+
+    it('returns no results if no NOMIS record is found', async () => {
+      req.query = {
+        crn: 'X1234',
+      }
+
+      probationService.getProbationer.mockResolvedValue({
+        crn: 'X1234',
+        nomisId: null,
+      })
+      prisonerService.searchPrisoners.mockResolvedValue([])
+
+      await handler.GET(req, res)
+      expect(res.render).toHaveBeenCalledWith('pages/support/offenderSearch', {
+        searchResults: [],
+        searchValues: { crn: 'X1234' },
       })
     })
   })

--- a/server/routes/support/handlers/offenderSearch.ts
+++ b/server/routes/support/handlers/offenderSearch.ts
@@ -49,11 +49,13 @@ export default class OffenderSearchRoutes {
 
     const searchResults = nomisRecords
       .map(o => {
+        const crn = deliusRecords.find(d => d.nomisId === o.prisonerNumber)?.crn
         return {
           name: convertToTitleCase(`${o.firstName} ${o.lastName}`),
           prison: o.prisonName,
           nomisId: o.prisonerNumber,
-          crn: deliusRecords.find(d => d.nomisId === o.prisonerNumber)?.crn,
+          crn,
+          isClickable: crn != null,
         }
       })
       .sort((a, b) => {

--- a/server/views/pages/support/offenderSearch.njk
+++ b/server/views/pages/support/offenderSearch.njk
@@ -10,6 +10,11 @@
 {% set offenders = [] %}
 
 {% for offender in searchResults %}
+    {% if offender.isClickable %}
+        {% set offenderName = '<a href="/support/offender/' + offender.nomisId + '/detail" class="govuk-link govuk-heading-s govuk-!-padding-left-0 govuk-!-margin-bottom-0">' + offender.name + '</a>' %}
+    {% else %}
+        {% set offenderName = '<span class="govuk-heading-s govuk-!-padding-left-0 govuk-!-margin-bottom-0">' + offender.name + '</span>' %}
+    {% endif %}
 
     {% set offenders = (offenders.push([
         {
@@ -17,7 +22,7 @@
                 "data-sort-value": offender.name
             },
             classes: "max-width max-width-220",
-            html: '<a href="/support/offender/' + offender.nomisId + '/detail" class="govuk-link govuk-heading-s govuk-!-padding-left-0 govuk-!-margin-bottom-0">' + offender.name + '</a>'
+            html: offenderName
         },
         {
             attributes: {


### PR DESCRIPTION
New display (using dummy data):
<img width="1181" height="141" alt="image" src="https://github.com/user-attachments/assets/931d121d-1fe1-4556-93ed-2f424daf8d66" />
