### PR TITLE
CVSL-4283 make change to confirmation screen for COM

### DIFF
--- a/server/views/pages/create/confirmation.njk
+++ b/server/views/pages/create/confirmation.njk
@@ -38,7 +38,10 @@
                 {% endif %}
             {% else %}
                 <p class="govuk-body" id="message">
-                    You can do so up to 2 days before a standard release. From this point, you can only ask the prison to change the initial appointment details. Other changes must be made after release.
+                    You can do so up to 2 days before a standard release.
+                    <br>
+                    <br>
+                    From this point, you can only ask the prison to change the contact details that will be shown on the licence, for an if an initial appointment is needed. Other changes must be made after release.
                 </p>
             {% endif %}
             {{ govukButton({

--- a/server/views/pages/create/confirmation.njk
+++ b/server/views/pages/create/confirmation.njk
@@ -37,12 +37,19 @@
                     </p>
                 {% endif %}
             {% else %}
-                <p class="govuk-body" id="message">
-                    You can do so up to 2 days before a standard release.
-                    <br>
-                    <br>
-                    From this point, you can only ask the prison to change the contact details that will be shown on the licence, for an if an initial appointment is needed. Other changes must be made after release.
-                </p>
+                {% if finalThirdEnabled %}
+                    <p class="govuk-body" id="first-part-message">
+                        You can do so up to 2 days before a standard release.
+                    </p>
+                    <p class="govuk-body" id="second-part-message">
+                        From this point, you can only ask the prison to change the contact details that will be shown on the licence, for example if an initial appointment is needed. Other changes must be made after release.
+                    </p>
+                {% else %}
+                    <p class="govuk-body" id="message">
+                        You can do so up to 2 days before a standard release.
+                        From this point, you can only ask the prison to change the initial appointment details. Other changes must be made after release.
+                    </p>
+                {% endif %}
             {% endif %}
             {{ govukButton({
                 text: "Return to case list",

--- a/server/views/pages/create/confirmation.test.ts
+++ b/server/views/pages/create/confirmation.test.ts
@@ -41,12 +41,9 @@ describe('Hdc Confirmation', () => {
     const $ = render({
       kind: 'CRD',
     })
+    expect($('#message').text().trim().toString()).toContain('You can do so up to 2 days before a standard release.')
     expect($('#message').text().trim().toString()).toContain(
-      'You can do so up to 2 days before a standard release. From this point, you can only ask the prison to change the initial appointment details. Other changes must be made after release.',
-    )
-
-    expect($('#message').text()).not.toContain(
-      'You can make changes to reporting instructions through the Create and vary a licence service. These changes do not need to be reapproved by the prison, but a case administrator may need to reprint the licence.',
+      'From this point, you can only ask the prison to change the contact details that will be shown on the licence, for an if an initial appointment is needed. Other changes must be made after release.',
     )
   })
 

--- a/server/views/pages/create/confirmation.test.ts
+++ b/server/views/pages/create/confirmation.test.ts
@@ -3,6 +3,22 @@ import { templateRenderer } from '../../../utils/__testutils/templateTestUtils'
 
 const render = templateRenderer(fs.readFileSync('server/views/pages/create/confirmation.njk').toString())
 
+describe('Confirmation page', () => {
+  it('should render the confirmation page', () => {
+    const $ = render({
+      fullName: 'John Smith',
+      prisonDescription: 'HMP Leeds',
+      kind: 'CRD',
+    })
+    expect($('.govuk-panel__title').text().trim().toString()).toBe('Licence conditions for John Smith sent')
+    expect($('#sent-to').text().trim().toString()).toBe('We have sent the licence to HMP Leeds for approval.')
+    expect($('#message').text().trim().toString()).toContain('You can do so up to 2 days before a standard release.')
+    expect($('#message').text().trim().toString()).toContain(
+      'From this point, you can only ask the prison to change the contact details that will be shown on the licence, for an if an initial appointment is needed. Other changes must be made after release.',
+    )
+  })
+})
+
 describe('Hdc Confirmation', () => {
   it('should show correct message when kind is HDC', () => {
     const $ = render({

--- a/server/views/pages/create/confirmation.test.ts
+++ b/server/views/pages/create/confirmation.test.ts
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import { templateRenderer } from '../../../utils/__testutils/templateTestUtils'
+import config from '../../../config'
 
 const render = templateRenderer(fs.readFileSync('server/views/pages/create/confirmation.njk').toString())
 
@@ -14,7 +15,24 @@ describe('Confirmation page', () => {
     expect($('#sent-to').text().trim().toString()).toBe('We have sent the licence to HMP Leeds for approval.')
     expect($('#message').text().trim().toString()).toContain('You can do so up to 2 days before a standard release.')
     expect($('#message').text().trim().toString()).toContain(
-      'From this point, you can only ask the prison to change the contact details that will be shown on the licence, for an if an initial appointment is needed. Other changes must be made after release.',
+      'From this point, you can only ask the prison to change the initial appointment details. Other changes must be made after release.',
+    )
+  })
+
+  it('should render different message on the confirmation page when finalThirdEnabled is true', () => {
+    config.finalThirdEnabled = true
+    const $ = render({
+      fullName: 'John Smith',
+      prisonDescription: 'HMP Leeds',
+      kind: 'CRD',
+    })
+    expect($('.govuk-panel__title').text().trim().toString()).toBe('Licence conditions for John Smith sent')
+    expect($('#sent-to').text().trim().toString()).toBe('We have sent the licence to HMP Leeds for approval.')
+    expect($('#first-part-message').text().trim().toString()).toContain(
+      'You can do so up to 2 days before a standard release.',
+    )
+    expect($('#second-part-message').text().trim().toString()).toContain(
+      'From this point, you can only ask the prison to change the contact details that will be shown on the licence, for example if an initial appointment is needed. Other changes must be made after release.',
     )
   })
 })
@@ -34,16 +52,6 @@ describe('Hdc Confirmation', () => {
 
     expect($('#message').text().trim().toString()).not.toContain(
       'You can do so up to 2 days before a standard release. From this point, you can only ask the prison to change the initial appointment details. Other changes must be made after release.',
-    )
-  })
-
-  it('should show correct message when kind is not HDC', () => {
-    const $ = render({
-      kind: 'CRD',
-    })
-    expect($('#message').text().trim().toString()).toContain('You can do so up to 2 days before a standard release.')
-    expect($('#message').text().trim().toString()).toContain(
-      'From this point, you can only ask the prison to change the contact details that will be shown on the licence, for an if an initial appointment is needed. Other changes must be made after release.',
     )
   })
 


### PR DESCRIPTION
This PR is to adjust the content for COM confirmation screen.

<img width="834" height="615" alt="Screenshot 2026-07-27 at 09 19 29" src="https://github.com/user-attachments/assets/e39f0b55-959e-43b9-9f03-eb9afef32f62" />

