### PR TITLE
CVSL-4350 populate info banner

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -37,6 +37,8 @@ generic-service:
     POLICY_V4_CREATION_DATE: "2026-07-27"
     POLICY_V4_GO_LIVE_DATE: "2030-09-02"
 
+    SHOW_WHATS_NEW_BANNER: "true"
+
   namespace_secrets:
     create-and-vary-a-licence-prison-events-sqs-instance-output:
       SQS_PRISON_EVENTS_QUEUE_URL: 'sqs_id'

--- a/helm_deploy/values-test1.yaml
+++ b/helm_deploy/values-test1.yaml
@@ -35,6 +35,8 @@ generic-service:
     COMPONENT_API_URL: 'https://frontend-components-dev.hmpps.service.justice.gov.uk'
     MANAGE_USERS_API_URL: 'https://manage-users-api-dev.hmpps.service.justice.gov.uk'
 
+    SHOW_WHATS_NEW_BANNER: 'true'
+
   namespace_secrets:
     create-and-vary-a-licence-prison-events-sqs-instance-output:
       SQS_PRISON_EVENTS_QUEUE_URL: 'sqs_id'

--- a/server/views/partials/whatsNewBanner.njk
+++ b/server/views/partials/whatsNewBanner.njk
@@ -1,5 +1,16 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "moj/components/alert/macro.njk" import mojAlert %}
 
+{% set bannerText = "<p>Standard and additional licence conditions are changing for people being released on or after 2 September 2026.</p><p>Probation practitioners can start using the new additional conditions for these people from 27 July 2026. Standard conditions for anyone released on or after 2 September will be updated automatically.</p>" %}
+
 {% if showCommsBanner %}
+    <div class="govuk-!-margin-top-6">
+        {{ mojAlert({
+            variant: "information",
+            title: "Upcoming changes to licence conditions",
+            showTitleAsHeading: true,
+            dismissible: false,
+            html: bannerText
+        }) }}
+    </div>
 {% endif %}

--- a/server/views/partials/whatsNewBanner.test.ts
+++ b/server/views/partials/whatsNewBanner.test.ts
@@ -5,12 +5,23 @@ import { templateRenderer } from '../../utils/__testutils/templateTestUtils'
 const render = templateRenderer(fs.readFileSync('server/views/partials/whatsNewBanner.njk').toString())
 
 describe('Whats new banner', () => {
-  it('Show whats new banner if showCommsBanner is true', () => {})
+  it('Show whats new banner if showCommsBanner is true', () => {
+    const $ = render({
+      showCommsBanner: true,
+    })
+    expect($('body').text()).toContain('Upcoming changes to licence conditions')
+    expect($('body').text()).toContain(
+      'Standard and additional licence conditions are changing for people being released on or after 2 September 2026.',
+    )
+    expect($('body').text()).toContain(
+      'Probation practitioners can start using the new additional conditions for these people from 27 July 2026. Standard conditions for anyone released on or after 2 September will be updated automatically.',
+    )
+  })
 
   it('Hide whats new banner if showCommsBanner is false', () => {
     const $ = render({
       showCommsBanner: false,
     })
-    expect($('body').text()).not.toContain(`What's new`)
+    expect($('body').text()).not.toContain(`Upcoming changes to licence conditions`)
   })
 })


### PR DESCRIPTION
This PR is to display a banner in CVL which informs users of upcoming changes with licence conditions

<img width="984" height="681" alt="Screenshot 2026-07-21 at 15 28 03" src="https://github.com/user-attachments/assets/b47301a3-c749-440a-aa4a-f1f6ea47048a" />
