### PR TITLE
CVSL-3345 remove paragraph

### DIFF
--- a/server/views/partials/hardStop/releasesInTwoWorkingDaysTab.njk
+++ b/server/views/partials/hardStop/releasesInTwoWorkingDaysTab.njk
@@ -9,7 +9,6 @@
                 <li>probation practitioners can no longer work on licences</li>
                 <li>you can generate a standard licence if a probation practitioner has not submitted one for approval</li>
             </ul>
-            <p>You will not be able to generate a standard licence for someone being released early if the probation practitioner has not submitted one.</p>
         {% endif %}
        {{ viewCases({ cases: params.cases, tabType: params.tabType, config: params.config, activeTab: params.activeTab}) }} 
     </div>


### PR DESCRIPTION
This PR is to remove a paragraph from the CA view which mentions the early release scheme. 

Before
<img width="1171" height="552" alt="Screenshot 2025-09-26 at 15 39 48" src="https://github.com/user-attachments/assets/153820b6-cf11-44bb-88a7-5049b2cb5071" />

After
<img width="1263" height="1083" alt="Screenshot 2025-09-26 at 15 42 09" src="https://github.com/user-attachments/assets/60e6fc00-8341-4f47-af23-b232d52fb175" />
