### PR TITLE
CVSL-4082 add release label to vary caseload

### DIFF
--- a/server/views/pages/vary/caseload.njk
+++ b/server/views/pages/vary/caseload.njk
@@ -23,13 +23,13 @@
 {% set licences = [] %}
 {% for offender in caseload %}
   {% if offender.kind === 'HDC' or offender.kind === 'HDC_VARIATION' %}
-    {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate
+    {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDateLabel + ': <br>' + offender.releaseDate
             + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
   {% elseif offender.licenceStatus === "REVIEW_NEEDED" %}
     {% set releaseMessage = 'Time-served release' if offender.kind === 'TIME_SERVED' else 'Timed out' %}
-    {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">' + releaseMessage + '</span>' %}
+    {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDateLabel + ': <br>' +  offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">' + releaseMessage + '</span>' %}
   {% else %}
-    {% set releaseDate = offender.releaseDate %}
+    {% set releaseDate = offender.releaseDateLabel + ': <br>' + offender.releaseDate %}
   {% endif %}
   {% if offender.probationPractitioner.allocated %}
     {% set practitionerHtml = '<a class="govuk-link" href="/licence/vary/id/' + offender.licenceId + '/probation-practitioner">' + offender.probationPractitioner.name + '</a>' %}

--- a/server/views/pages/vary/caseload.test.ts
+++ b/server/views/pages/vary/caseload.test.ts
@@ -163,6 +163,7 @@ describe('Caseload', () => {
           crnNumber: 'Z882661',
           licenceType: 'AP',
           releaseDate: '13 Feb 2023',
+          releaseDateLabel: 'HDC eligible date',
           licenceStatus: 'ACTIVE',
           probationPractitioner: {
             staffCode: 'X12342',
@@ -187,7 +188,7 @@ describe('Caseload', () => {
     })
     expect($('tbody .govuk-table__row').length).toBe(1)
     expect($('.status-badge').text().toString()).toContain('Active')
-    expect($('#release-date-1').text()).toBe('13 Feb 2023HDC release')
+    expect($('#release-date-1').text()).toBe('HDC eligible date: 13 Feb 2023HDC release')
     expect($('.urgent-highlight-message').text().toString()).toEqual('HDC release')
   })
 
@@ -200,6 +201,7 @@ describe('Caseload', () => {
           crnNumber: 'Z882661',
           licenceType: 'AP',
           releaseDate: '13 Feb 2023',
+          releaseDateLabel: 'HDC actual date',
           licenceStatus: 'ACTIVE',
           probationPractitioner: {
             staffCode: 'X12342',
@@ -224,7 +226,7 @@ describe('Caseload', () => {
     })
     expect($('tbody .govuk-table__row').length).toBe(1)
     expect($('.status-badge').text().toString()).toContain('Active')
-    expect($('#release-date-1').text()).toBe('13 Feb 2023HDC release')
+    expect($('#release-date-1').text()).toBe('HDC actual date: 13 Feb 2023HDC release')
     expect($('.urgent-highlight-message').text().toString()).toEqual('HDC release')
   })
 
@@ -237,6 +239,7 @@ describe('Caseload', () => {
           crnNumber: 'Z882661',
           licenceType: 'AP',
           releaseDate: '13 Feb 2023',
+          releaseDateLabel: 'Confirmed release date',
           licenceStatus: 'REVIEW_NEEDED',
           probationPractitioner: {
             name: 'Not allocated',
@@ -266,7 +269,7 @@ describe('Caseload', () => {
     })
     expect($('tbody .govuk-table__row').length).toBe(1)
     expect($('.status-badge').text().toString()).toContain('Review needed')
-    expect($('#release-date-1').text()).toBe('13 Feb 2023Time-served release')
+    expect($('#release-date-1').text()).toBe('Confirmed release date: 13 Feb 2023Time-served release')
     expect($('.urgent-highlight-message').text().toString()).toEqual('Time-served release')
   })
 
@@ -474,5 +477,71 @@ describe('Caseload', () => {
     expect($('#name-1').text()).toContain('Access restricted on NDelius')
 
     expect($('#name-link-2').attr('href')).toBe('/licence/vary/id/2/timeline')
+  })
+
+  it.each([
+    {
+      kind: 'CRD',
+      releaseDateLabel: 'CRD',
+      releaseDate: '20 Dec 2026',
+      licenseStatus: 'ACTIVE',
+      expected: 'CRD: 20 Dec 2026',
+    },
+    {
+      kind: 'CRD',
+      releaseDateLabel: 'Confirmed release date',
+      releaseDate: '21 Dec 2026',
+      licenseStatus: 'REVIEW_NEEDED',
+      expected: 'Confirmed release date: 21 Dec 2026',
+    },
+    {
+      kind: 'PRRD',
+      releaseDateLabel: 'Post-recall release date (PRRD)',
+      releaseDate: '22 Dec 2026',
+      licenseStatus: 'ACTIVE',
+      expected: 'Post-recall release date (PRRD): 22 Dec 2026',
+    },
+    {
+      kind: 'HDC',
+      releaseDateLabel: 'HDC eligible date',
+      releaseDate: '23 Dec 2026',
+      licenseStatus: 'ACTIVE',
+      expected: 'HDC eligible date: 23 Dec 2026HDC release',
+    },
+    {
+      kind: 'HDC VARIATION',
+      releaseDateLabel: 'HDC actual date',
+      releaseDate: '24 Dec 2026',
+      licenseStatus: 'ACTIVE',
+      expected: 'HDC actual date: 24 Dec 2026',
+    },
+  ])('should display "$releaseDateLabel" release date label', ({ kind, releaseDateLabel, releaseDate, expected }) => {
+    const $ = render({
+      caseload: [
+        {
+          licenceId: 3,
+          kind,
+          name: 'Test Person',
+          crnNumber: 'Z882661',
+          licenceType: 'AP',
+          releaseDate,
+          releaseDateLabel,
+          licenceStatus: 'ACTIVE',
+          probationPractitioner: {
+            staffCode: 'X12342',
+            name: 'CVL COM',
+            allocated: true,
+          },
+        },
+      ],
+      statusConfig: {
+        ACTIVE: {
+          label: 'Active',
+          description: 'Approved by the prison and is now the currently active licence',
+          colour: 'turquoise',
+        },
+      },
+    })
+    expect($('#release-date-1').text()).toBe(expected)
   })
 })


### PR DESCRIPTION
This PR is to add a release date label for each of the cases on the vary caseload. This can be:

- Confirmed release date
- CRD
- Post-recall release date (PRRD)
- HDC eligible date
- HDC actual date

<img width="1214" height="600" alt="Screenshot 2026-06-19 at 16 15 42" src="https://github.com/user-attachments/assets/458abd91-7679-400c-b93f-2f09aa560a74" />
