### PR TITLE
CVSL-4066 fix approver confirmation spacing issue

### DIFF
--- a/server/views/pages/approve/confirmation.njk
+++ b/server/views/pages/approve/confirmation.njk
@@ -11,11 +11,7 @@
 
     {% set isTimeServed = (licence.kind == "TIME_SERVED") %}
 
-    {% set timeServedBannerMessage %}
-        {% if isTimeServed %}
-            Check a case administrator has contacted the probation team
-        {% endif %}
-    {% endset %}
+    {% set timeServedBannerMessage = "Check a case administrator has contacted the probation team" %}
 
     {% set emailMessage %}
         {% if isTimeServed %}
@@ -35,7 +31,7 @@
             <div data-qa="approval-title-panel">
                 {{ govukPanel({
                     titleText: 'Licence approved',
-                    html: timeServedBannerMessage
+                    html: timeServedBannerMessage if isTimeServed
                 }) }}
             </div>
 


### PR DESCRIPTION
This PR is to address spacing issues highlighted by Tom in the approver confirmation screen. 

Before

<img width="804" height="528" alt="Screenshot 2026-07-07 at 16 47 43" src="https://github.com/user-attachments/assets/f21235e3-935a-4bc3-964e-b03be55facbf" />

<img width="767" height="553" alt="Screenshot 2026-07-07 at 16 48 01" src="https://github.com/user-attachments/assets/b3549c00-d583-44c1-84f7-8c1735eb00bd" />

After

<img width="772" height="544" alt="Screenshot 2026-07-07 at 16 39 30" src="https://github.com/user-attachments/assets/469e3c6b-7fcb-4bfc-b2a8-63c4f8b015ed" />

<img width="666" height="541" alt="Screenshot 2026-07-07 at 16 38 50" src="https://github.com/user-attachments/assets/d987fd21-8674-4c73-b2bc-d4365e3c97bc" />
