### PR TITLE
CVSL-4269 Wrapped the badge in a span to stop it stretching

### DIFF
--- a/server/views/pages/licence/partials/hdcCurfewTimes.njk
+++ b/server/views/pages/licence/partials/hdcCurfewTimes.njk
@@ -30,7 +30,7 @@
     {% set addressHtml %}
         <p>
             {{ params.licence.curfewAddress | formatAddressLine }}
-            {{ hdcBadge | safe if not params.isVaryJourney }}
+            <span>{{ hdcBadge | safe if not params.isVaryJourney }}</span>
         </p>
     {% endset %}
 


### PR DESCRIPTION
The span tag stops the badge from stretching to the size of the address if it's two or more lines
<img width="1269" height="338" alt="image" src="https://github.com/user-attachments/assets/9a9b0bf4-299e-44f3-abda-d2ea0d788c81" />
