### PR TITLE
CVSL-4350 change content for comms banner for probation user

### DIFF
--- a/server/views/partials/whatsNewBanner.njk
+++ b/server/views/partials/whatsNewBanner.njk
@@ -1,7 +1,11 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "moj/components/alert/macro.njk" import mojAlert %}
 
-{% set bannerText = "<p>Standard and additional licence conditions are changing for people being released on or after 2 September 2026.</p><p>Probation practitioners can start using the new additional conditions for these people from 27 July 2026. Standard conditions for anyone released on or after 2 September will be updated automatically.</p>" %}
+{% if isProbationUser %}
+    {% set bannerText = "<p>Standard and additional licence conditions are changing for people being released on or after 2 September 2026.</p><p>Probation practitioners can start using the new additional conditions for these people from 27 July 2026. The new additional conditions will be available when varying licences from 2 September.</p><p>Standard conditions for anyone released on or after 2 September will be updated automatically.</p>" %}
+{% else %}
+    {% set bannerText = "<p>Standard and additional licence conditions are changing for people being released on or after 2 September 2026.</p><p>Probation practitioners can start using the new additional conditions for these people from 27 July 2026. Standard conditions for anyone released on or after 2 September will be updated automatically.</p>" %}
+{% endif %}
 
 {% if showCommsBanner %}
     <div class="govuk-!-margin-top-6">

--- a/server/views/partials/whatsNewBanner.test.ts
+++ b/server/views/partials/whatsNewBanner.test.ts
@@ -24,4 +24,18 @@ describe('Whats new banner', () => {
     })
     expect($('body').text()).not.toContain(`Upcoming changes to licence conditions`)
   })
+
+  it('Show whats new banner with probation staff message if isProbationStaff is true', () => {
+    const $ = render({
+      showCommsBanner: true,
+      isProbationUser: true,
+    })
+    expect($('body').text()).toContain('Upcoming changes to licence conditions')
+    expect($('body').text()).toContain(
+      'Probation practitioners can start using the new additional conditions for these people from 27 July 2026. The new additional conditions will be available when varying licences from 2 September.',
+    )
+    expect($('body').text()).toContain(
+      'Standard conditions for anyone released on or after 2 September will be updated automatically.',
+    )
+  })
 })


### PR DESCRIPTION
This PR is to adjust text for the comms banner for upcoming licence condition changes for probation users. 

<img width="1118" height="558" alt="Screenshot 2026-07-23 at 10 36 00" src="https://github.com/user-attachments/assets/5b64b3af-70fb-4678-a3a7-ee14141ef995" />
