### PR TITLE
CVSL-4083 add missing release date labels

### DIFF
--- a/server/views/pages/search/probationSearch/probationSearch.njk
+++ b/server/views/pages/search/probationSearch/probationSearch.njk
@@ -128,9 +128,9 @@
     {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort
             + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
   {% elseif offender | shouldShowHardStopWarning %}
-    {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Submit licence by ' + offender.hardStopDate | cvlDateToDateShort  +'</span>' %}
+    {% set releaseDate = '<span class="urgent-highlight">' +  offender.releaseDateLabel + ': <br>' +offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Submit licence by ' + offender.hardStopDate | cvlDateToDateShort  +'</span>' %}
   {% elseif offender.kind == "TIME_SERVED" %}
-    {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate | cvlDateToDateShort + '</span><span class="urgent-highlight urgent-highlight-message">Time-served release</span>' %}
+    {% set releaseDate = '<span class="urgent-highlight">' +  offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort + '</span><span class="urgent-highlight urgent-highlight-message">Time-served release</span>' %}
   {% else %}
     {% set releaseDate = '<p>' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort + '</p>' %}
   {% endif %}
@@ -186,9 +186,9 @@
     {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort
             + '</span><span class="urgent-highlight urgent-highlight-message">HDC release</span>' %}
   {% elseif offender | shouldShowHardStopWarning %}
-    {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate + '</span><span class="urgent-highlight urgent-highlight-message">Submit licence by ' + offender.hardStopDate | cvlDateToDateShort  +'</span>' %}
+    {% set releaseDate = '<span class="urgent-highlight">' +  offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort + '</span><span class="urgent-highlight urgent-highlight-message">Submit licence by ' + offender.hardStopDate | cvlDateToDateShort  +'</span>' %}
   {% elseif offender.kind == "TIME_SERVED" %}
-    {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDate | cvlDateToDateShort + '</span><span class="urgent-highlight urgent-highlight-message">Time-served release</span>' %}
+    {% set releaseDate = '<span class="urgent-highlight">' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort + '</span><span class="urgent-highlight urgent-highlight-message">Time-served release</span>' %}
   {% else %}
     {% set releaseDate = '<p>' + offender.releaseDateLabel + ': <br>' + offender.releaseDate | cvlDateToDateShort + '</p>' %}
   {% endif %}

--- a/server/views/pages/search/probationSearch/probationSearch.test.ts
+++ b/server/views/pages/search/probationSearch/probationSearch.test.ts
@@ -763,7 +763,7 @@ describe('View Probation Search Results', () => {
     })
 
     // Then
-    expect($('#release-date-1').text()).toBe('1 Jul 2025Time-served release')
+    expect($('#release-date-1').text()).toBe('CRD: 1 Jul 2025Time-served release')
   })
 
   it('renders release date for time-served when people people on probation', () => {
@@ -804,7 +804,7 @@ describe('View Probation Search Results', () => {
     })
 
     // Then
-    expect($('#release-date-1').text()).toBe('1 Jul 2025Time-served release')
+    expect($('#release-date-1').text()).toBe('CRD: 1 Jul 2025Time-served release')
   })
 
   it('should correctly show tab counts result counts', () => {

--- a/server/views/pages/search/probationSearch/probationSearch.test.ts
+++ b/server/views/pages/search/probationSearch/probationSearch.test.ts
@@ -989,4 +989,88 @@ describe('View Probation Search Results', () => {
     expect($('#probation-practitioner-1').text()).toBe('Restricted')
     expect($('#probation-practitioner-1 > .govuk-link').length).toBe(0)
   })
+
+  it.each([
+    {
+      kind: 'CRD',
+      releaseDateLabel: 'CRD',
+      releaseDate: '20/12/2026',
+      expected: 'CRD: 20 Dec 2026',
+    },
+    {
+      kind: 'CRD',
+      releaseDateLabel: 'Confirmed release date',
+      releaseDate: '21/12/2026',
+      expected: 'Confirmed release date: 21 Dec 2026',
+    },
+    {
+      kind: 'HARD_STOP',
+      releaseDateLabel: 'Confirmed release date',
+      releaseDate: '22/12/2026',
+      expected: 'Confirmed release date: 22 Dec 2026',
+    },
+    {
+      kind: 'TIME_SERVED',
+      releaseDateLabel: 'Confirmed release date',
+      releaseDate: '23/12/2026',
+      expected: 'Confirmed release date: 23 Dec 2026Time-served release',
+    },
+    {
+      kind: 'VARIATION',
+      releaseDateLabel: 'Confirmed release date',
+      releaseDate: '24/12/2026',
+      expected: 'Confirmed release date: 24 Dec 2026',
+    },
+    {
+      kind: 'PRRD',
+      releaseDateLabel: 'Post-recall release date',
+      releaseDate: '25/12/2026',
+      expected: 'Post-recall release date: 25 Dec 2026',
+    },
+    {
+      kind: 'HDC',
+      releaseDateLabel: 'HDC eligible date',
+      releaseDate: '26/12/2026',
+      expected: 'HDC eligible date: 26 Dec 2026HDC release',
+    },
+    {
+      kind: 'HDC_VARIATION',
+      releaseDateLabel: 'HDC actual date',
+      releaseDate: '27/12/2026',
+      expected: 'HDC actual date: 27 Dec 2026HDC release',
+    },
+  ])('should display "$releaseDateLabel" release date label', ({ kind, releaseDateLabel, releaseDate, expected }) => {
+    const $ = render({
+      statusConfig,
+      peopleInPrison: [
+        {
+          name: 'Test Person',
+          kind,
+          crn: 'A123456',
+          nomisId: 'A1234BC',
+          comName: 'Test Staff',
+          comStaffCode: '3000',
+          probationPractitioner: {
+            name: 'Test Staff',
+            staffCode: '3000',
+            allocated: true,
+          },
+          teamName: 'Test Team',
+          releaseDate,
+          licenceId: 1,
+          licenceStatus: LicenceStatus.IN_PROGRESS,
+          isOnProbation: false,
+          releaseDateLabel,
+        },
+      ],
+      peopleOnProbation: [],
+      tabParameters: {
+        activeTab: '#people-in-prison',
+        prisonTabId: 'tab-heading-prison',
+        probationTabId: 'tab-heading-probation',
+      },
+      queryTerm: 'Test',
+    })
+    expect($('#release-date-1').text()).toBe(expected)
+  })
 })

--- a/server/views/pages/vary/caseload.test.ts
+++ b/server/views/pages/vary/caseload.test.ts
@@ -496,10 +496,10 @@ describe('Caseload', () => {
     },
     {
       kind: 'PRRD',
-      releaseDateLabel: 'Post-recall release date (PRRD)',
+      releaseDateLabel: 'Post-recall release date',
       releaseDate: '22 Dec 2026',
       licenseStatus: 'ACTIVE',
-      expected: 'Post-recall release date (PRRD): 22 Dec 2026',
+      expected: 'Post-recall release date: 22 Dec 2026',
     },
     {
       kind: 'HDC',


### PR DESCRIPTION
This PR is to add some missing release date labels for the COM search. This already exists as a default but there are some instances where release date label is not present. 

<img width="1102" height="543" alt="Screenshot 2026-06-25 at 12 11 36" src="https://github.com/user-attachments/assets/c9a9ee7a-e9f4-42a9-81de-85a3e9f428c5" />
