### PR TITLE
CVSL-4116 remove licence type from com search

### DIFF
--- a/integration_tests/integration/comSearch.cy.ts
+++ b/integration_tests/integration/comSearch.cy.ts
@@ -68,7 +68,6 @@ context('Search for a person', () => {
 
     searchPage.getRow(1).find('.search-offender-name').should('contain.text', 'Access restricted on NDelius')
     searchPage.getRow(1).find('.govuk-hint').should('contain.text', 'CRN: A123456')
-    searchPage.getRow(1).find('#licence-type-2').contains('Restricted')
     searchPage.getRow(1).find('#probation-practitioner-2').contains('Restricted')
     searchPage.getRow(1).find('#team-name-2').contains('Restricted')
     searchPage.getRow(1).find('#release-date-2').contains('Restricted')
@@ -97,7 +96,6 @@ context('Search for a person', () => {
 
     searchPage.getRow(0).find('.search-offender-name').should('contain.text', 'Access restricted on NDelius')
     searchPage.getRow(0).find('#name-1>.search-offender-name>.govuk-hint').should('contain.text', 'CRN: A123456')
-    searchPage.getRow(0).find('#licence-type-1').contains('Restricted')
     searchPage.getRow(0).find('#probation-practitioner-1').contains('Restricted')
     searchPage.getRow(0).find('#team-name-1').contains('Restricted')
     searchPage.getRow(0).find('#release-date-1').contains('Restricted')

--- a/server/views/pages/search/probationSearch/probationSearch.njk
+++ b/server/views/pages/search/probationSearch/probationSearch.njk
@@ -4,7 +4,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "partials/statusBadge.njk" import statusBadge %}
-{% from "partials/licenceDescription.njk" import licenceDescription %}
 {% set pageTitle = applicationName + " - Probation - Search" %}
 {% set pageId = "probation-search-page" %}
 {% set backLinkHref = backLink %}
@@ -87,9 +86,6 @@
                         }
                     },
                     {
-                        text: "Licence type"
-                    },
-                    {
                         text: "Probation practitioner",
                         attributes: {
                             "aria-sort": "none"
@@ -149,12 +145,6 @@
         },
         {
             attributes: {
-                id: 'licence-type-' + loop.index
-            },
-            html:licenceDescription(offender.licenceType) | redactIfLao(offender)
-        },
-        {
-            attributes: {
                 id: 'probation-practitioner-' + loop.index,
                 "data-sort-value": offender.probationPractitioner.name
             },
@@ -210,12 +200,6 @@
             },
             classes: "max-width max-width-220",
             html: offenderName(offender, loop.index)
-        },
-        {
-            attributes: {
-                id: 'licence-type-' + loop.index
-            },
-            html:licenceDescription(offender.licenceType) | redactIfLao(offender)
         },
         {
             attributes: {

--- a/server/views/pages/search/probationSearch/probationSearch.test.ts
+++ b/server/views/pages/search/probationSearch/probationSearch.test.ts
@@ -35,7 +35,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: 1,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.IN_PROGRESS,
           isOnProbation: false,
           releaseDateLabel: 'CRD',
@@ -59,7 +58,6 @@ describe('View Probation Search Results', () => {
     expect($('#name-1 > .search-offender-name > a').text()).toBe('Test Person')
     expect($('#name-1 > .search-offender-name > .govuk-hint').text()).toBe('CRN: A123456')
     expect($('#name-1 > .search-offender-name > a').attr('href').trim()).toBe('/licence/create/id/1/check-your-answers')
-    expect($('#licence-type-1').text().trim()).toBe('Standard determinate')
     expect($('#probation-practitioner-1').text()).toBe('Test Staff')
     expect($('#probation-practitioner-1 > .govuk-link').attr('href').trim()).toBe(
       '/licence/create/probation-practitioner/staffCode/3000',
@@ -85,7 +83,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: 1,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.IN_PROGRESS,
           isOnProbation: false,
           releaseDateLabel: 'CRD',
@@ -117,7 +114,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: 1,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.IN_PROGRESS,
           isOnProbation: true,
           releaseDateLabel: 'CRD',
@@ -149,7 +145,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: 1,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.IN_PROGRESS,
           isOnProbation: false,
           kind: 'TIME_SERVED',
@@ -183,7 +178,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: 1,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.TIMED_OUT,
           isOnProbation: false,
           kind: 'TIME_SERVED',
@@ -219,7 +213,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: null,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.NOT_STARTED,
           isOnProbation: false,
           releaseDateLabel: 'CRD',
@@ -243,7 +236,6 @@ describe('View Probation Search Results', () => {
     expect($('#name-1 > .search-offender-name > a').text()).toBe('Test Person')
     expect($('#name-1 > .search-offender-name > .govuk-hint').text()).toBe('CRN: A123456')
     expect($('#name-1 > .search-offender-name > a').attr('href').trim()).toBe('/licence/create/nomisId/A1234BC/confirm')
-    expect($('#licence-type-1').text().trim()).toBe('Standard determinate')
     expect($('#probation-practitioner-1').text()).toBe('Test Staff')
     expect($('#probation-practitioner-1 > .govuk-link').attr('href').trim()).toBe(
       '/licence/create/probation-practitioner/staffCode/3000',
@@ -271,7 +263,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: null,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.NOT_STARTED,
           isOnProbation: false,
           releaseDateLabel: 'CRD',
@@ -294,7 +285,6 @@ describe('View Probation Search Results', () => {
     expect($('tbody .govuk-table__row').length).toBe(1)
     expect($('#name-1 > .search-offender-name > .govuk-heading-s').text()).toBe('Test Person')
     expect($('#name-1 > .search-offender-name > .govuk-hint').text()).toBe('CRN: A123456')
-    expect($('#licence-type-1').text().trim()).toBe('Standard determinate')
     expect($('#probation-practitioner-1').text()).toBe('Not allocated')
 
     expect($('#team-name-1').text()).toBe('Test Team')
@@ -320,7 +310,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '',
           licenceId: null,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.NOT_STARTED,
           isOnProbation: false,
           releaseDateLabel: 'CRD',
@@ -355,7 +344,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: null,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.NOT_STARTED,
           isOnProbation: false,
           releaseDateLabel: 'Confirmed release date',
@@ -390,7 +378,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: 1,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.TIMED_OUT,
           isOnProbation: false,
           releaseDateLabel: 'CRD',
@@ -426,7 +413,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: null,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.TIMED_OUT,
           isOnProbation: false,
           releaseDateLabel: 'CRD',
@@ -462,7 +448,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: null,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.IN_PROGRESS,
           isOnProbation: false,
           releaseDateLabel: 'CRD',
@@ -498,7 +483,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: 2,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.ACTIVE,
           isOnProbation: false,
           releaseDateLabel: 'CRD',
@@ -534,7 +518,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: null,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.NOT_STARTED,
           isOnProbation: false,
           releaseDateLabel: 'CRD',
@@ -569,7 +552,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '16/08/2023',
           licenceId: 3,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.NOT_STARTED,
           isOnProbation: false,
           releaseDateLabel: 'CRD',
@@ -604,7 +586,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '20/12/2025',
           licenceId: 1,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.IN_PROGRESS,
           isOnProbation: false,
           releaseDateLabel: 'HDCAD',
@@ -644,7 +625,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '20/12/2025',
           licenceId: 1,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.ACTIVE,
           isOnProbation: true,
           releaseDateLabel: 'HDCAD',
@@ -684,7 +664,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '20/12/2025',
           licenceId: 1,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.IN_PROGRESS,
           isOnProbation: false,
           releaseDateLabel: 'HDCAD',
@@ -726,7 +705,6 @@ describe('View Probation Search Results', () => {
           teamName: 'Test Team',
           releaseDate: '20/12/2025',
           licenceId: 1,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.ACTIVE,
           isOnProbation: true,
           releaseDateLabel: 'HDCAD',
@@ -766,7 +744,6 @@ describe('View Probation Search Results', () => {
         allocated: true,
       },
       teamName: 'AAA',
-      licenceType: 'AP',
       licenceId: 1,
       licenceStatus: LicenceStatus.IN_PROGRESS,
       isOnProbation: false,
@@ -808,7 +785,6 @@ describe('View Probation Search Results', () => {
         allocated: true,
       },
       teamName: 'AAA',
-      licenceType: 'AP',
       licenceId: 1,
       licenceStatus: LicenceStatus.IN_PROGRESS,
       isOnProbation: false,
@@ -872,7 +848,6 @@ describe('View Probation Search Results', () => {
           } as ProbationPractitioner,
           teamName: 'Test Team',
           licenceId: 1,
-          licenceType: 'AP',
           licenceStatus: LicenceStatus.TIMED_OUT,
           isOnProbation: false,
           releaseDate: '16/08/2023',
@@ -908,7 +883,6 @@ describe('View Probation Search Results', () => {
             staffCode: 'Restricted',
             allocated: true,
           },
-          licenceType: null,
           teamName: 'Restricted',
           releaseDate: '16/08/2023',
           licenceId: 1,
@@ -932,7 +906,6 @@ describe('View Probation Search Results', () => {
     expect($('#name-1 > .search-offender-name').text()).toContain('Access restricted on NDelius')
     expect($('#name-1 > .search-offender-name > a').attr('href')).toContain('/A123456/restricted')
     expect($('#name-1 > .search-offender-name > .govuk-hint').text()).toBe('CRN: A123456')
-    expect($('#licence-type-1').text().trim()).toBe('Restricted')
     expect($('#probation-practitioner-1').text()).toBe('Restricted')
     expect($('#probation-practitioner-1 > .govuk-link').length).toBe(0)
     expect($('#team-name-1').text()).toBe('Restricted')
@@ -954,7 +927,6 @@ describe('View Probation Search Results', () => {
             staffCode: 'Restricted',
             allocated: true,
           },
-          licenceType: null,
           teamName: 'Restricted',
           releaseDate: '16/08/2023',
           licenceId: 1,
@@ -976,7 +948,6 @@ describe('View Probation Search Results', () => {
     expect($('#name-1 > .search-offender-name').text()).toContain('Access restricted on NDelius')
     expect($('#name-1 > .search-offender-name > a').attr('href')).toContain('/A123456/restricted')
     expect($('#name-1 > .search-offender-name > .govuk-hint').text()).toBe('CRN: A123456')
-    expect($('#licence-type-1').text().trim()).toBe('Restricted')
     expect($('#probation-practitioner-1').text()).toBe('Restricted')
     expect($('#probation-practitioner-1 > .govuk-link').length).toBe(0)
     expect($('#team-name-1').text()).toBe('Restricted')
@@ -998,7 +969,6 @@ describe('View Probation Search Results', () => {
             staffCode: 'Restricted',
             allocated: true,
           },
-          licenceType: null,
           teamName: 'Restricted',
           releaseDate: '16/08/2023',
           licenceId: 1,


### PR DESCRIPTION
This PR is for the frontend changes to remove licence type from COM search

Before
<img width="1340" height="738" alt="Screenshot 2026-06-08 at 14 12 30" src="https://github.com/user-attachments/assets/b883974b-691b-4fd6-b3cf-c7c39a3742ab" />

After
<img width="1317" height="756" alt="Screenshot 2026-06-08 at 14 11 42" src="https://github.com/user-attachments/assets/36d52a85-d462-4def-b940-11b7e113cc05" />
