### PR TITLE
CVSL-4346 update devsec hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,9 +6,12 @@
 
 repos:
   - repo: https://github.com/ministryofjustice/devsecops-hooks
-    rev: v1.3.0
+    rev: v2.0.2
     hooks:
       - id: baseline
+        env:
+          GITLEAKS_CONFIGURATION_FILE: ./.gitleaks/config.toml
+          GITLEAKS_IGNORE_FILE: ./.gitleaks/.gitleaksignore
   - repo: local
     hooks:
       - id: lint


### PR DESCRIPTION
This may require installing gitleaks if you don't already have it installed