### PR TITLE
CVSL-4169 Move restriction zones to after exclusion zones.

### DIFF
--- a/server/routes/viewingLicences/handlers/printLicence.test.ts
+++ b/server/routes/viewingLicences/handlers/printLicence.test.ts
@@ -220,30 +220,32 @@ describe('Route - print a licence', () => {
           htmlPrint: false,
           licence: res.locals.licence,
           watermark,
-          singleItemConditions: [
-            {
-              code: '0f9a20f4-35c7-4c77-8af8-f200f153fa11',
-              data: [
-                {
-                  field: 'outOfBoundArea',
-                  id: 0,
-                  sequence: 0,
-                  contributesToLicence: true,
-                },
-              ],
-              id: 1,
-              text: 'some text',
-              uploadSummary: [
-                {
-                  description: 'Some words',
-                  id: 1,
-                  fileSize: 0,
-                  uploadedTime: '',
-                },
-              ],
-            },
+          singleItemConditions: [],
+          multipleItemConditions: [
+            [
+              {
+                code: '0f9a20f4-35c7-4c77-8af8-f200f153fa11',
+                data: [
+                  {
+                    field: 'outOfBoundArea',
+                    id: 0,
+                    sequence: 0,
+                    contributesToLicence: true,
+                  },
+                ],
+                id: 1,
+                text: 'some text',
+                uploadSummary: [
+                  {
+                    description: 'Some words',
+                    id: 1,
+                    fileSize: 0,
+                    uploadedTime: '',
+                  },
+                ],
+              },
+            ],
           ],
-          multipleItemConditions: [],
           exclusionZoneMapData: [
             {
               dataValue: {
@@ -327,27 +329,6 @@ describe('Route - print a licence', () => {
           licence: res.locals.licence,
           singleItemConditions: [
             {
-              code: '005d70e4-a247-4f82-b8b3-6d294a0f5051',
-              data: [
-                {
-                  contributesToLicence: true,
-                  field: 'outOfBoundArea',
-                  id: 0,
-                  sequence: 0,
-                },
-              ],
-              id: 3,
-              text: 'this is a restriction',
-              uploadSummary: [
-                {
-                  description: 'Some words about a restriction',
-                  fileSize: 0,
-                  id: 3,
-                  uploadedTime: '',
-                },
-              ],
-            },
-            {
               code: '99195049-f355-46fb-b7d8-aef87a1b19c5',
               data: [
                 {
@@ -409,6 +390,29 @@ describe('Route - print a licence', () => {
                     description: 'Some more words',
                     id: 2,
                     fileSize: 0,
+                    uploadedTime: '',
+                  },
+                ],
+              },
+            ],
+            [
+              {
+                code: '005d70e4-a247-4f82-b8b3-6d294a0f5051',
+                data: [
+                  {
+                    contributesToLicence: true,
+                    field: 'outOfBoundArea',
+                    id: 0,
+                    sequence: 0,
+                  },
+                ],
+                id: 3,
+                text: 'this is a restriction',
+                uploadSummary: [
+                  {
+                    description: 'Some words about a restriction',
+                    fileSize: 0,
+                    id: 3,
                     uploadedTime: '',
                   },
                 ],

--- a/server/routes/viewingLicences/handlers/printLicence.ts
+++ b/server/routes/viewingLicences/handlers/printLicence.ts
@@ -21,6 +21,8 @@ const pdfHeaderFooterStyle =
   'text-align: center; ' +
   'padding: 20px;'
 
+const multipleUploadMapConditionCodes = [MEZ_CONDITION_CODE, RESTRICTION_ZONE_CONDITION_CODE]
+
 export default class PrintLicenceRoutes {
   constructor(
     private readonly prisonerService: PrisonerService,
@@ -116,9 +118,13 @@ export default class PrintLicenceRoutes {
   private groupConditions(licence: Licence) {
     const groupedAdditionalConditions: Map<string, AdditionalCondition[]> = this.getGroupedAdditionalConditions(licence)
     const additionalConditions = Array.from(groupedAdditionalConditions, ([code, conditions]) => ({ code, conditions }))
-    const singleItemConditions = additionalConditions.filter(v => v.conditions.length === 1).flatMap(v => v.conditions)
-    const multipleItemConditions = additionalConditions.filter(v => v.conditions.length > 1).map(v => v.conditions)
-    return { singleItemConditions, multipleItemConditions }
+    const singleItemConditions = additionalConditions
+      .filter(v => v.conditions.length === 1 && !multipleUploadMapConditionCodes.includes(v.code))
+      .flatMap(v => v.conditions)
+    const multipleItemMapConditions = additionalConditions
+      .filter(v => v.conditions.length > 1 || multipleUploadMapConditionCodes.includes(v.code))
+      .map(v => v.conditions)
+    return { singleItemConditions, multipleItemConditions: multipleItemMapConditions }
   }
 
   private async splitUploadConditions(licence: Licence, user: User) {

--- a/server/views/pages/licence/partials/multiItemConditions.njk
+++ b/server/views/pages/licence/partials/multiItemConditions.njk
@@ -1,7 +1,7 @@
 {% macro multiItemConditions(multipleItemConditions) %}
     {% if multipleItemConditions.length %}
         {% for condition in multipleItemConditions %}
-            {% if condition[0].textPlural %}
+            {% if condition.length > 1 and condition[0].textPlural %}
                 <div class="condition">
                     <span>{{ condition[0].textPlural }}</span>
                 </div>

--- a/server/views/pages/licence/partials/multiitemConditions.test.ts
+++ b/server/views/pages/licence/partials/multiitemConditions.test.ts
@@ -28,6 +28,18 @@ describe('multiItemConditions check plural text is correctly selected', () => {
     expect($('.condition').length).toBe(2)
   })
 
+  it('Single conditions should be rendered with the singular text', () => {
+    const $ = render({
+      multipleItemConditions: [
+        [{ textPlural: 'You must not enter the following areas:', text: 'You must not enter the following area:' }],
+        [{ textPlural: 'You must not leave the following areas:', text: 'You must not leave the following area:' }],
+      ],
+    })
+    expect($('.condition:nth-of-type(1) span').text()).toBe('You must not enter the following area:')
+    expect($('.condition:nth-of-type(2) span').text()).toBe('You must not leave the following area:')
+    expect($('.condition').length).toBe(2)
+  })
+
   it('should render the plural form when condition textPlural is present and display both texts if pluralText is not present', () => {
     const $ = render({
       multipleItemConditions: [


### PR DESCRIPTION
During testing it was observed that if a licence had a singular restriction zone and multiple exclusion zones the restriction zone was being displayed before the exclusion zones (as the singular conditions are grouped and displayed first). UCD asked if was possible if the restriction zone could always be displayed after the exclusion zones.

<img width="672" height="168" alt="image" src="https://github.com/user-attachments/assets/a9fdd6d9-151a-4992-a218-ce8134b26365" />

See above with two exclusions zones displayed above a single restriction zone
