### PR TITLE
CVSL-4283 remove text from sentence

### DIFF
--- a/server/views/pages/create/confirmation.njk
+++ b/server/views/pages/create/confirmation.njk
@@ -39,7 +39,7 @@
             {% else %}
                 {% if finalThirdEnabled %}
                     <p class="govuk-body" id="first-part-message">
-                        You can do so up to 2 days before a standard release.
+                        You can do so up to 2 days before release.
                     </p>
                     <p class="govuk-body" id="second-part-message">
                         From this point, you can only ask the prison to change the contact details that will be shown on the licence, for example if an initial appointment is needed. Other changes must be made after release.

--- a/server/views/pages/create/confirmation.test.ts
+++ b/server/views/pages/create/confirmation.test.ts
@@ -28,9 +28,7 @@ describe('Confirmation page', () => {
     })
     expect($('.govuk-panel__title').text().trim().toString()).toBe('Licence conditions for John Smith sent')
     expect($('#sent-to').text().trim().toString()).toBe('We have sent the licence to HMP Leeds for approval.')
-    expect($('#first-part-message').text().trim().toString()).toContain(
-      'You can do so up to 2 days before a standard release.',
-    )
+    expect($('#first-part-message').text().trim().toString()).toContain('You can do so up to 2 days before release.')
     expect($('#second-part-message').text().trim().toString()).toContain(
       'From this point, you can only ask the prison to change the contact details that will be shown on the licence, for example if an initial appointment is needed. Other changes must be made after release.',
     )


### PR DESCRIPTION
This PR is a small change to the sentence around release for the COM user on the confirmation page. 

<img width="769" height="514" alt="Screenshot 2026-07-27 at 13 26 32" src="https://github.com/user-attachments/assets/e5d38594-9696-414d-a1bc-0871bf113912" />
