### PR TITLE
CVSL-3225 change content for AP licence

### DIFF
--- a/server/views/pages/licence/AP.njk
+++ b/server/views/pages/licence/AP.njk
@@ -42,10 +42,6 @@
             Under the provisions of Chapter 6 of the Criminal Justice Act 2003 you are being released on licence.
         </p>
         <p>
-            Unless you are deported/removed from the United Kingdom, you will be under the supervision of a nominated 
-            officer and must comply with the conditions of this licence.
-        </p>
-        <p>
             The objectives of this supervision are to:
         </p>
         <ul class="bullet-point">

--- a/server/views/pages/licence/AP.njk
+++ b/server/views/pages/licence/AP.njk
@@ -42,6 +42,9 @@
             Under the provisions of Chapter 6 of the Criminal Justice Act 2003 you are being released on licence.
         </p>
         <p>
+            You will be under the supervision of a nominated officer and must comply with the conditions of this licence.         
+        </p>
+        <p>
             The objectives of this supervision are to:
         </p>
         <ul class="bullet-point">

--- a/server/views/pages/licence/AP.test.ts
+++ b/server/views/pages/licence/AP.test.ts
@@ -55,7 +55,7 @@ describe('Print an AP licence', () => {
     expect($('#offender > #offender-image').length).toBe(1)
 
     // Check the objectives section is present - 3 paragraphs, 1 bullet-point list
-    expect($('#objectives > p').length).toBe(3)
+    expect($('#objectives > p').length).toBe(2)
     expect($('#objectives > .bullet-point').length).toBe(1)
 
     // Check the supervision section is present with 2 bold dates

--- a/server/views/pages/licence/AP.test.ts
+++ b/server/views/pages/licence/AP.test.ts
@@ -54,8 +54,8 @@ describe('Print an AP licence', () => {
     // Check the offender image is present
     expect($('#offender > #offender-image').length).toBe(1)
 
-    // Check the objectives section is present - 2 paragraphs, 1 bullet-point list
-    expect($('#objectives > p').length).toBe(2)
+    // Check the objectives section is present - 3 paragraphs, 1 bullet-point list
+    expect($('#objectives > p').length).toBe(3)
     expect($('#objectives > .bullet-point').length).toBe(1)
 
     // Check the supervision section is present with 2 bold dates

--- a/server/views/pages/licence/AP.test.ts
+++ b/server/views/pages/licence/AP.test.ts
@@ -54,7 +54,7 @@ describe('Print an AP licence', () => {
     // Check the offender image is present
     expect($('#offender > #offender-image').length).toBe(1)
 
-    // Check the objectives section is present - 3 paragraphs, 1 bullet-point list
+    // Check the objectives section is present - 2 paragraphs, 1 bullet-point list
     expect($('#objectives > p').length).toBe(2)
     expect($('#objectives > .bullet-point').length).toBe(1)
 


### PR DESCRIPTION
Based on the change of requirement to the ticket, this PR is to remove the paragraph entirely and not replace it with anything. 

**Before**
<img width="994" height="1160" alt="Screenshot 2025-09-17 at 18 21 53" src="https://github.com/user-attachments/assets/cd181207-a52c-4ee6-8b39-aa9a05944c84" />

**After**
<img width="956" height="1128" alt="Screenshot 2025-09-18 at 10 23 00" src="https://github.com/user-attachments/assets/39e23c4e-fabe-4a9b-b236-786be9db63c1" />
